### PR TITLE
Allow errors on Data streaming message.

### DIFF
--- a/model/shared/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/shared/src/main/scala/clue/model/StreamingMessage.scala
@@ -125,7 +125,7 @@ object StreamingMessage {
      */
     final case object ConnectionKeepAlive extends FromServer
 
-    final case class DataWrapper(data: Json)
+    final case class DataWrapper(data: Json, errors: Option[Json])
 
     object DataWrapper {
       implicit val EqDataWrapper: Eq[DataWrapper] =
@@ -151,7 +151,9 @@ object StreamingMessage {
     }
 
     final object DataJson {
-      def unapply(data: Data): Option[(String, Json)] = Some((data.id, data.payload.data))
+      def unapply(data: Data): Option[(String, Json, Option[Json])] = Some(
+        (data.id, data.payload.data, data.payload.errors)
+      )
     }
 
     /**

--- a/model/shared/src/main/scala/clue/model/json/package.scala
+++ b/model/shared/src/main/scala/clue/model/json/package.scala
@@ -114,14 +114,21 @@ package object json {
 
   implicit val EncoderDataWrapper: Encoder[DataWrapper] =
     (a: DataWrapper) =>
-      Json.obj(
-        "data" -> a.data
-      )
+      Json
+        .obj(
+          "data"   -> a.data,
+          "errors" -> a.errors.getOrElse(Json.Null)
+        )
+        .dropNullValues
 
   implicit val DecoderDataWrapper: Decoder[DataWrapper] =
-    (c: HCursor) => c.downField("data").as[Json].map(DataWrapper(_))
+    (c: HCursor) =>
+      for {
+        data   <- c.downField("data").as[Json]
+        errors <- c.downField("errors").as[Option[Json]]
+      } yield DataWrapper(data, errors)
 
-  implicit val EncoderData: Encoder[Data]               =
+  implicit val EncoderData: Encoder[Data] =
     (a: Data) =>
       Json.obj(
         "type"    -> Json.fromString("data"),

--- a/model/shared/src/test/scala/clue/model/arb/ArbFromServer.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbFromServer.scala
@@ -38,6 +38,9 @@ trait ArbFromServer {
       arbitrary[String].map(Json.fromString)
     }
 
+  val genErrosJson: Gen[Json]                                 =
+    arbitrary[String].map(s => Json.arr(Json.obj("message" -> Json.fromString(s))))
+
   implicit val arbConnectionError: Arbitrary[ConnectionError] =
     Arbitrary {
       arbitrary[Json](arbErrorJson).map(ConnectionError(_))
@@ -45,7 +48,10 @@ trait ArbFromServer {
 
   implicit val arbDataWrapper: Arbitrary[DataWrapper] =
     Arbitrary {
-      arbitrary[Json](arbDataJson).map(DataWrapper(_))
+      for {
+        data   <- arbitrary[Json](arbDataJson)
+        errors <- Gen.option(genErrosJson)
+      } yield DataWrapper(data, errors)
     }
 
   implicit val arbData: Arbitrary[Data] =


### PR DESCRIPTION
According to the unofficial spec a `Data` message can contain `errors`: https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_data.

Here we implement that, and process the errors on the client.