### PR TITLE
Trim query on get

### DIFF
--- a/scalajs/src/main/scala/clue/js/AjaxJSBackend.scala
+++ b/scalajs/src/main/scala/clue/js/AjaxJSBackend.scala
@@ -48,7 +48,9 @@ final class AjaxJSBackend[F[_]: Async](method: AjaxMethod) extends Transactional
           val op        = request.operationName.foldMap(o => s"&operationName=$o")
           Ajax
             .get(
-              url = URIUtils.encodeURI(s"$uri?query=${request.query.trim.replaceAll(" +", " ")}$variables$op")
+              url = URIUtils.encodeURI(
+                s"$uri?query=${request.query.trim.replaceAll(" +", " ")}$variables$op"
+              )
             )
             .onComplete {
               case Success(r) => cb(Right(r.responseText))


### PR DESCRIPTION
This is a small thing but with url encoding the GET query urls get fairly large and harder to debug