### PR TITLE
add optional headers for transactional client

### DIFF
--- a/core/src/main/scala/clue/TransactionalClientImpl.scala
+++ b/core/src/main/scala/clue/TransactionalClientImpl.scala
@@ -10,6 +10,7 @@ import io.circe._
 import io.circe.parser._
 import org.http4s.Uri
 import org.typelevel.log4cats.Logger
+import org.http4s.Headers
 
 // Response format from Spec: https://github.com/APIs-guru/graphql-over-http
 // {
@@ -17,7 +18,8 @@ import org.typelevel.log4cats.Logger
 //   "errors": [ ... ]
 // }
 class TransactionalClientImpl[F[_]: MonadThrow: TransactionalBackend: Logger, S](
-  uri: Uri
+  uri: Uri,
+  headers: Headers
 ) extends clue.TransactionalClient[F, S] {
   override protected def requestInternal[D: Decoder](
     document:      String,
@@ -25,7 +27,7 @@ class TransactionalClientImpl[F[_]: MonadThrow: TransactionalBackend: Logger, S]
     variables:     Option[Json] = None
   ): F[D] =
     TransactionalBackend[F]
-      .request(uri, GraphQLRequest(document, operationName, variables))
+      .request(uri, GraphQLRequest(document, operationName, variables), headers)
       .map { response =>
         parse(response).flatMap { json =>
           val cursor = json.hcursor

--- a/core/src/main/scala/clue/backends.scala
+++ b/core/src/main/scala/clue/backends.scala
@@ -7,12 +7,13 @@ import cats.syntax.all._
 import clue.model.GraphQLRequest
 import clue.model.StreamingMessage
 import org.http4s.Uri
+import org.http4s.Headers
 
 /*
  * One-shot backend.
  */
 trait TransactionalBackend[F[_]] {
-  def request(uri: Uri, request: GraphQLRequest): F[String]
+  def request(uri: Uri, request: GraphQLRequest, headers: Headers): F[String]
 }
 
 object TransactionalBackend {

--- a/core/src/main/scala/clue/clients.scala
+++ b/core/src/main/scala/clue/clients.scala
@@ -10,6 +10,7 @@ import io.circe._
 import io.circe.syntax._
 import org.http4s.Uri
 import org.typelevel.log4cats.Logger
+import org.http4s.Headers
 
 /**
  * A client that allows one-shot queries and mutations.
@@ -47,7 +48,7 @@ trait TransactionalClient[F[_], S] {
 }
 
 object TransactionalClient {
-  def of[F[_], S](uri: Uri, name: String = "")(implicit
+  def of[F[_], S](uri: Uri, name: String = "", headers: Headers = Headers.empty)(implicit
     F:                 MonadError[F, Throwable],
     backend:           TransactionalBackend[F],
     logger:            Logger[F]
@@ -55,7 +56,7 @@ object TransactionalClient {
     val logPrefix = s"clue.TransactionalClient[${if (name.isEmpty) uri else name}]"
 
     Applicative[F].pure(
-      new TransactionalClientImpl[F, S](uri)(
+      new TransactionalClientImpl[F, S](uri, headers)(
         F,
         backend,
         logger.withModifiedString(s => s"$logPrefix $s")

--- a/http4s-jdk/src/main/scala/clue/http4sjdk/Http4sJDKBackend.scala
+++ b/http4s-jdk/src/main/scala/clue/http4sjdk/Http4sJDKBackend.scala
@@ -18,6 +18,7 @@ import org.http4s.headers._
 import org.http4s.jdkhttpclient.JdkHttpClient
 
 import java.net.http.HttpClient
+import org.http4s.Headers
 
 final class Http4sJDKBackend[F[_]: Async](val client: Client[F]) extends TransactionalBackend[F] {
 
@@ -26,10 +27,11 @@ final class Http4sJDKBackend[F[_]: Async](val client: Client[F]) extends Transac
 
   def request(
     uri:     Uri,
-    request: GraphQLRequest
+    request: GraphQLRequest,
+    headers: Headers
   ): F[String] =
     client.expect[String](
-      POST(request.asJson, uri).withContentType(`Content-Type`(MediaType.application.json))
+      POST(request.asJson, uri, headers).withContentType(`Content-Type`(MediaType.application.json))
     )
 }
 


### PR DESCRIPTION
This adds something similar to `PersistentStreamingClient.initialize` to basic transactional http clients by allowing you to pass an optional http4s `Headers` to `TransactionalClient.of[...]`, and these headers will be sent with all requests.

This lets you set the `Authorization` header in particular, which we need.