### PR TITLE
Type rework with Web Socket instances. ReconnectionStretegy in client.

### DIFF
--- a/core/shared/src/main/scala/clue/ApolloStreamingClient.scala
+++ b/core/shared/src/main/scala/clue/ApolloStreamingClient.scala
@@ -150,7 +150,7 @@ abstract class ApolloClient[F[_]: ConcurrentEffect: Timer: Logger, S, CP, CE](ur
               }
     } yield ()
 
-  def connect(payload: F[JsonObject]): F[Unit] = {
+  def connect(payload: F[Map[String, Json]]): F[Unit] = {
 
     def processClose(closeEvent: CE): F[Unit] =
       (for {

--- a/core/shared/src/main/scala/clue/ApolloStreamingClient.scala
+++ b/core/shared/src/main/scala/clue/ApolloStreamingClient.scala
@@ -27,17 +27,15 @@ protected[clue] trait Emitter[F[_]] {
   def terminate(): F[Unit]
 }
 
-abstract class ApolloStreamingClient[F[_]: ConcurrentEffect: Timer: Logger, S](uri: Uri)
-    extends GraphQLPersistentStreamingClient[F, S] {
+abstract class ApolloClient[F[_]: ConcurrentEffect: Timer: Logger, S, CP, CE](uri: Uri)
+    extends GraphQLPersistentClient[F, S, CP, CE] {
   private val LogPrefix = "[clue.ApolloStreamingClient]"
 
   private val F = implicitly[ConcurrentEffect[F]]
 
-  override protected implicit val backend: PersistentBackend[F]
-
   val connectionStatus: SignallingRef[F, StreamingClientStatus]
   protected val subscriptions: Ref[F, Map[String, Emitter[F]]]
-  protected val connectionMVar: MVar2[F, Either[Throwable, backend.Connection]]
+  protected val connectionMVar: MVar2[F, Either[Throwable, PersistentConnection[F, CP]]]
   protected val connectionAttempt: Ref[F, Int]
 
   override def status: F[StreamingClientStatus] =
@@ -46,7 +44,7 @@ abstract class ApolloStreamingClient[F[_]: ConcurrentEffect: Timer: Logger, S](u
   override def statusStream: fs2.Stream[F, StreamingClientStatus] =
     connectionStatus.discrete
 
-  override def disconnectInternal(closeParameters: Option[backend.CP]): F[Unit] =
+  override protected def disconnectInternal(closeParameters: Option[CP]): F[Unit] =
     connectionMVar.read.rethrow.flatMap(connection =>
       connectionStatus.set(StreamingClientStatus.Disconnecting) >> connection.closeInternal(
         closeParameters
@@ -144,7 +142,7 @@ abstract class ApolloStreamingClient[F[_]: ConcurrentEffect: Timer: Logger, S](u
       }
       .handleErrorWith(t => Logger[F].error(t)(s"Error processing error on WebSocket for [$uri]"))
 
-  private def restartSubscriptions(sender: backend.Connection): F[Unit] =
+  private def restartSubscriptions(sender: PersistentConnection[F, CP]): F[Unit] =
     for {
       subs <- subscriptions.get
       _    <- subs.toList.traverse { case (id, emitter) =>
@@ -152,19 +150,16 @@ abstract class ApolloStreamingClient[F[_]: ConcurrentEffect: Timer: Logger, S](u
               }
     } yield ()
 
-  def connect(
-    payload:              F[JsonObject],
-    reconnectionStrategy: Option[ReconnectionStrategy[F, backend.CE]] // If None, no reconnect
-  ): F[Unit] = {
+  def connect(payload: F[JsonObject]): F[Unit] = {
 
-    def processClose(closeEvent: backend.CE): F[Unit] =
+    def processClose(closeEvent: CE): F[Unit] =
       (for {
         _         <- connectionMVar.take
         _         <- connectionStatus.set(StreamingClientStatus.Disconnected)
         attempt   <- connectionAttempt.updateAndGet(_ + 1)
         backoffOpt = reconnectionStrategy.flatMap(_.backoffFn(attempt, closeEvent))
-        _         <- backoffOpt.fold(F.unit)(backoff =>
-                       Timer[F].sleep(backoff) >> connect(payload, reconnectionStrategy)
+        _         <- backoffOpt.fold(terminateAllSubscriptions())(backoff =>
+                       Timer[F].sleep(backoff) >> connect(payload)
                      )
       } yield ()).handleErrorWith(t =>
         Logger[F].error(t)(s"Error processing close on WebSocket for [$uri]")
@@ -255,27 +250,4 @@ abstract class ApolloStreamingClient[F[_]: ConcurrentEffect: Timer: Logger, S](u
           .drain
       }
     }
-}
-
-object ApolloStreamingClient {
-  def of[F[_]: ConcurrentEffect: Timer: Logger, S](
-    uri:               Uri
-  )(implicit _backend: PersistentBackend[F]): F[ApolloStreamingClient[F, S]] =
-    for {
-      _connectionStatus  <-
-        SignallingRef[F, StreamingClientStatus](StreamingClientStatus.Disconnected)
-      _subscriptions     <- Ref.of[F, Map[String, Emitter[F]]](Map.empty)
-      _connectionMVar    <- MVar.empty[F, Either[Throwable, _backend.Connection]]
-      _connectionAttempt <- Ref.of[F, Int](0)
-      client              =
-        new ApolloStreamingClient[F, S](uri) {
-          override protected implicit val backend = _backend
-
-          override val connectionStatus            = _connectionStatus
-          override protected val subscriptions     = _subscriptions
-          override protected val connectionMVar    =
-            _connectionMVar.asInstanceOf[MVar2[F, Either[Throwable, backend.Connection]]]
-          override protected val connectionAttempt = _connectionAttempt
-        }
-    } yield client
 }

--- a/core/shared/src/main/scala/clue/ApolloWebSocketClient.scala
+++ b/core/shared/src/main/scala/clue/ApolloWebSocketClient.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import cats.syntax.all._
+import cats.effect.ConcurrentEffect
+import cats.effect.Timer
+import io.chrisdavenport.log4cats.Logger
+import sttp.model.Uri
+import fs2.concurrent.SignallingRef
+import cats.effect.concurrent.Ref
+import cats.effect.concurrent.MVar
+import cats.effect.concurrent.MVar2
+import scala.concurrent.duration.FiniteDuration
+
+case class ApolloWebSocketClient[F[_]: ConcurrentEffect: Timer: Logger, S](
+  uri:                                         Uri,
+  override protected val backend:              WebSocketBackend[F],
+  override val connectionStatus:               SignallingRef[F, StreamingClientStatus],
+  override protected val subscriptions:        Ref[F, Map[String, Emitter[F]]],
+  override protected val connectionMVar:       MVar2[
+    F,
+    Either[Throwable, PersistentConnection[F, WebSocketCloseParams]]
+  ],
+  override protected val connectionAttempt:    Ref[F, Int],
+  override protected val reconnectionStrategy: Option[ReconnectionStrategy[F, WebSocketCloseEvent]]
+) extends ApolloClient[F, S, WebSocketCloseParams, WebSocketCloseEvent](uri)
+    with GraphQLWebSocketClient[F, S] {
+  def withReconnectionStrategy(
+    reconnectionStrategy: ReconnectionStrategy[F, WebSocketCloseEvent]
+  ): ApolloWebSocketClient[F, S] = copy(reconnectionStrategy = reconnectionStrategy.some)
+}
+
+object ApolloWebSocketClient {
+  def of[F[_]: ConcurrentEffect: Timer: Logger, S](
+    uri:                  Uri,
+    reconnectionStrategy: Option[ReconnectionStrategy[F, WebSocketCloseEvent]] = none
+  )(implicit backend:     WebSocketBackend[F]): F[ApolloWebSocketClient[F, S]] =
+    for {
+      connectionStatus  <-
+        SignallingRef[F, StreamingClientStatus](StreamingClientStatus.Disconnected)
+      subscriptions     <- Ref.of[F, Map[String, Emitter[F]]](Map.empty)
+      connectionMVar    <-
+        MVar.empty[F, Either[Throwable, PersistentConnection[F, WebSocketCloseParams]]]
+      connectionAttempt <- Ref.of[F, Int](0)
+    } yield new ApolloWebSocketClient[F, S](uri,
+                                            backend,
+                                            connectionStatus,
+                                            subscriptions,
+                                            connectionMVar,
+                                            connectionAttempt,
+                                            reconnectionStrategy
+    )
+
+  def of[F[_]: ConcurrentEffect: Timer: Logger, S](
+    uri:                  Uri,
+    reconnectionStrategy: ReconnectionStrategy[F, WebSocketCloseEvent]
+  )(implicit backend:     WebSocketBackend[F]): F[ApolloWebSocketClient[F, S]] =
+    of(uri, reconnectionStrategy.some)
+
+  def of[F[_]: ConcurrentEffect: Timer: Logger, S](
+    uri:              Uri,
+    maxAttempts:      Int,
+    backoffFn:        (Int, WebSocketCloseEvent) => Option[FiniteDuration]
+  )(implicit backend: WebSocketBackend[F]): F[ApolloWebSocketClient[F, S]] =
+    of(uri, ReconnectionStrategy[F, WebSocketCloseEvent](maxAttempts, backoffFn).some)
+}

--- a/core/shared/src/main/scala/clue/GraphQLPersistentClient.scala
+++ b/core/shared/src/main/scala/clue/GraphQLPersistentClient.scala
@@ -3,6 +3,6 @@
 
 package clue
 
-trait GraphQLPersistentStreamingClient[F[_], S]
+trait GraphQLPersistentClient[F[_], S, CP, CE]
     extends GraphQLStreamingClient[F, S]
-    with PersistentClient[F]
+    with PersistentClient[F, CP, CE]

--- a/core/shared/src/main/scala/clue/GraphQLWebSocketClient.scala
+++ b/core/shared/src/main/scala/clue/GraphQLWebSocketClient.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+trait GraphQLWebSocketClient[F[_], S]
+    extends GraphQLPersistentClient[F, S, WebSocketCloseParams, WebSocketCloseEvent]

--- a/core/shared/src/main/scala/clue/PersistentBackend.scala
+++ b/core/shared/src/main/scala/clue/PersistentBackend.scala
@@ -7,25 +7,26 @@ import cats.syntax.all._
 import clue.model.StreamingMessage
 import sttp.model.Uri
 
-trait PersistentBackend[F[_]] {
-  type CE // CloseEvent
-  type CP // Close Parameters
-
+// CP = Close Parameters, sent by client when close is requested.
+// CE = Close Event, received by client when server closes.
+trait PersistentBackend[F[_], CP, CE] {
   def connect(
     uri:       Uri,
     onMessage: String => F[Unit],
     onError:   Throwable => F[Unit],
-    onClose:   CE => F[Unit] // Boolean = wasClean
-  ): F[Connection]
-
-  trait Connection {
-    def send(msg:                    StreamingMessage.FromClient): F[Unit]
-    final def close(closeParameters: CP): F[Unit] = closeInternal(closeParameters.some)
-    final def close(): F[Unit] = closeInternal(none)
-    protected[clue] def closeInternal(closeParameters: Option[CP]): F[Unit]
-  }
+    onClose:   CE => F[Unit]
+  ): F[PersistentConnection[F, CP]]
 }
 
 object PersistentBackend {
-  def apply[F[_]: PersistentBackend]: PersistentBackend[F] = implicitly
+  def apply[F[_], CP, CE](implicit
+    backend: PersistentBackend[F, CP, CE]
+  ): PersistentBackend[F, CP, CE] = backend
+}
+
+trait PersistentConnection[F[_], CP] {
+  def send(msg:                    StreamingMessage.FromClient): F[Unit]
+  final def close(closeParameters: CP): F[Unit] = closeInternal(closeParameters.some)
+  final def close(): F[Unit] = closeInternal(none)
+  protected[clue] def closeInternal(closeParameters: Option[CP]): F[Unit]
 }

--- a/core/shared/src/main/scala/clue/PersistentClient.scala
+++ b/core/shared/src/main/scala/clue/PersistentClient.scala
@@ -4,9 +4,9 @@
 package clue
 
 import cats.syntax.all._
-import io.circe.JsonObject
 import cats.effect.Sync
 import scala.concurrent.duration.FiniteDuration
+import io.circe.Json
 
 /**
  * A client that keeps a connection open with the server.
@@ -19,9 +19,9 @@ trait PersistentClient[F[_], CP, CE] {
 
   def statusStream: fs2.Stream[F, StreamingClientStatus]
 
-  def connect(payload: F[JsonObject]): F[Unit]
+  def connect(payload: F[Map[String, Json]]): F[Unit]
 
-  final def connect(payload: JsonObject = JsonObject.empty)(implicit sync: Sync[F]): F[Unit] =
+  final def connect(payload: Map[String, Json] = Map.empty)(implicit sync: Sync[F]): F[Unit] =
     connect(Sync[F].delay(payload))
 
   final def disconnect(closeParameters: CP): F[Unit] =

--- a/core/shared/src/main/scala/clue/PersistentClient.scala
+++ b/core/shared/src/main/scala/clue/PersistentClient.scala
@@ -6,36 +6,40 @@ package clue
 import cats.syntax.all._
 import io.circe.JsonObject
 import cats.effect.Sync
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * A client that keeps a connection open with the server.
  */
-trait PersistentClient[F[_]] {
-  protected implicit val backend: PersistentBackend[F]
-
-  type CP = backend.CP
-  type CE = backend.CE
+trait PersistentClient[F[_], CP, CE] {
+  protected val backend: PersistentBackend[F, CP, CE]
+  protected val reconnectionStrategy: Option[ReconnectionStrategy[F, CE]] // If None, no reconnect.
 
   def status: F[StreamingClientStatus]
 
   def statusStream: fs2.Stream[F, StreamingClientStatus]
 
-  def connect(
-    payload:              F[JsonObject],
-    reconnectionStrategy: Option[ReconnectionStrategy[F, backend.CE]]
-  ): F[Unit]
+  def connect(payload: F[JsonObject]): F[Unit]
 
-  def connect(
-    payload:              JsonObject = JsonObject.empty,
-    reconnectionStrategy: Option[ReconnectionStrategy[F, backend.CE]] = None
-  )(implicit sync:        Sync[F]): F[Unit] =
-    connect(Sync[F].delay(payload), reconnectionStrategy)
+  final def connect(payload: JsonObject = JsonObject.empty)(implicit sync: Sync[F]): F[Unit] =
+    connect(Sync[F].delay(payload))
 
-  final def disconnect(closeParameters: backend.CP): F[Unit] =
+  final def disconnect(closeParameters: CP): F[Unit] =
     disconnectInternal(closeParameters.some)
 
   final def disconnect(): F[Unit] =
     disconnectInternal(none)
 
-  protected def disconnectInternal(closeParameters: Option[backend.CP]): F[Unit]
+  protected def disconnectInternal(closeParameters: Option[CP]): F[Unit]
+
+  def withReconnectionStrategy(
+    reconnectionStrategy: ReconnectionStrategy[F, CE]
+  ): PersistentClient[F, CP, CE]
+
+  final def withReconnectionStrategy(
+    maxAttempts: Int,
+    backoffFn:   (Int, CE) => Option[FiniteDuration]
+  ): PersistentClient[F, CP, CE] = withReconnectionStrategy(
+    ReconnectionStrategy(maxAttempts, backoffFn)
+  )
 }

--- a/core/shared/src/main/scala/clue/WebSocketBackend.scala
+++ b/core/shared/src/main/scala/clue/WebSocketBackend.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import cats.syntax.all._
+
+case class WebSocketCloseParams(code: Option[Int] = none, reason: Option[String] = none)
+object WebSocketCloseParams {
+  def apply(code:   Int): WebSocketCloseParams = WebSocketCloseParams(code = code.some)
+  def apply(reason: String): WebSocketCloseParams = WebSocketCloseParams(reason = reason.some)
+  def apply(code:   Int, reason: String): WebSocketCloseParams =
+    WebSocketCloseParams(code = code.some, reason = reason.some)
+}
+case class WebSocketCloseEvent(code: Int, reason: String, wasClean: Boolean)
+
+trait WebSocketBackend[F[_]] extends PersistentBackend[F, WebSocketCloseParams, WebSocketCloseEvent]
+
+trait WebSocketConnection[F[_]] extends PersistentConnection[F, WebSocketCloseParams]

--- a/core/shared/src/main/scala/clue/WebSocketReconnectionStrategy.scala
+++ b/core/shared/src/main/scala/clue/WebSocketReconnectionStrategy.scala
@@ -5,7 +5,9 @@ package clue
 
 import scala.concurrent.duration.FiniteDuration
 
-case class ReconnectionStrategy[F[_], CE](
-  maxAttempts: Int,
-  backoffFn:   (Int, CE) => Option[FiniteDuration] // If None is returned, no more reconnect attempts
-)
+object WebSocketReconnectionStrategy {
+  def apply[F[_]](
+    maxAttempts: Int,
+    backoffFn:   (Int, WebSocketCloseEvent) => Option[FiniteDuration]
+  ): WebSocketReconnectionStrategy[F] = ReconnectionStrategy(maxAttempts, backoffFn)
+}

--- a/core/shared/src/main/scala/clue/package.scala
+++ b/core/shared/src/main/scala/clue/package.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package object clue {
+  type WebSocketReconnectionStrategy[F[_]] = ReconnectionStrategy[F, WebSocketCloseEvent]
+}

--- a/model/shared/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/shared/src/main/scala/clue/model/StreamingMessage.scala
@@ -6,7 +6,6 @@ package clue.model
 import cats.Eq
 import cats.syntax.all._
 import io.circe.Json
-import io.circe.JsonObject
 
 /**
  * GraphQL web socket protocol streaming messages.  Messages are cleanly
@@ -44,9 +43,9 @@ object StreamingMessage {
      *
      * @param payload any connection parameters that the client wishes to send
      */
-    final case class ConnectionInit(payload: JsonObject = JsonObject.empty)
+    final case class ConnectionInit(payload: Map[String, Json] = Map.empty)
         extends FromClient
-        with Payload[JsonObject]
+        with Payload[Map[String, Json]]
 
     object ConnectionInit {
       implicit val EqConnectionInit: Eq[ConnectionInit] =
@@ -115,9 +114,9 @@ object StreamingMessage {
      *
      * @param payload error information
      */
-    final case class ConnectionError(payload: JsonObject)
+    final case class ConnectionError(payload: Map[String, Json])
         extends FromServer
-        with Payload[JsonObject]
+        with Payload[Map[String, Json]]
 
     object ConnectionError {
       implicit val EqConnectionError: Eq[ConnectionError] =

--- a/model/shared/src/main/scala/clue/model/json/package.scala
+++ b/model/shared/src/main/scala/clue/model/json/package.scala
@@ -45,7 +45,7 @@ package object json {
     (c: HCursor) =>
       for {
         _ <- checkType(c, "connection_init")
-        p <- c.downField("payload").as[JsonObject]
+        p <- c.downField("payload").as[Map[String, Json]]
       } yield ConnectionInit(p)
 
   implicit val EncoderStart: Encoder[Start] =
@@ -124,7 +124,7 @@ package object json {
     (c: HCursor) =>
       for {
         _ <- checkType(c, "connection_error")
-        p <- c.downField("payload").as[JsonObject]
+        p <- c.downField("payload").as[Map[String, Json]]
       } yield ConnectionError(p)
 
   implicit val DecoderConnectionKA: Decoder[ConnectionKeepAlive.type] =

--- a/model/shared/src/test/scala/clue/model/arb/ArbFromClient.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbFromClient.scala
@@ -8,7 +8,7 @@ import clue.model.StreamingMessage.FromClient
 import clue.model.StreamingMessage.FromClient._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary._
-import io.circe.JsonObject
+import io.circe.Json
 
 trait ArbFromClient {
   import ArbGraphQLRequest._
@@ -16,7 +16,7 @@ trait ArbFromClient {
 
   implicit val arbConnectionInit: Arbitrary[ConnectionInit] =
     Arbitrary {
-      arbitrary[JsonObject](arbJsonObjectOfStrings).map(ConnectionInit(_))
+      arbitrary[Map[String, Json]](arbJsonStringMap).map(ConnectionInit(_))
     }
 
   implicit val arbStart: Arbitrary[Start] =

--- a/model/shared/src/test/scala/clue/model/arb/ArbFromServer.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbFromServer.scala
@@ -9,7 +9,6 @@ import io.circe.Json
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen
-import io.circe.JsonObject
 
 trait ArbFromServer {
   import ArbJson._
@@ -40,7 +39,7 @@ trait ArbFromServer {
 
   implicit val arbConnectionError: Arbitrary[ConnectionError] =
     Arbitrary {
-      arbitrary[JsonObject](arbJsonObjectOfStrings).map(ConnectionError(_))
+      arbitrary[Map[String, Json]](arbJsonStringMap).map(ConnectionError(_))
     }
 
   implicit val arbDataWrapper: Arbitrary[DataWrapper] =

--- a/model/shared/src/test/scala/clue/model/arb/ArbJson.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbJson.scala
@@ -5,7 +5,6 @@ package clue.model.arb
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
-import io.circe.JsonObject
 import io.circe.Json
 import org.scalacheck.Gen
 
@@ -21,9 +20,9 @@ trait ArbJson {
       jsonStr <- arbitrary[Json](arbJsonString)
     } yield (str, jsonStr)
 
-  val arbJsonObjectOfStrings: Arbitrary[JsonObject] =
+  val arbJsonStringMap: Arbitrary[Map[String, Json]] =
     Arbitrary {
-      Gen.mapOf[String, Json](genJsonStringJsonTuple).map(JsonObject.fromMap _)
+      Gen.mapOf[String, Json](genJsonStringJsonTuple)
     }
 }
 


### PR DESCRIPTION
I was not convinced at all of the embedded types used in `0.5.0`. It resulted in an awkward API.

This PR works around the issue by moving `CloseParameters` and `CloseEvent` to client's and backend's type parameters, and creating convenience types for Web Socket instances.

Also, `ReconnectionStrategy` is now in the client instead of being passed in the `connect` method.

Also, uses of `JsonObject` in the `StreamingMessage`s were replaced by `Map[String, Json]`.