### PR TITLE
Generate decoder for sums without generic-extras.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,8 @@ lazy val genRules =
       libraryDependencies ++=
         Settings.Libraries.Grackle.value ++
           Settings.Libraries.ScalaFix.value ++
-          Settings.Libraries.DisciplineMUnit.value
+          Settings.Libraries.DisciplineMUnit.value,
+      scalacOptions ~= (_.filterNot(Set("-Vtype-diffs")))
     )
     .dependsOn(core)
     .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(rulesCrossVersions.head))
@@ -139,14 +140,11 @@ lazy val genOutput = projectMatrix
   .settings(
     publish / skip := true,
     scalacOptions += "-Wconf:cat=unused:info",
-    libraryDependencies ++= Settings.Libraries.Monocle.value ++ Settings.Libraries.CirceGenericExtras.value
+    libraryDependencies ++= Settings.Libraries.Monocle.value
   )
   .dependsOn(core)
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala3Version))
-  .jvmPlatform(
-    // TODO Change to allVersions when we generate a substitute for circe generic extras in Scala 3 (https://github.com/circe/circe/pull/1800)
-    rulesCrossVersions
-  )
+  .jvmPlatform(allVersions)
 
 lazy val genTestsAggregate = Project("genTests", file("target/genTestsAggregate"))
   .aggregate(genTests.projectRefs: _*)
@@ -176,12 +174,11 @@ lazy val genTests = projectMatrix
   .defaultAxes(
     rulesCrossVersions.map(VirtualAxis.scalaABIVersion) :+ VirtualAxis.jvm: _*
   )
