### PR TITLE
Provide Undefined/Unset/Set options for input types.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly" 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.11
-      - uses: olafurpg/setup-gpg@v2
+      - uses: olafurpg/setup-gpg@v3
       - name: Publish
         run: sbt ci-release
         env:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v4
+      - uses: coursier/cache-action@v5
       - name: Set up JDK
-        uses: olafurpg/setup-scala@v7
+        uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.11
       - name: Run compile

--- a/MACROS.md
+++ b/MACROS.md
@@ -153,7 +153,7 @@ object BasicQuery extends GraphQLOperation[StarWars] {
     implicit val showVariables: cats.Show[Variables] = cats.Show.fromToString
 
     // Circe typeclasses
-    implicit val jsonEncoderVariables: io.circe.Encoder[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJson(_.deepDropNullValues)
+    implicit val jsonEncoderVariables: io.circe.Encoder[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJson(_.foldWith(clue.data.Input.dropUndefinedFolder))
   }
 
   // Operation result.

--- a/MACROS.md
+++ b/MACROS.md
@@ -153,7 +153,7 @@ object BasicQuery extends GraphQLOperation[StarWars] {
     implicit val showVariables: cats.Show[Variables] = cats.Show.fromToString
 
     // Circe typeclasses
-    implicit val jsonEncoderVariables: io.circe.Encoder[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJson(_.foldWith(clue.data.Input.dropUndefinedFolder))
+    implicit val jsonEncoderVariables: io.circe.Encoder[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJson(_.foldWith(clue.data.Input.dropIgnoreFolder))
   }
 
   // Operation result.

--- a/macros/src/main/scala/clue/macros/GraphQL.scala
+++ b/macros/src/main/scala/clue/macros/GraphQL.scala
@@ -110,6 +110,7 @@ private[clue] final class GraphQLImpl(val c: blackbox.Context) extends GraphQLMa
             parAccum = List(
               ClassParam.fromGrackleType(paramName,
                                          nextType.dealias,
+                                         isInput = false,
                                          mappings,
                                          paramTypeNameOverride
               )
@@ -234,8 +235,9 @@ private[clue] final class GraphQLImpl(val c: blackbox.Context) extends GraphQLMa
       log(s"Warning resolving operation input variables types [$vars]: [${inputs.left}]]")
     val inputValues = inputs.right.get
 
-    CaseClass("Variables",
-              inputValues.map(iv => ClassParam.fromGrackleType(iv.name, iv.tpe, mappings))
+    CaseClass(
+      "Variables",
+      inputValues.map(iv => ClassParam.fromGrackleType(iv.name, iv.tpe, isInput = true, mappings))
     )
   }
 

--- a/macros/src/main/scala/clue/macros/GraphQLMacro.scala
+++ b/macros/src/main/scala/clue/macros/GraphQLMacro.scala
@@ -50,7 +50,7 @@ protected[macros] trait GraphQLMacro extends Macro {
       val d = tpe match {
         case tq"Option[$inner]"                 => if (!asVals) q"None" else EmptyTree
         case tq"_root_.clue.data.Input[$inner]" =>
-          if (!asVals) q"_root_.clue.data.Undefined" else EmptyTree
+          if (!asVals) q"_root_.clue.data.Ignore" else EmptyTree
         case _                                  => EmptyTree
       }
       if (!asVals && overrides) q"override val $n: $t = $d" else q"val $n: $t = $d"

--- a/macros/src/main/scala/clue/macros/GraphQLMacro.scala
+++ b/macros/src/main/scala/clue/macros/GraphQLMacro.scala
@@ -48,10 +48,10 @@ protected[macros] trait GraphQLMacro extends Macro {
       val n = TermName(name)
       val t = typeTree(nestTree, nestedTypes)
       val d = tpe match {
-        case tq"Option[$inner]"                 => if (!asVals) q"None" else EmptyTree
-        case tq"_root_.clue.data.Input[$inner]" =>
+        case tq"Option[$inner]"          => if (!asVals) q"None" else EmptyTree
+        case tq"clue.data.Input[$inner]" =>
           if (!asVals) q"_root_.clue.data.Undefined" else EmptyTree
-        case _                                  => EmptyTree
+        case _                           => EmptyTree
       }
       if (!asVals && overrides) q"override val $n: $t = $d" else q"val $n: $t = $d"
     }

--- a/macros/src/main/scala/clue/macros/GraphQLMacro.scala
+++ b/macros/src/main/scala/clue/macros/GraphQLMacro.scala
@@ -48,8 +48,9 @@ protected[macros] trait GraphQLMacro extends Macro {
       val n = TermName(name)
       val t = typeTree(nestTree, nestedTypes)
       val d = tpe match {
-        case tq"Option[$inner]" => if (!asVals) q"None" else EmptyTree
-        case _                  => EmptyTree
+        case tq"Option[$inner]"          => if (!asVals) q"None" else EmptyTree
+        case tq"clue.data.Input[$inner]" => if (!asVals) q"clue.data.Undefined" else EmptyTree
+        case _                           => EmptyTree
       }
       if (!asVals && overrides) q"override val $n: $t = $d" else q"val $n: $t = $d"
     }
@@ -59,12 +60,17 @@ protected[macros] trait GraphQLMacro extends Macro {
     def fromGrackleType(
       name:         String,
       tpe:          Type,
+      isInput:      Boolean,
       mappings:     Map[String, String],
       nameOverride: Option[String] = None
     ): ClassParam = {
       def resolveType(tpe: Type): Tree =
         tpe match {
-          case NullableType(tpe) => tq"Option[${resolveType(tpe)}]"
+          case NullableType(tpe) =>
+            if (isInput)
+              tq"clue.data.Input[${resolveType(tpe)}]"
+            else
+              tq"Option[${resolveType(tpe)}]"
           case ListType(tpe)     => tq"List[${resolveType(tpe)}]"
           case nt: NamedType     =>
             parseType(mappings.getOrElse(nt.name, snakeToCamel(nameOverride.getOrElse(nt.name))))

--- a/macros/src/main/scala/clue/macros/GraphQLMacro.scala
+++ b/macros/src/main/scala/clue/macros/GraphQLMacro.scala
@@ -48,9 +48,10 @@ protected[macros] trait GraphQLMacro extends Macro {
       val n = TermName(name)
       val t = typeTree(nestTree, nestedTypes)
       val d = tpe match {
-        case tq"Option[$inner]"          => if (!asVals) q"None" else EmptyTree
-        case tq"clue.data.Input[$inner]" => if (!asVals) q"clue.data.Undefined" else EmptyTree
-        case _                           => EmptyTree
+        case tq"Option[$inner]"                 => if (!asVals) q"None" else EmptyTree
+        case tq"_root_.clue.data.Input[$inner]" =>
+          if (!asVals) q"_root_.clue.data.Undefined" else EmptyTree
+        case _                                  => EmptyTree
       }
       if (!asVals && overrides) q"override val $n: $t = $d" else q"val $n: $t = $d"
     }

--- a/macros/src/main/scala/clue/macros/GraphQLMacro.scala
+++ b/macros/src/main/scala/clue/macros/GraphQLMacro.scala
@@ -48,10 +48,10 @@ protected[macros] trait GraphQLMacro extends Macro {
       val n = TermName(name)
       val t = typeTree(nestTree, nestedTypes)
       val d = tpe match {
-        case tq"Option[$inner]"          => if (!asVals) q"None" else EmptyTree
-        case tq"clue.data.Input[$inner]" =>
+        case tq"Option[$inner]"                 => if (!asVals) q"None" else EmptyTree
+        case tq"_root_.clue.data.Input[$inner]" =>
           if (!asVals) q"_root_.clue.data.Undefined" else EmptyTree
-        case _                           => EmptyTree
+        case _                                  => EmptyTree
       }
       if (!asVals && overrides) q"override val $n: $t = $d" else q"val $n: $t = $d"
     }
@@ -69,7 +69,7 @@ protected[macros] trait GraphQLMacro extends Macro {
         tpe match {
           case NullableType(tpe) =>
             if (isInput)
-              tq"clue.data.Input[${resolveType(tpe)}]"
+              tq"_root_.clue.data.Input[${resolveType(tpe)}]"
             else
               tq"Option[${resolveType(tpe)}]"
           case ListType(tpe)     => tq"List[${resolveType(tpe)}]"

--- a/macros/src/main/scala/clue/macros/GraphQLSchema.scala
+++ b/macros/src/main/scala/clue/macros/GraphQLSchema.scala
@@ -79,7 +79,9 @@ private[clue] final class GraphQLSchemaImpl(val c: blackbox.Context) extends Gra
             .collect { case InputObjectType(name, _, fields) =>
               CaseClass(
                 name.capitalize,
-                fields.map(iv => ClassParam.fromGrackleType(iv.name, iv.tpe, params.mappings))
+                fields.map(iv =>
+                  ClassParam.fromGrackleType(iv.name, iv.tpe, isInput = true, params.mappings)
+                )
               )
             }
             .map(

--- a/macros/src/main/scala/clue/macros/Macro.scala
+++ b/macros/src/main/scala/clue/macros/Macro.scala
@@ -311,7 +311,7 @@ protected[macros] trait Macro {
 
     val encoderDef = Option.when(encoder)(typeType match {
       case TypeType.CaseClass        =>
-        q"implicit val ${TermName(s"jsonEncoder$name")}: io.circe.Encoder[$n] = io.circe.generic.semiauto.deriveEncoder[$n].mapJson(_.foldWith(clue.data.Input.dropUndefinedFolder))"
+        q"implicit val ${TermName(s"jsonEncoder$name")}: io.circe.Encoder[$n] = io.circe.generic.semiauto.deriveEncoder[$n].mapJson(_.foldWith(_root_.clue.data.Input.dropUndefinedFolder))"
       case TypeType.Enum(enumValues) =>
         val cases =
           enumValues.map(enumValue =>

--- a/macros/src/main/scala/clue/macros/Macro.scala
+++ b/macros/src/main/scala/clue/macros/Macro.scala
@@ -311,7 +311,7 @@ protected[macros] trait Macro {
 
     val encoderDef = Option.when(encoder)(typeType match {
       case TypeType.CaseClass        =>
-        q"implicit val ${TermName(s"jsonEncoder$name")}: io.circe.Encoder[$n] = io.circe.generic.semiauto.deriveEncoder[$n].mapJson(_.deepDropNullValues)"
+        q"implicit val ${TermName(s"jsonEncoder$name")}: io.circe.Encoder[$n] = io.circe.generic.semiauto.deriveEncoder[$n].mapJson(_.foldWith(clue.data.Input.dropUndefinedFolder))"
       case TypeType.Enum(enumValues) =>
         val cases =
           enumValues.map(enumValue =>

--- a/macros/src/main/scala/clue/macros/Macro.scala
+++ b/macros/src/main/scala/clue/macros/Macro.scala
@@ -311,7 +311,7 @@ protected[macros] trait Macro {
 
     val encoderDef = Option.when(encoder)(typeType match {
       case TypeType.CaseClass        =>
-        q"implicit val ${TermName(s"jsonEncoder$name")}: io.circe.Encoder[$n] = io.circe.generic.semiauto.deriveEncoder[$n].mapJson(_.foldWith(_root_.clue.data.Input.dropUndefinedFolder))"
+        q"implicit val ${TermName(s"jsonEncoder$name")}: io.circe.Encoder[$n] = io.circe.generic.semiauto.deriveEncoder[$n].mapJson(_.foldWith(_root_.clue.data.Input.dropIgnoreFolder))"
       case TypeType.Enum(enumValues) =>
         val cases =
           enumValues.map(enumValue =>

--- a/model/shared/src/main/scala/clue/data/Input.scala
+++ b/model/shared/src/main/scala/clue/data/Input.scala
@@ -1,0 +1,202 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.data
+
+import cats.syntax.all._
+import cats.Eq
+import cats.Align
+import cats.Applicative
+import cats.Eval
+import cats.Functor
+import cats.Traverse
+import cats.data.Ior
+import scala.annotation.tailrec
+import cats.Monad
+import cats.Show
+import io.circe._
+import io.circe.syntax._
+import clue.data.syntax._
+
+sealed trait Input[+A] {
+  def map[B](f: A => B): Input[B] =
+    this match {
+      case Undefined => Undefined
+      case Unset     => Unset
+      case Set(a)    => Set(f(a))
+    }
+
+  def fold[B](fundef: => B, funset: => B, fset: A => B): B =
+    this match {
+      case Undefined => fundef
+      case Unset     => funset
+      case Set(a)    => fset(a)
+    }
+
+  def flatten[B](implicit ev: A <:< Input[B]): Input[B] =
+    this match {
+      case Undefined => Undefined
+      case Unset     => Unset
+      case Set(a)    => a
+    }
+
+  def flatMap[B](f: A => Input[B]): Input[B] =
+    map(f).flatten
+
+  def toOption: Option[A] =
+    this match {
+      case Set(a) => a.some
+      case _      => none
+    }
+}
+
+final case object Undefined extends Input[Nothing]
+final case object Unset     extends Input[Nothing]
+final case class Set[A](value: A) extends Input[A]
+
+object Input {
+  def apply[A](a: A): Input[A] = Set(a)
+
+  def unset[A]: Input[A] = Unset
+
+  def undefined[A]: Input[A] = Undefined
+
+  def orUndefined[A](opt: Option[A]): Input[A] =
+    opt match {
+      case Some(a) => Set(a)
+      case None    => Undefined
+    }
+
+  def orUnset[A](opt: Option[A]): Input[A] =
+    opt match {
+      case Some(a) => Set(a)
+      case None    => Unset
+    }
+
+  implicit def inputEq[A: Eq]: Eq[Input[A]] =
+    new Eq[Input[A]] {
+      def eqv(x: Input[A], y: Input[A]): Boolean =
+        x match {
+          case Undefined =>
+            y match {
+              case Undefined => true
+              case _         => false
+            }
+          case Unset     =>
+            y match {
+              case Unset => true
+              case _     => false
+            }
+          case Set(ax)   =>
+            y match {
+              case Set(ay) => ax === ay
+              case _       => false
+            }
+        }
+    }
+
+  implicit def inputShow[A: Show]: Show[Input[A]] =
+    new Show[Input[A]] {
+      override def show(t: Input[A]): String = t match {
+        case Set(a)    => s"Set(${a.show})"
+        case other @ _ => other.toString
+      }
+    }
+
+  private val UndefinedValue: Json = Json.fromString("clue.data.Undefined")
+
+  val dropUndefinedFolder: Json.Folder[Json] = new Json.Folder[Json] {
+    def onNull: Json = Json.Null
+    def onBoolean(value: Boolean): Json      = Json.fromBoolean(value)
+    def onNumber(value:  JsonNumber): Json   = Json.fromJsonNumber(value)
+    def onString(value:  String): Json       = Json.fromString(value)
+    def onArray(value:   Vector[Json]): Json =
+      Json.fromValues(value.collect {
+        case v if v =!= UndefinedValue => v.foldWith(this)
+      })
+    def onObject(value:  JsonObject): Json   =
+      Json.fromJsonObject(
+        value.filter { case (_, v) => v =!= UndefinedValue }.mapValues(_.foldWith(this))
+      )
+  }
+
+  implicit def inputEncoder[A: Encoder]: Encoder[Input[A]] = new Encoder[Input[A]] {
+    override def apply(a: Input[A]): Json = a match {
+      case Undefined => UndefinedValue
+      case Unset     => Json.Null
+      case Set(a)    => a.asJson
+    }
+  }
+
+  implicit def inputDecoder[A: Decoder]: Decoder[Input[A]] = new Decoder[Input[A]] {
+    override def apply(c: HCursor): Decoder.Result[Input[A]] =
+      c.as[Option[A]].map(_.orUnset)
+  }
+
+  implicit object InputCats extends Monad[Input] with Traverse[Input] with Align[Input] {
+
+    override def pure[A](a: A): Input[A] = Input(a)
+
+    @tailrec
+    override def tailRecM[A, B](a: A)(f: A => Input[Either[A, B]]): Input[B] =
+      f(a) match {
+        case Undefined     => Undefined
+        case Unset         => Unset
+        case Set(Left(a))  => tailRecM(a)(f)
+        case Set(Right(b)) => Set(b)
+      }
+
+    override def flatMap[A, B](fa: Input[A])(f: A => Input[B]): Input[B] =
+      fa.flatMap(f)
+
+    override def traverse[F[_], A, B](
+      fa: Input[A]
+    )(f:  A => F[B])(implicit F: Applicative[F]): F[Input[B]] =
+      fa match {
+        case Undefined => F.pure(Undefined)
+        case Unset     => F.pure(Unset)
+        case Set(a)    => F.map(f(a))(Set(_))
+      }
+
+    override def foldLeft[A, B](fa: Input[A], b: B)(f: (B, A) => B): B =
+      fa match {
+        case Undefined => b
+        case Unset     => b
+        case Set(a)    => f(b, a)
+      }
+
+    override def foldRight[A, B](fa: Input[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+      fa match {
+        case Undefined => lb
+        case Unset     => lb
+        case Set(a)    => f(a, lb)
+      }
+
+    override def functor: Functor[Input] = this
+
+    override def align[A, B](fa: Input[A], fb: Input[B]): Input[Ior[A, B]] =
+      alignWith(fa, fb)(identity)
+
+    override def alignWith[A, B, C](fa: Input[A], fb: Input[B])(f: Ior[A, B] => C): Input[C] =
+      fa match {
+        case Undefined =>
+          fb match {
+            case Undefined => Undefined
+            case Unset     => Unset
+            case Set(b)    => Set(f(Ior.right(b)))
+          }
+        case Unset     =>
+          fb match {
+            case Undefined => Undefined
+            case Unset     => Unset
+            case Set(b)    => Set(f(Ior.right(b)))
+          }
+        case Set(a)    =>
+          fb match {
+            case Undefined => Set(f(Ior.left(a)))
+            case Unset     => Set(f(Ior.left(a)))
+            case Set(b)    => Set(f(Ior.both(a, b)))
+          }
+      }
+  }
+}

--- a/model/shared/src/main/scala/clue/data/syntax/package.scala
+++ b/model/shared/src/main/scala/clue/data/syntax/package.scala
@@ -7,15 +7,15 @@ import io.circe.Json
 
 package object syntax {
   implicit final class AnyToInputOps[A](private val a: A) extends AnyVal {
-    def set: Input[A] = Set(a)
+    def assign: Input[A] = Assign(a)
   }
 
   implicit final class AnyOptionToInputOps[A](private val a: Option[A]) extends AnyVal {
-    def orUndefined: Input[A] = Input.orUndefined(a)
-    def orUnset: Input[A]     = Input.orUnset(a)
+    def orIgnore: Input[A]   = Input.orIgnore(a)
+    def orUnassign: Input[A] = Input.orUnassign(a)
   }
 
   implicit final class JsonOps(private val json: Json) extends AnyVal {
-    def deepDropUndefined: Json = json.foldWith(Input.dropUndefinedFolder)
+    def deepDropIgnore: Json = json.foldWith(Input.dropIgnoreFolder)
   }
 }

--- a/model/shared/src/main/scala/clue/data/syntax/package.scala
+++ b/model/shared/src/main/scala/clue/data/syntax/package.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.data
+
+import io.circe.Json
+
+package object syntax {
+  implicit final class AnyToInputOps[A](private val a: A) extends AnyVal {
+    def set: Input[A] = Set(a)
+  }
+
+  implicit final class AnyOptionToInputOps[A](private val a: Option[A]) extends AnyVal {
+    def orUndefined: Input[A] = Input.orUndefined(a)
+    def orUnset: Input[A]     = Input.orUnset(a)
+  }
+
+  implicit final class JsonOps(private val json: Json) extends AnyVal {
+    def deepDropUndefined: Json = json.foldWith(Input.dropUndefinedFolder)
+  }
+}

--- a/model/shared/src/test/scala/clue/data/InputSpec.scala
+++ b/model/shared/src/test/scala/clue/data/InputSpec.scala
@@ -21,14 +21,14 @@ import io.circe.testing.instances._
 import io.circe.generic.extras.semiauto._
 import io.circe.generic.extras.Configuration
 
-case class SomeInput(value: Input[Int] = Undefined)
+case class SomeInput(value: Input[Int] = Ignore)
 object SomeInput {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
 
   implicit val someInputDecoder: Decoder[SomeInput] =
     deriveConfiguredDecoder[SomeInput]
   implicit val someInputEncoder: Encoder[SomeInput] =
-    deriveConfiguredEncoder[SomeInput].mapJson(_.deepDropUndefined)
+    deriveConfiguredEncoder[SomeInput].mapJson(_.deepDropIgnore)
   implicit val someInputArb: Arbitrary[SomeInput]   =
     Arbitrary(
       arbitrary[Input[Int]].map(SomeInput.apply)
@@ -59,50 +59,50 @@ class InputSpec extends DisciplineSuite {
     TraverseTests[Input].traverse[Int, Int, Int, Int, Option, Option]
   )
 
-  property("Input[Int].toOption: Undefined is None") {
-    Input.undefined[Int].toOption === none
+  property("Input[Int].toOption: Ignore is None") {
+    Input.ignore[Int].toOption === none
   }
 
-  property("Input[Int].toOption: Unset is None") {
-    Input.unset[Int].toOption === none
+  property("Input[Int].toOption: Unassign is None") {
+    Input.unassign[Int].toOption === none
   }
 
-  property("Input[Int].toOption: Set(a) is Some(a)") {
-    forAll((i: Int) => Set(i).toOption === i.some)
+  property("Input[Int].toOption: Assign(a) is Some(a)") {
+    forAll((i: Int) => Assign(i).toOption === i.some)
   }
 
-  property("Input[Int] (Any.set): a.set === Set(a)") {
-    forAll((i: Int) => i.set === Set(i))
+  property("Input[Int] (Any.set): a.assign === Assign(a)") {
+    forAll((i: Int) => i.assign === Assign(i))
   }
 
-  property("Input[Int] (Option.toInput): None.orUndefined === Undefined") {
-    none[Int].orUndefined match {
-      case Undefined => true
-      case _         => false
+  property("Input[Int] (Option.orIgnore): None.orIgnore === Ignore") {
+    none[Int].orIgnore match {
+      case Ignore => true
+      case _      => false
     }
   }
 
-  property("Input[Int] (Option.toInput): Some(a).orUndefined === Set(a)") {
-    forAll((i: Int) => i.some.orUndefined === Set(i))
+  property("Input[Int] (Option.orIgnore): Some(a).orIgnore === Assign(a)") {
+    forAll((i: Int) => i.some.orIgnore === Assign(i))
   }
 
-  property("Input[Int] (Option.toInput): None.orUnset === Undefined") {
-    none[Int].orUnset match {
-      case Unset => true
-      case _     => false
+  property("Input[Int] (Option.orUnassign): None.orUnassign === Unassign") {
+    none[Int].orUnassign match {
+      case Unassign => true
+      case _        => false
     }
   }
 
-  property("Input[Int] (Option.toInput): Some(a).orUnset === Set(a)") {
-    forAll((i: Int) => i.some.orUnset === Set(i))
+  property("Input[Int] (Option.orUnassign): Some(a).orUnassign === Assign(a)") {
+    forAll((i: Int) => i.some.orUnassign === Assign(i))
   }
 
-  property("Input[Input[Int]] (Input.flatten): Set(Set(a)).flatten === Set(a)") {
-    forAll((i: Int) => Set(Set(i)).flatten === Set(i))
+  property("Input[Input[Int]] (Input.flatten): Assign(Assign(a)).flatten === Assign(a)") {
+    forAll((i: Int) => Assign(Assign(i)).flatten === Assign(i))
   }
 
-  property("Input[Input[Int]] (Input.flatten): Set(Undefined).flatten === Undefined") {
-    Input[Input[Int]](Undefined).flatten === Undefined
+  property("Input[Input[Int]] (Input.flatten): Assign(Ignore).flatten === Ignore") {
+    Input[Input[Int]](Ignore).flatten === Ignore
   }
 
   checkAll("SomeInput", CodecTests[SomeInput].codec)

--- a/model/shared/src/test/scala/clue/data/InputSpec.scala
+++ b/model/shared/src/test/scala/clue/data/InputSpec.scala
@@ -12,7 +12,7 @@ import org.scalacheck.Prop.forAll
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import clue.data.implicits._
+import clue.data.syntax._
 import io.circe._
 import io.circe.testing.CodecTests
 import org.scalacheck.Arbitrary

--- a/model/shared/src/test/scala/clue/data/InputSpec.scala
+++ b/model/shared/src/test/scala/clue/data/InputSpec.scala
@@ -1,0 +1,109 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.data
+
+import cats.Eq
+import munit.DisciplineSuite
+import arb.ArbInput._
+import cats.syntax.all._
+import cats.kernel.laws.discipline.EqTests
+import org.scalacheck.Prop.forAll
+import cats.laws.discipline._
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import clue.data.implicits._
+import io.circe._
+import io.circe.testing.CodecTests
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import io.circe.testing.instances._
+import io.circe.generic.extras.semiauto._
+import io.circe.generic.extras.Configuration
+
+case class SomeInput(value: Input[Int] = Undefined)
+object SomeInput {
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+
+  implicit val someInputDecoder: Decoder[SomeInput] =
+    deriveConfiguredDecoder[SomeInput]
+  implicit val someInputEncoder: Encoder[SomeInput] =
+    deriveConfiguredEncoder[SomeInput].mapJson(_.deepDropUndefined)
+  implicit val someInputArb: Arbitrary[SomeInput]   =
+    Arbitrary(
+      arbitrary[Input[Int]].map(SomeInput.apply)
+    )
+  implicit val someInputEq: Eq[SomeInput]           = Eq.fromUniversalEquals
+}
+
+class InputSpec extends DisciplineSuite {
+  implicit def iso: Isomorphisms[Input] = Isomorphisms.invariant[Input]
+
+  checkAll(
+    "Input[Int].EqLaws",
+    EqTests[Input[Int]].eqv
+  )
+
+  checkAll(
+    "Input[Int].AlignLaws",
+    AlignTests[Input].align[Int, Int, Int, Int]
+  )
+
+  checkAll(
+    "Input[Int].MonadLaws",
+    MonadTests[Input].monad[Int, Int, String]
+  )
+
+  checkAll(
+    "Input[Int].TraverseLaws",
+    TraverseTests[Input].traverse[Int, Int, Int, Int, Option, Option]
+  )
+
+  property("Input[Int].toOption: Undefined is None") {
+    Input.undefined[Int].toOption === none
+  }
+
+  property("Input[Int].toOption: Unset is None") {
+    Input.unset[Int].toOption === none
+  }
+
+  property("Input[Int].toOption: Set(a) is Some(a)") {
+    forAll((i: Int) => Set(i).toOption === i.some)
+  }
+
+  property("Input[Int] (Any.set): a.set === Set(a)") {
+    forAll((i: Int) => i.set === Set(i))
+  }
+
+  property("Input[Int] (Option.toInput): None.orUndefined === Undefined") {
+    none[Int].orUndefined match {
+      case Undefined => true
+      case _         => false
+    }
+  }
+
+  property("Input[Int] (Option.toInput): Some(a).orUndefined === Set(a)") {
+    forAll((i: Int) => i.some.orUndefined === Set(i))
+  }
+
+  property("Input[Int] (Option.toInput): None.orUnset === Undefined") {
+    none[Int].orUnset match {
+      case Unset => true
+      case _     => false
+    }
+  }
+
+  property("Input[Int] (Option.toInput): Some(a).orUnset === Set(a)") {
+    forAll((i: Int) => i.some.orUnset === Set(i))
+  }
+
+  property("Input[Input[Int]] (Input.flatten): Set(Set(a)).flatten === Set(a)") {
+    forAll((i: Int) => Set(Set(i)).flatten === Set(i))
+  }
+
+  property("Input[Input[Int]] (Input.flatten): Set(Undefined).flatten === Undefined") {
+    Input[Input[Int]](Undefined).flatten === Undefined
+  }
+
+  checkAll("SomeInput", CodecTests[SomeInput].codec)
+}

--- a/model/shared/src/test/scala/clue/data/arb/ArbInput.scala
+++ b/model/shared/src/test/scala/clue/data/arb/ArbInput.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.data.arb
+
+import org.scalacheck._
+import Arbitrary._
+import Gen._
+import clue.data._
+
+trait ArbInput {
+  implicit def arbInput[A: Arbitrary]: Arbitrary[Input[A]] =
+    Arbitrary(
+      oneOf(
+        Gen.const(Undefined),
+        Gen.const(Unset),
+        arbitrary[A].map(Set.apply)
+      )
+    )
+
+  implicit def arbInputF[A](implicit fArb: Arbitrary[A => A]): Arbitrary[Input[A] => Input[A]] =
+    Arbitrary(
+      arbitrary[A => A].map(f => _.map(f))
+    )
+}
+
+object ArbInput extends ArbInput

--- a/model/shared/src/test/scala/clue/data/arb/ArbInput.scala
+++ b/model/shared/src/test/scala/clue/data/arb/ArbInput.scala
@@ -12,9 +12,9 @@ trait ArbInput {
   implicit def arbInput[A: Arbitrary]: Arbitrary[Input[A]] =
     Arbitrary(
       oneOf(
-        Gen.const(Undefined),
-        Gen.const(Unset),
-        arbitrary[A].map(Set.apply)
+        Gen.const(Ignore),
+        Gen.const(Unassign),
+        arbitrary[A].map(Assign.apply)
       )
     )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -11,7 +11,7 @@ object Settings {
     val disciplineMUnit = "1.0.2"
     val fs2             = "2.4.5"
     val grackle         = "0.0.19"
-    val jawn            = "1.0.0"
+    val jawn            = "1.0.1"
     val log4Cats        = "1.1.1"
     val monocle         = "2.1.0"
     val scalaJSDom      = "1.1.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.4.4


### PR DESCRIPTION
This is an attempt to deal with the fact that nullable input types actually can have 3 states:

* missing (undefined)
* `null` value
* actual value

We were previously modeling nullable input types as `Option[A]` but this fails short to model the fact that we can omit or send a `null` value to indicate "ignore" or "unset" semantics to a server.

A new 3-state sum type `Input[A]` was created with members `Undefined`, `Unset` and `Set(a)`. The macros now generate this type for nullable input values, with a default of `Undefined`.

Encoding is tricky and is a bit hackish: because of `circe`'s internal working, by the time we have to encode an `Input[A]` we are forced to provide a value. Therefore, a dummy value is provided for `Undefined`, which must be later on deep-wiped. Convenience methods are provided to achieve this, and the generated `Encoder`s already take care of this.


