### PR TITLE
small changes in error handling

### DIFF
--- a/core/src/main/scala/clue/ApolloClient.scala
+++ b/core/src/main/scala/clue/ApolloClient.scala
@@ -574,7 +574,7 @@ class ApolloClient[F[_], S, CP, CE](
     }
 
     def emitError(json: Json): F[Unit] = {
-      val error = new ResponseException(json.asArray.fold(List(json))(_.toList))
+      val error = new ResponseException(json.hcursor.get[List[Json]]("errors").getOrElse(Nil))
       // TODO When an Error message is received, we terminate the stream and halt the subscription. Do we want that?
       queue.offer(error.asLeft)
     }

--- a/core/src/main/scala/clue/TransactionalClientImpl.scala
+++ b/core/src/main/scala/clue/TransactionalClientImpl.scala
@@ -39,5 +39,8 @@ class TransactionalClientImpl[F[_]: MonadThrow: TransactionalBackend: Logger, S]
         }
       }
       .rethrow
-      .onError { case t: Throwable => t.logF("Error in query: ") }
+      .onError {
+        case re: ResponseException => re.debugF("Query returned errors:")
+        case other                 => other.warnF("Error executing query:")
+      }
 }

--- a/core/src/main/scala/clue/package.scala
+++ b/core/src/main/scala/clue/package.scala
@@ -63,6 +63,9 @@ package object clue {
 
     def warnF[F[_]](msg: String)(implicit logger: Logger[F]): F[Unit] =
       logger.warn(t)(msg)
+
+    def debugF[F[_]](msg: String)(implicit logger: Logger[F]): F[Unit] =
+      logger.debug(t)(msg)
   }
 }
 


### PR DESCRIPTION
This fixes a couple issues I ran into while writing some tests for the new ODB:

- `emitError` was not extracting the error list correctly from the response when constructing a `ResponseException` which resulted in an empty list when calling `asGraphQLErrors`
- Errors returned by the GraphQL backend as a GraphQL response aren't really worth logging at a high level because we know they have been detected and handled by the back end. So I turned logging down for that case.