### PR TITLE
Disconnect rework.

### DIFF
--- a/core/shared/src/main/scala/clue/StreamingClientStatus.scala
+++ b/core/shared/src/main/scala/clue/StreamingClientStatus.scala
@@ -10,6 +10,10 @@ sealed trait StreamingClientStatus
 object StreamingClientStatus {
   final case object Connecting    extends StreamingClientStatus
   final case object Connected     extends StreamingClientStatus
+  final case object Initializing  extends StreamingClientStatus
+  final case object Initialized   extends StreamingClientStatus
+  final case object Terminating   extends StreamingClientStatus
+  final case object Terminated    extends StreamingClientStatus
   final case object Disconnecting extends StreamingClientStatus
   final case object Disconnected  extends StreamingClientStatus
 

--- a/core/shared/src/main/scala/clue/package.scala
+++ b/core/shared/src/main/scala/clue/package.scala
@@ -5,7 +5,8 @@ import cats.syntax.all._
 import scala.concurrent.duration.FiniteDuration
 
 package object clue {
-  type ReconnectionStrategy[CE]      = (Int, CE) => Option[FiniteDuration]
+  type CloseReason[CE]               = Either[Throwable, CE]
+  type ReconnectionStrategy[CE]      = (Int, CloseReason[CE]) => Option[FiniteDuration]
   type WebSocketReconnectionStrategy = ReconnectionStrategy[WebSocketCloseEvent]
 }
 


### PR DESCRIPTION
We now allow differentiating between underlying channel state (eg: web socket connected/disconnected) and protocol state (eg: apollo initialized/terminated).

This implied a nontrivial rework of the connection and disconnection logic.

Now, the client will request to `init` or `terminate` (instead of the former `connect`/`disconnect`). When `init` is called, the channel will be `connected` if it's not yet. When `terminate` is called, the client has the option to `KeepConnection` or `Disconnect`.

Furthermore, when the `reconnectionStrategy` function is invoked, now the client is informed whether an error occurred or a normal disconnection.