### PR TITLE
Dont log handled errors

### DIFF
--- a/core/shared/src/main/scala/clue/ApolloClient.scala
+++ b/core/shared/src/main/scala/clue/ApolloClient.scala
@@ -231,7 +231,7 @@ class ApolloClient[F[_], S, CP, CE](
   ): F[D] = F.asyncF[D] { cb =>
     startSubscription[D](document, operationName, variables).flatMap { subscriptionInfo =>
       subscriptionInfo.subscription.stream.attempt
-        .evalMap(result => F.delay(cb(result)) >> subscriptionInfo.onComplete)
+        .evalMap(result => F.delay(cb(result)))
         .compile
         .drain
     }

--- a/macros/src/test/scala/clue/macros/MacroTest.scala
+++ b/macros/src/test/scala/clue/macros/MacroTest.scala
@@ -566,9 +566,10 @@ class MacroTest extends FunSuite {
         Data
           .Result(
             List(
-              Data.Result.Observations("o-2",
-                                       "Observation 2".some,
-                                       Data.Result.Observations.ObservationTarget.Target("t-2").some
+              Data.Result.Observations(
+                "o-2",
+                "Observation 2".some,
+                Data.Result.Observations.ObservationTarget.Target("t-2").some
               ),
               Data.Result.Observations(
                 "o-3",


### PR DESCRIPTION
Whenever an "error" message was received on a subscription, `clue` logged it. However, we may want to handle them at the application level, so these are not logged anymore (they still produce an error on the stream or effect).

Also, in case of errors on queries/mutations over persistent connections we were cleaning up the subscription queue twice. We now solve this by letting the "complete" message from the server trigger the cleanup.