### PR TITLE
Fix WebSockets on JVM.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,18 @@ lazy val http4sJDK = project
   )
   .dependsOn(coreJVM)
 
+lazy val http4sJDKDemo = project
+  .in(file("http4s-jdk-demo"))
+  .settings(
+    moduleName := "clue-http4s-jdk-client-demo",
+    publish := false,
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "log4cats-slf4j" % Settings.LibraryVersions.log4Cats,
+      "org.slf4j"      % "slf4j-simple"   % "1.6.4"
+    )
+  )
+  .dependsOn(http4sJDK)
+
 lazy val genRules = project
   .in(file("gen/rules"))
   .settings(

--- a/http4s-jdk-demo/src/main/scala/clue/http4sjdk-demo/Demo.scala
+++ b/http4s-jdk-demo/src/main/scala/clue/http4sjdk-demo/Demo.scala
@@ -1,0 +1,50 @@
+package clue.`http4sjdk-demo`
+
+import cats.effect.IOApp
+import cats.effect.IO
+import clue.http4sjdk.Http4sJDKWSBackend
+import clue.ApolloWebSocketClient
+import clue.GraphQLOperation
+import io.circe.Encoder
+import io.circe.Decoder
+import io.circe.Json
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import sttp.model.Uri
+
+object Demo extends IOApp.Simple {
+  def run =
+    Slf4jLogger.create[IO].flatMap { implicit logger =>
+      Http4sJDKWSBackend[IO].use { implicit backend =>
+        ApolloWebSocketClient
+          .of[IO, Unit](
+            Uri.parse("wss://lucuma-odb-development.herokuapp.com/ws").getOrElse(???)
+          )
+          .flatMap { implicit client =>
+            client.connect() >>
+              client.initialize() >>
+              client
+                .request(new GraphQLOperation[Unit] {
+                  type Data      = Json
+                  type Variables = Json
+
+                  override val document: String = """
+                  |query {
+                  |  observations(programId: "p-2") {
+                  |    nodes {
+                  |      id
+                  |      name
+                  |    }
+                  |  }
+                  |}""".stripMargin
+
+                  override val varEncoder: Encoder[Variables] = Encoder[Json]
+
+                  override val dataDecoder: Decoder[Data] = Decoder[Json]
+
+                })
+                .flatMap(IO.println) >> client.terminate() >> client.disconnect()
+          }
+          .onError(t => IO(t.printStackTrace()))
+      }
+    }
+}

--- a/http4s-jdk/src/main/scala/clue/http4sjdk/Http4sJDKWSBackend.scala
+++ b/http4s-jdk/src/main/scala/clue/http4sjdk/Http4sJDKWSBackend.scala
@@ -11,8 +11,12 @@ import clue._
 import clue.model.StreamingMessage
 import clue.model.json._
 import io.circe.syntax._
-import sttp.model.Uri
 import org.http4s.jdkhttpclient._
+import org.http4s.Header
+import org.http4s.Headers
+import org.typelevel.ci._
+import sttp.model.Uri
+
 import java.net.http.HttpClient
 
 /**
@@ -27,7 +31,9 @@ final class Http4sJDKWSBackend[F[_]: Async](client: WSClient[F]) extends WebSock
   ): F[PersistentConnection[F, WebSocketCloseParams]] =
     client
       .connectHighLevel(
-        WSRequest(sttpUriToHttp4sUri(uri))
+        WSRequest(sttpUriToHttp4sUri(uri),
+                  headers = Headers(Header.Raw(ci"Sec-WebSocket-Protocol", "graphql-ws"))
+        )
       )
       .allocated
       .flatMap { case (connection, release) =>

--- a/http4s-jdk/src/main/scala/clue/http4sjdk/package.scala
+++ b/http4s-jdk/src/main/scala/clue/http4sjdk/package.scala
@@ -8,19 +8,18 @@ import org.http4s.Uri
 import org.http4s.Query
 
 package object http4sjdk {
-  protected[http4sjdk] def sttpUriToHttp4sUri(uri: SUri): Uri = Uri(
-    scheme = uri.scheme.map(Uri.Scheme.unsafeFromString),
-    authority = uri.authority.map(a =>
-      Uri.Authority(
-        userInfo = a.userInfo.map(ui => Uri.UserInfo(ui.username, ui.password)),
-        host = Uri.Ipv4Address
-          .fromString(a.host)
-          .getOrElse(Uri.Ipv6Address.unsafeFromString(a.host)),
-        port = a.port
-      )
-    ),
-    path = Uri.Path(uri.pathSegments.segments.map(s => Uri.Path.Segment(s.v)).toVector),
-    query = Query.unsafeFromString(uri.toString),
-    fragment = uri.fragment
-  )
+  protected[http4sjdk] def sttpUriToHttp4sUri(uri: SUri): Uri =
+    Uri(
+      scheme = uri.scheme.map(Uri.Scheme.unsafeFromString),
+      authority = uri.authority.map(a =>
+        Uri.Authority(
+          userInfo = a.userInfo.map(ui => Uri.UserInfo(ui.username, ui.password)),
+          host = Uri.RegName(a.host),
+          port = a.port
+        )
+      ),
+      path = Uri.Path(uri.pathSegments.segments.map(s => Uri.Path.Segment(s.v)).toVector),
+      query = Query.unsafeFromString(uri.toString),
+      fragment = uri.fragment
+    )
 }


### PR DESCRIPTION
* Fixes on the JVM WebSocket implementation:
  * `Uri` conversion was failing for non-IP hosts.
  * `subprotocol` was missing.
* Added demo project for JVM