-  // TODO Enable when we generate a substitute for circe generic extras in Scala 3 (https://github.com/circe/circe/pull/1800)
-  // .customRow(
-  //   scalaVersions = Seq(V.scala213),
-  //   axisValues = Seq(TargetAxis(scala3Version), VirtualAxis.jvm),
-  //   settings = Seq()
-  // )
+  .customRow(
+    scalaVersions = Seq(V.scala213),
+    axisValues = Seq(TargetAxis(scala3Version), VirtualAxis.jvm),
+    settings = Seq()
+  )
   .customRow(
     scalaVersions = Seq(V.scala213),
     axisValues = Seq(TargetAxis(V.scala213), VirtualAxis.jvm),

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,11 @@ lazy val genOutput = projectMatrix
   .in(file("gen/output"))
   .settings(
     publish / skip := true,
-    scalacOptions += "-Wconf:cat=unused:info",
+    scalacOptions ++=
+      (scalaVersion.value match {
+        case `scala3Version` => Nil
+        case _               => List("-Wconf:cat=unused:info")
+      }),
     libraryDependencies ++= Settings.Libraries.Monocle.value
   )
   .dependsOn(core)

--- a/gen/input/src/main/scala/test/LucumaQuery.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery.scala
@@ -23,7 +23,6 @@ trait LucumaQuery extends GraphQLOperation[LucumaODB] {
               id
               name
               tracking {
-                tracktype: __typename
                 ... on Sidereal {
                   epoch
                 }

--- a/gen/input/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery3.scala
@@ -19,7 +19,6 @@ trait LucumaQuery3 extends GraphQLOperation[LucumaODB] {
           nodes {
             id
             observationTarget {
-              type: __typename
               ... on Target {
                 target_id: id
                 target_name: name

--- a/gen/input/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery.scala
@@ -28,7 +28,6 @@ trait StarWarsQuery extends GraphQLOperation[StarWars] {
             ... on Droid {
               primaryFunction
             }
-            __typename
           }
         }
       """

--- a/gen/input/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery2.scala
@@ -31,7 +31,6 @@ object Wrapper /* gql: extends Something */ {
             ... on Droid {
               primaryFunction
             }
-            __typename
           }
         }
       """

--- a/gen/output/src/main/scala/test/LucumaQuery.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery.scala
@@ -25,7 +25,6 @@ object LucumaQuery extends GraphQLOperation[LucumaODB] {
               id
               name
               tracking {
-                tracktype: __typename
                 ... on Sidereal {
                   epoch
                 }
@@ -69,8 +68,7 @@ object LucumaQuery extends GraphQLOperation[LucumaODB] {
             }
             implicit val eqTracking: cats.Eq[Data.Program.Targets.Nodes.Tracking] = cats.Eq.fromUniversalEquals
             implicit val showTracking: cats.Show[Data.Program.Targets.Nodes.Tracking] = cats.Show.fromToString
-            implicit protected val jsonConfiguration: io.circe.generic.extras.Configuration = io.circe.generic.extras.Configuration.default.withDiscriminator("tracktype")
-            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = io.circe.generic.extras.semiauto.deriveConfiguredDecoder[Data.Program.Targets.Nodes.Tracking]
+            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = List[io.circe.Decoder[Data.Program.Targets.Nodes.Tracking]](io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Sidereal].asInstanceOf[io.circe.Decoder[Data.Program.Targets.Nodes.Tracking]], io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Nonsidereal].asInstanceOf[io.circe.Decoder[Data.Program.Targets.Nodes.Tracking]]).reduceLeft(_ or _)
           }
           implicit val id: monocle.Lens[Data.Program.Targets.Nodes, TargetId] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.id)
           implicit val name: monocle.Lens[Data.Program.Targets.Nodes, NonEmptyString] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.name)

--- a/gen/output/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery3.scala
@@ -21,7 +21,6 @@ object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
           nodes {
             id
             observationTarget {
-              type: __typename
               ... on Target {
                 target_id: id
                 target_name: name
@@ -66,8 +65,7 @@ object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
           }
           implicit val eqObservationTarget: cats.Eq[Data.Observations.Nodes.ObservationTarget] = cats.Eq.fromUniversalEquals
           implicit val showObservationTarget: cats.Show[Data.Observations.Nodes.ObservationTarget] = cats.Show.fromToString
-          implicit protected val jsonConfiguration: io.circe.generic.extras.Configuration = io.circe.generic.extras.Configuration.default.withDiscriminator("type")
-          implicit val jsonDecoderObservationTarget: io.circe.Decoder[Data.Observations.Nodes.ObservationTarget] = io.circe.generic.extras.semiauto.deriveConfiguredDecoder[Data.Observations.Nodes.ObservationTarget]
+          implicit val jsonDecoderObservationTarget: io.circe.Decoder[Data.Observations.Nodes.ObservationTarget] = List[io.circe.Decoder[Data.Observations.Nodes.ObservationTarget]](io.circe.Decoder[Data.Observations.Nodes.ObservationTarget.Target].asInstanceOf[io.circe.Decoder[Data.Observations.Nodes.ObservationTarget]], io.circe.Decoder[Data.Observations.Nodes.ObservationTarget.Asterism].asInstanceOf[io.circe.Decoder[Data.Observations.Nodes.ObservationTarget]]).reduceLeft(_ or _)
         }
         implicit val id: monocle.Lens[Data.Observations.Nodes, ObservationId] = monocle.macros.GenLens[Data.Observations.Nodes](_.id)
         implicit val observationTarget: monocle.Lens[Data.Observations.Nodes, Option[Data.Observations.Nodes.ObservationTarget]] = monocle.macros.GenLens[Data.Observations.Nodes](_.observationTarget)

--- a/gen/output/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery.scala
@@ -30,7 +30,6 @@ object StarWarsQuery extends GraphQLOperation[StarWars] {
             ... on Droid {
               primaryFunction
             }
-            __typename
           }
         }
       """
@@ -102,8 +101,7 @@ object StarWarsQuery extends GraphQLOperation[StarWars] {
       }
       implicit val eqCharacter: cats.Eq[Data.Character] = cats.Eq.fromUniversalEquals
       implicit val showCharacter: cats.Show[Data.Character] = cats.Show.fromToString
-      implicit protected val jsonConfiguration: io.circe.generic.extras.Configuration = io.circe.generic.extras.Configuration.default.withDiscriminator("__typename")
-      implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = io.circe.generic.extras.semiauto.deriveConfiguredDecoder[Data.Character]
+      implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = List[io.circe.Decoder[Data.Character]](io.circe.Decoder[Data.Character.Human].asInstanceOf[io.circe.Decoder[Data.Character]], io.circe.Decoder[Data.Character.Droid].asInstanceOf[io.circe.Decoder[Data.Character]]).reduceLeft(_ or _)
     }
     implicit val character: monocle.Lens[Data, Option[Data.Character]] = monocle.macros.GenLens[Data](_.character)
     implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals

--- a/gen/output/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery2.scala
@@ -32,7 +32,6 @@ object Wrapper extends Something {
               ... on Droid {
                 primaryFunction
               }
-              __typename
             }
           }
         """
@@ -120,8 +119,7 @@ object Wrapper extends Something {
           import japgolly.scalajs.react.Reusability
           japgolly.scalajs.react.Reusability.derive
         }
-        implicit protected val jsonConfiguration: io.circe.generic.extras.Configuration = io.circe.generic.extras.Configuration.default.withDiscriminator("__typename")
-        implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = io.circe.generic.extras.semiauto.deriveConfiguredDecoder[Data.Character]
+        implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = List[io.circe.Decoder[Data.Character]](io.circe.Decoder[Data.Character.Human].asInstanceOf[io.circe.Decoder[Data.Character]], io.circe.Decoder[Data.Character.Droid].asInstanceOf[io.circe.Decoder[Data.Character]]).reduceLeft(_ or _)
       }
       implicit val character: monocle.Lens[Data, Option[Data.Character]] = monocle.macros.GenLens[Data](_.character)
       implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -269,32 +269,16 @@ trait QueryGen extends Generator {
                                singleSubType._2.parAccum
               )
             case _                    =>
-              // More than one subtype. Needs discriminator.
-              // Figure out discriminator name. Could be renamed.
-              val discriminator = selections.collect {
-                case Select(TypeSelect, _, _)               => TypeSelect
-                case Rename(name, Select(TypeSelect, _, _)) => name
-              } match {
-                case field :: Nil => field
-                case _            =>
-                  abort(
-                    s"Multiple inline fragments require (unique) selection of $TypeSelect"
-                  ).unsafeRunSync()
-              }
-
-              val baseParams = baseAccumulator.parAccum.filterNot(_.name == discriminator)
+              val baseParams = baseAccumulator.parAccum
 
               val subTypes = subTypeAccumulators.collect { case (typeName, accumulator) =>
-                CaseClass(typeName,
-                          accumulator.parAccum.filterNot(_.name == discriminator),
-                          accumulator.classes
-                )
+                CaseClass(typeName, accumulator.parAccum, accumulator.classes)
               }
 
               ClassAccumulator(
                 baseAccumulator.classes,
                 baseParams,
-                Sum(baseParams, baseAccumulator.classes, subTypes, discriminator).some
+                Sum(baseParams, baseAccumulator.classes, subTypes).some
               )
           }
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -50,12 +50,6 @@ object Settings {
       ).map(_ % circe)
     )
 
-    val CirceGenericExtras = Def.setting(
-      Seq(
-        "io.circe" %%% "circe-generic-extras" % circe
-      )
-    )
-
     val DisciplineMUnit = Def.setting(
       Seq[ModuleID](
         "org.typelevel" %%% "discipline-munit" % disciplineMUnit % "test"


### PR DESCRIPTION
Generating types for queries that return `|` or `interface` types no longer requires a discriminator. Instead, trial and error is used as described in https://circe.github.io/circe/codecs/adt.html.

This removes the need to depend on `circe-generic-extras` and therefore makes the generator work in Scala 3.