### PR TITLE
Fix reconnect logic. Add names for clients.

### DIFF
--- a/core/shared/src/main/scala/clue/ApolloWebSocketClient.scala
+++ b/core/shared/src/main/scala/clue/ApolloWebSocketClient.scala
@@ -14,6 +14,7 @@ import cats.effect.concurrent.Deferred
 
 case class ApolloWebSocketClient[F[_]: ConcurrentEffect: Timer: Logger, S](
   uri:                                         Uri,
+  name:                                        String,
   override protected val backend:              WebSocketBackend[F],
   override val connectionStatus:               SignallingRef[F, StreamingClientStatus],
   override protected val subscriptions:        Ref[F, Map[String, Emitter[F]]],
@@ -21,12 +22,13 @@ case class ApolloWebSocketClient[F[_]: ConcurrentEffect: Timer: Logger, S](
   override protected val connectionRef:        Ref[F, ApolloClient.Connection[F, WebSocketCloseParams]],
   override protected val connectionAttempt:    Ref[F, Int],
   override protected val reconnectionStrategy: ReconnectionStrategy[WebSocketCloseEvent]
-) extends ApolloClient[F, S, WebSocketCloseParams, WebSocketCloseEvent](uri)
+) extends ApolloClient[F, S, WebSocketCloseParams, WebSocketCloseEvent](uri, name)
     with GraphQLWebSocketClient[F, S]
 
 object ApolloWebSocketClient {
   def of[F[_]: ConcurrentEffect: Timer: Logger, S](
     uri:                  Uri,
+    name:                 String = "",
     reconnectionStrategy: ReconnectionStrategy[WebSocketCloseEvent] = ReconnectionStrategy.never
   )(implicit backend:     WebSocketBackend[F]): F[ApolloWebSocketClient[F, S]] =
     for {
@@ -38,6 +40,7 @@ object ApolloWebSocketClient {
         Ref.of[F, ApolloClient.Connection[F, WebSocketCloseParams]](none)
       connectionAttempt <- Ref.of[F, Int](0)
     } yield new ApolloWebSocketClient[F, S](uri,
+                                            name,
                                             backend,
                                             connectionStatus,
                                             subscriptions,

--- a/core/shared/src/main/scala/clue/StreamingClientStatus.scala
+++ b/core/shared/src/main/scala/clue/StreamingClientStatus.scala
@@ -13,7 +13,6 @@ object StreamingClientStatus {
   final case object Initializing  extends StreamingClientStatus
   final case object Initialized   extends StreamingClientStatus
   final case object Terminating   extends StreamingClientStatus
-  final case object Terminated    extends StreamingClientStatus
   final case object Disconnecting extends StreamingClientStatus
   final case object Disconnected  extends StreamingClientStatus
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,7 +5,7 @@ import sbt.librarymanagement._
 object Settings {
 
   object LibraryVersions {
-    val cats            = "2.3.1"
+    val cats            = "2.4.1"
     val catsEffect      = "2.3.1"
     val circe           = "0.13.0"
     val disciplineMUnit = "1.0.5"

--- a/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
+++ b/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
@@ -92,7 +92,7 @@ final class WebSocketJSConnection[F[_]: Sync: Logger](private val ws: WebSocket)
     Logger[F].trace("Disconnecting WebSocket...") >>
       Sync[F].delay {
         val params = closeParameters.getOrElse(WebSocketCloseParams())
-        // Facade for "ws.close" should define parameters as js.Undef, but it doesn't.
+        // Facade for "ws.close" should define parameters as js.Undef, but it doesn't. So we contemplate all cases.
         (params.code, params.reason)
           .mapN { case (code, reason) => ws.close(code, reason) }
           .orElse(params.code.map(code => ws.close(code)))


### PR DESCRIPTION
* Remove `Terminated` status. When a session is terminated but the channel is kept open, we should go straight to `Connected`.
* Added names for client, for easier logging. If not passed, the `uri` is used.
* When reconnecting, do not connect until after waiting. This is the right logic. It does introduce a bug though where messages sent by the client while waiting are queued up in the old, discarded client. Fixing this requires a larger change in the logic, which will be addressed in a future PR.