### PR TITLE
Add ResponseException and GraphQLErrors

### DIFF
--- a/core/shared/src/main/scala/clue/ApolloClient.scala
+++ b/core/shared/src/main/scala/clue/ApolloClient.scala
@@ -570,7 +570,7 @@ class ApolloClient[F[_], S, CP, CE](
     }
 
     def emitError(json: Json): F[Unit] = {
-      val error = new GraphQLException(json.toString)
+      val error = new ResponseException(json.asArray.fold(List(json))(_.toList))
       // TODO When an Error message is received, we terminate the stream and halt the subscription. Do we want that?
       queue.offer(error.asLeft)
     }

--- a/core/shared/src/main/scala/clue/GraphQLException.scala
+++ b/core/shared/src/main/scala/clue/GraphQLException.scala
@@ -6,7 +6,7 @@ package clue
 import cats.syntax.traverse._
 import clue.model.GraphQLError
 import clue.model.json.DecoderGraphQLError
-import io.circe.{Decoder, Json}
+import io.circe.{ Decoder, Json }
 
 class GraphQLException(msg: String) extends Exception(msg)
 
@@ -15,10 +15,10 @@ class ConnectionException() extends GraphQLException("Could not establish connec
 class DisconnectedException() extends GraphQLException("Connection was closed")
 
 class InvalidSubscriptionIdException(id: String)
-  extends GraphQLException(s"Invalid subscription id: $id")
+    extends GraphQLException(s"Invalid subscription id: $id")
 
 class ResponseException(errors: List[Json])
-  extends GraphQLException(errors.map(_.spaces2).mkString(",")) {
+    extends GraphQLException(errors.map(_.spaces2).mkString(",")) {
 
   /**
    * Decodes and returns the errors as `GraphQLError` if possible.
@@ -27,5 +27,3 @@ class ResponseException(errors: List[Json])
     errors.traverse(Decoder[GraphQLError].decodeJson).getOrElse(List.empty)
 
 }
-
-

--- a/core/shared/src/main/scala/clue/GraphQLException.scala
+++ b/core/shared/src/main/scala/clue/GraphQLException.scala
@@ -21,9 +21,12 @@ class ResponseException(errors: List[Json])
     extends GraphQLException(errors.map(_.spaces2).mkString(",")) {
 
   /**
-   * Decodes and returns the errors as `GraphQLError` if possible.
+   * Decodes and returns the errors as a list of `GraphQLError` if possible.
+   *
+   * @return None if there is a problem parsing the JSON as an array of
+   *         GraphQLError, Some(List[GraphQLError]) if successful
    */
-  def asGraphQLErrors: List[GraphQLError] =
-    errors.traverse(Decoder[GraphQLError].decodeJson).getOrElse(List.empty)
+  def asGraphQLErrors: Option[List[GraphQLError]] =
+    errors.traverse(Decoder[GraphQLError].decodeJson).toOption
 
 }

--- a/core/shared/src/main/scala/clue/TransactionalClientImpl.scala
+++ b/core/shared/src/main/scala/clue/TransactionalClientImpl.scala
@@ -31,7 +31,7 @@ class TransactionalClientImpl[F[_]: MonadError[*[_], Throwable]: TransactionalBa
           val cursor = json.hcursor
           cursor
             .get[List[Json]]("errors")
-            .map(errors => new GraphQLException(errors.toString))
+            .map(errors => new ResponseException(errors))
             .swap
             .flatMap(_ => cursor.get[D]("data"))
         }

--- a/model/shared/src/main/scala/clue/model/GraphQLError.scala
+++ b/model/shared/src/main/scala/clue/model/GraphQLError.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model
+
+import cats.Eq
+import clue.model.GraphQLError.Location
+
+final case class GraphQLError(
+  message:   String,
+  path:      List[String],
+  locations: List[Location]
+)
+
+object GraphQLError {
+
+  final case class Location(line: Int, column: Int)
+
+  object Location {
+    implicit val EqLocation: Eq[Location] =
+      Eq.by { a => (
+        a.line,
+        a.column
+      )}
+  }
+
+  implicit val EqGraphQLError: Eq[GraphQLError] =
+    Eq.by { a => (
+      a.message,
+      a.path,
+      a.locations
+    )}
+
+}

--- a/model/shared/src/main/scala/clue/model/GraphQLError.scala
+++ b/model/shared/src/main/scala/clue/model/GraphQLError.scala
@@ -18,17 +18,21 @@ object GraphQLError {
 
   object Location {
     implicit val EqLocation: Eq[Location] =
-      Eq.by { a => (
-        a.line,
-        a.column
-      )}
+      Eq.by { a =>
+        (
+          a.line,
+          a.column
+        )
+      }
   }
 
   implicit val EqGraphQLError: Eq[GraphQLError] =
-    Eq.by { a => (
-      a.message,
-      a.path,
-      a.locations
-    )}
+    Eq.by { a =>
+      (
+        a.message,
+        a.path,
+        a.locations
+      )
+    }
 
 }

--- a/model/shared/src/main/scala/clue/model/GraphQLError.scala
+++ b/model/shared/src/main/scala/clue/model/GraphQLError.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package clue.model

--- a/model/shared/src/main/scala/clue/model/GraphQLError.scala
+++ b/model/shared/src/main/scala/clue/model/GraphQLError.scala
@@ -9,9 +9,10 @@ import cats.syntax.eq._
 import clue.model.GraphQLError.{ Location, PathElement }
 
 final case class GraphQLError(
-  message:   String,
-  path:      List[PathElement],
-  locations: List[Location]
+  message:    String,
+  path:       List[PathElement],
+  locations:  List[Location],
+  extensions: Map[String, String]
 )
 
 object GraphQLError {
@@ -70,7 +71,8 @@ object GraphQLError {
       (
         a.message,
         a.path,
-        a.locations
+        a.locations,
+        a.extensions
       )
     }
 

--- a/model/shared/src/main/scala/clue/model/GraphQLError.scala
+++ b/model/shared/src/main/scala/clue/model/GraphQLError.scala
@@ -4,15 +4,54 @@
 package clue.model
 
 import cats.Eq
-import clue.model.GraphQLError.Location
+import cats.syntax.either._
+import cats.syntax.eq._
+import clue.model.GraphQLError.{ Location, PathElement }
 
 final case class GraphQLError(
   message:   String,
-  path:      List[String],
+  path:      List[PathElement],
   locations: List[Location]
 )
 
 object GraphQLError {
+
+  sealed trait PathElement extends Product with Serializable {
+
+    def toEither: Either[Int, String] =
+      this match {
+        case StringPathElement(e) => e.asRight[Int]
+        case IntPathElement(e)    => e.asLeft[String]
+      }
+
+    def fold[A](fi: Int => A, fs: String => A): A =
+      this match {
+        case StringPathElement(e) => fs(e)
+        case IntPathElement(e)    => fi(e)
+      }
+
+  }
+
+  object PathElement {
+
+    def int(element: Int): PathElement =
+      IntPathElement(element)
+
+    def string(element: String): PathElement =
+      StringPathElement(element)
+
+    implicit val EqPathElement: Eq[PathElement] =
+      Eq.instance {
+        case (IntPathElement(a), IntPathElement(b))       => a === b
+        case (StringPathElement(a), StringPathElement(b)) => a === b
+        case _                                            => false
+      }
+
+  }
+
+  final case class StringPathElement(element: String) extends PathElement
+  final case class IntPathElement(element: Int) extends PathElement
+
 
   final case class Location(line: Int, column: Int)
 

--- a/model/shared/src/main/scala/clue/model/GraphQLError.scala
+++ b/model/shared/src/main/scala/clue/model/GraphQLError.scala
@@ -53,7 +53,6 @@ object GraphQLError {
   final case class StringPathElement(element: String) extends PathElement
   final case class IntPathElement(element: Int) extends PathElement
 
-
   final case class Location(line: Int, column: Int)
 
   object Location {

--- a/model/shared/src/main/scala/clue/model/json/package.scala
+++ b/model/shared/src/main/scala/clue/model/json/package.scala
@@ -221,6 +221,36 @@ package object json {
             )
         }
 
+  implicit val EncoderGraphQLErrorLocation: Encoder[GraphQLError.Location] =
+    (a: GraphQLError.Location) =>
+      Json.obj(
+        "line"   -> a.line.asJson,
+        "column" -> a.column.asJson
+      )
+
+  implicit val DecoderGraphQLErrorLocation: Decoder[GraphQLError.Location] =
+    (c: HCursor) =>
+      for {
+        line   <- c.downField("line").as[Int]
+        column <- c.downField("column").as[Int]
+      } yield GraphQLError.Location(line, column)
+
+  implicit val EncoderGraphQLError: Encoder[GraphQLError] =
+    (a: GraphQLError) =>
+      Json.obj(
+        "message"   -> a.message.asJson,
+        "path"      -> a.path.asJson,
+        "locations" -> a.locations.asJson
+      )
+
+  implicit val DecoderGraphQLError: Decoder[GraphQLError] =
+    (c: HCursor) =>
+      for {
+        message   <- c.downField("message").as[String]
+        path      <- c.downField("path").as[List[String]]
+        locations <- c.downField("locations").as[List[GraphQLError.Location]]
+      } yield GraphQLError(message, path, locations)
+
   private def checkType(c: HCursor, expected: String): Decoder.Result[Unit] =
     c.downField("type")
       .as[String]

--- a/model/shared/src/main/scala/clue/model/json/package.scala
+++ b/model/shared/src/main/scala/clue/model/json/package.scala
@@ -222,14 +222,14 @@ package object json {
         }
 
   implicit val EncoderGraphQLErrorPathElement: Encoder[GraphQLError.PathElement] =
-    (a: GraphQLError.PathElement) =>
-      a.fold(_.asJson, _.asJson)
+    (a: GraphQLError.PathElement) => a.fold(_.asJson, _.asJson)
 
   implicit val DecoderGraphQLErrorPathElement: Decoder[GraphQLError.PathElement] =
     (c: HCursor) =>
-      c.as[Int].map(GraphQLError.PathElement.int)
-       .orElse(c.as[String].map(GraphQLError.PathElement.string))
-       .orElse(DecodingFailure(s"Unexpected PathElement", c.history).asLeft)
+      c.as[Int]
+        .map(GraphQLError.PathElement.int)
+        .orElse(c.as[String].map(GraphQLError.PathElement.string))
+        .orElse(DecodingFailure(s"Unexpected PathElement", c.history).asLeft)
 
   implicit val EncoderGraphQLErrorLocation: Encoder[GraphQLError.Location] =
     (a: GraphQLError.Location) =>
@@ -245,7 +245,9 @@ package object json {
         column <- c.get[Int]("column")
       } yield GraphQLError.Location(line, column)
 
-  private def optionalField[A: Encoder](name: String, a: A)(predicate: A => Boolean): Option[(String, Json)] =
+  private def optionalField[A: Encoder](name: String, a: A)(
+    predicate:                                A => Boolean
+  ): Option[(String, Json)] =
     if (predicate(a)) (name, a.asJson).some else none
 
   implicit val EncoderGraphQLError: Encoder[GraphQLError] =

--- a/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package clue.model

--- a/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model
+package arb
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbGraphQLError {
+
+  import GraphQLError.Location
+
+  implicit val arbGraphQLErrorLocation: Arbitrary[Location] =
+    Arbitrary {
+      for {
+        line   <- arbitrary[Int]
+        column <- arbitrary[Int]
+      } yield Location(line, column)
+    }
+
+  implicit val arbGraphQLError: Arbitrary[GraphQLError] =
+    Arbitrary {
+      for {
+        message   <- arbitrary[String]
+        path      <- arbitrary[List[String]]
+        locations <- arbitrary[List[Location]]
+      } yield GraphQLError(message, path, locations)
+    }
+
+}
+
+object ArbGraphQLError extends ArbGraphQLError

--- a/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
@@ -30,10 +30,11 @@ trait ArbGraphQLError {
   implicit val arbGraphQLError: Arbitrary[GraphQLError] =
     Arbitrary {
       for {
-        message   <- arbitrary[String]
-        path      <- arbitrary[List[PathElement]]
-        locations <- arbitrary[List[Location]]
-      } yield GraphQLError(message, path, locations)
+        message    <- arbitrary[String]
+        path       <- arbitrary[List[PathElement]]
+        locations  <- arbitrary[List[Location]]
+        extensions <- arbitrary[Map[String, String]]
+      } yield GraphQLError(message, path, locations, extensions)
     }
 
 }

--- a/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
+++ b/model/shared/src/test/scala/clue/model/arb/ArbGraphQLError.scala
@@ -9,7 +9,15 @@ import org.scalacheck.Arbitrary._
 
 trait ArbGraphQLError {
 
-  import GraphQLError.Location
+  import GraphQLError.{ Location, PathElement }
+
+  implicit val arbPathElement: Arbitrary[PathElement] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[Int].map(PathElement.int),
+        arbitrary[String].map(PathElement.string)
+      )
+    }
 
   implicit val arbGraphQLErrorLocation: Arbitrary[Location] =
     Arbitrary {
@@ -23,7 +31,7 @@ trait ArbGraphQLError {
     Arbitrary {
       for {
         message   <- arbitrary[String]
-        path      <- arbitrary[List[String]]
+        path      <- arbitrary[List[PathElement]]
         locations <- arbitrary[List[Location]]
       } yield GraphQLError(message, path, locations)
     }

--- a/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
+++ b/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
@@ -14,6 +14,7 @@ final class GraphQLErrorJsonSpec extends DisciplineSuite {
 
   import ArbGraphQLError._
 
+  checkAll("GraphQLError.PathElement", CodecTests[GraphQLError.PathElement].codec)
   checkAll("GraphQLError.Location", CodecTests[GraphQLError.Location].codec)
   checkAll("GraphQLError", CodecTests[GraphQLError].codec)
 

--- a/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
+++ b/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model.json
+
+import clue.model.GraphQLError
+import clue.model.arb._
+import io.circe.testing.instances._
+import io.circe.testing.CodecTests
+
+import munit.DisciplineSuite
+
+final class GraphQLErrorJsonSpec extends DisciplineSuite {
+
+  import ArbGraphQLError._
+
+  checkAll("GraphQLError.Location", CodecTests[GraphQLError.Location].codec)
+  checkAll("GraphQLError",          CodecTests[GraphQLError].codec)
+
+}

--- a/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
+++ b/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package clue.model.json

--- a/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
+++ b/model/shared/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
@@ -15,6 +15,6 @@ final class GraphQLErrorJsonSpec extends DisciplineSuite {
   import ArbGraphQLError._
 
   checkAll("GraphQLError.Location", CodecTests[GraphQLError.Location].codec)
-  checkAll("GraphQLError",          CodecTests[GraphQLError].codec)
+  checkAll("GraphQLError", CodecTests[GraphQLError].codec)
 
 }


### PR DESCRIPTION
Working on testing for expected errors in GraphQL queries, I noticed that I could only extract the error information from the `GraphQLException` message `String`.  Wanting easier access to the actual errors, I added a `ResponseException` that keeps up with the `Json` array itself and support for turning this into structured data.

I'm not sure about or convinced of any of this so take it as a request to obtain access to error information somehow and let me know if there are better ways to accomplish this.