### PR TITLE
Specify synthetic class parents.

### DIFF
--- a/macros/src/test/scala/clue/macros/MacroTest.scala
+++ b/macros/src/test/scala/clue/macros/MacroTest.scala
@@ -15,6 +15,11 @@ class MacroTest extends FunSuite {
 
   import Schemas._
 
+  trait Person {
+    val id: String
+    val name: Option[String]
+  }
+
   @GraphQL(debug = false)
   object SumQuery extends GraphQLOperation[StarWars] {
     val document = """
@@ -35,6 +40,10 @@ class MacroTest extends FunSuite {
           }
         }
       """
+
+    object Data {
+      trait Character extends Person
+    }
   }
 
   test("StarWars query with inline fragments macro - Human") {

--- a/model/shared/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/shared/src/main/scala/clue/model/StreamingMessage.scala
@@ -130,6 +130,10 @@ object StreamingMessage {
     object DataWrapper {
       implicit val EqDataWrapper: Eq[DataWrapper] =
         Eq.by(_.data)
+
+      def fromData(data: Json): DataWrapper = DataWrapper(data, none)
+
+      def fromErrors(errors: Json): DataWrapper = DataWrapper(Json.Null, errors.some)
     }
 
     /**


### PR DESCRIPTION
This allows client code to specify parent types for generated classes.

For example:
``` scala
  trait Person {
    val id: String
    val name: Option[String]
  }

  @GraphQL(debug = false)
  object SumQuery extends GraphQLOperation[StarWars] {
    val document = """
        query ($charId: ID!) {
          character(id: $charId) {
            id
            name
        }
      """

    object Data {
      trait Character extends Person
    }
  }
```

will generate:

``` scala
  object SumQuery extends GraphQLOperation[StarWars] {
    ...
    case class Character(id: String, name: Option[String]) extends Person
    ...
  }
```