### PR TITLE
Make http4s integration backend-agnostic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,6 @@ ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_
 ThisBuild / scalaVersion               := scala2Version
 Global / onChangedBuildSource          := ReloadOnSourceChanges
 
-resolvers +=
-  "Sonatype S01 OSS Snapshots".at("https://s01.oss.sonatype.org/content/repositories/snapshots")
-
 ThisBuild / coverageEnabled := false // TODO figure out how to make it work with projectmatrix
 
 lazy val mimaSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,14 @@ lazy val scala3Version      = "3.1.1"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
-ThisBuild / tlBaseVersion              := "0.20"
+ThisBuild / tlBaseVersion              := "0.21"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))
 ThisBuild / scalaVersion               := scala2Version
 Global / onChangedBuildSource          := ReloadOnSourceChanges
+
+resolvers +=
+  "Sonatype S01 OSS Snapshots".at("https://s01.oss.sonatype.org/content/repositories/snapshots")
 
 ThisBuild / coverageEnabled := false // TODO figure out how to make it work with projectmatrix
 
@@ -22,7 +25,7 @@ lazy val root = tlCrossRootProject
     model,
     core,
     scalaJS,
-    http4sJDK,
+    http4s,
     genRules,
     genInput,
     genOutput,
@@ -85,14 +88,14 @@ lazy val scalaJS = projectMatrix
   .defaultAxes(VirtualAxis.js, VirtualAxis.scalaPartialVersion(scala3Version))
   .jsPlatform(allVersions)
 
-lazy val http4sJDK = projectMatrix
-  .in(file("http4s-jdk"))
+lazy val http4s = projectMatrix
+  .in(file("http4s"))
   .settings(
-    moduleName := "clue-http4s-jdk-client",
+    moduleName := "clue-http4s",
     mimaSettings,
     libraryDependencies ++=
       Settings.Libraries.Http4sCirce.value ++
-        Settings.Libraries.Http4sJDKClient.value
+        Settings.Libraries.Http4sClient.value
   )
   .dependsOn(core)
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala3Version))
@@ -106,9 +109,9 @@ lazy val http4sJDKDemo = projectMatrix
     libraryDependencies ++= Seq(
       "org.typelevel" %% "log4cats-slf4j" % Settings.LibraryVersions.log4Cats,
       "org.slf4j"      % "slf4j-simple"   % "1.6.4"
-    )
+    ) ++ Settings.Libraries.Http4sJDKClient.value
   )
-  .dependsOn(http4sJDK)
+  .dependsOn(http4s)
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala3Version))
   .jvmPlatform(allVersions)
 

--- a/http4s/src/main/scala/clue/http4s/Http4sBackend.scala
+++ b/http4s/src/main/scala/clue/http4s/Http4sBackend.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package clue.http4sjdk
+package clue.http4s
 
 import cats.effect._
 import clue._
@@ -15,12 +15,9 @@ import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers._
-import org.http4s.jdkhttpclient.JdkHttpClient
-
-import java.net.http.HttpClient
 import org.http4s.Headers
 
-final class Http4sJDKBackend[F[_]: Async](val client: Client[F]) extends TransactionalBackend[F] {
+final class Http4sBackend[F[_]: Concurrent](val client: Client[F]) extends TransactionalBackend[F] {
 
   object dsl extends Http4sClientDsl[F]
   import dsl._
@@ -35,11 +32,7 @@ final class Http4sJDKBackend[F[_]: Async](val client: Client[F]) extends Transac
     )
 }
 
-object Http4sJDKBackend {
-  def apply[F[_]: Async]: Resource[F, Http4sJDKBackend[F]] =
-    JdkHttpClient.simple[F].map(new Http4sJDKBackend[F](_))
-
-  def fromHttpClient[F[_]: Async](client: HttpClient): Resource[F, Http4sJDKBackend[F]] =
-    JdkHttpClient[F](client).map(new Http4sJDKBackend(_))
-
+object Http4sBackend {
+  def apply[F[_]: Concurrent](client: Client[F]): Http4sBackend[F] =
+    new Http4sBackend[F](client)
 }

--- a/http4s/src/main/scala/clue/http4s/Http4sWSBackend.scala
+++ b/http4s/src/main/scala/clue/http4s/Http4sWSBackend.scala
@@ -50,9 +50,9 @@ final class Http4sWSBackend[F[_]: Concurrent](client: WSClient[F]) extends WebSo
               }
             case ExitCase.Errored(t) => handler.onClose(connectionId, t.asLeft) >> release // TODO
             case ExitCase.Canceled   =>
-                handler.onClose(connectionId,
-                                new GraphQLException(s"WS listener canceled. URI: [$uri]").asLeft
-                ) >> release // TODO
+              handler.onClose(connectionId,
+                              new GraphQLException(s"WS listener canceled. URI: [$uri]").asLeft
+              ) >> release // TODO
           }
           .compile
           .drain
@@ -73,7 +73,6 @@ final class Http4sWSConnection[F[_]: Concurrent /*: Sync: Logger*/ ](
     conn.send(WSFrame.Text(msg.asJson.toString))
 
   // In high-level WS, we cannot specify close code.
-  override def closeInternal(closeParameters: Option[WebSocketCloseParams]): F[Unit] = {
+  override def closeInternal(closeParameters: Option[WebSocketCloseParams]): F[Unit] =
     Concurrent[F].unit // TODO
-  }
 }

--- a/http4s/src/main/scala/clue/http4s/Http4sWSBackend.scala
+++ b/http4s/src/main/scala/clue/http4s/Http4sWSBackend.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package clue.http4sjdk
+package clue.http4s
 
 import cats.effect.Resource.ExitCase
 import cats.effect._
@@ -13,14 +13,12 @@ import clue.model.json._
 import io.circe.syntax._
 import org.http4s.Headers
 import org.http4s.Uri
-import org.http4s.jdkhttpclient._
-
-import java.net.http.HttpClient
+import org.http4s.client.websocket._
 
 /**
- * Streaming backend for http4s-JDK WebSocket.
+ * Streaming backend for http4s WebSocket client.
  */
-final class Http4sJDKWSBackend[F[_]: Async](client: WSClient[F]) extends WebSocketBackend[F] {
+final class Http4sWSBackend[F[_]: Concurrent](client: WSClient[F]) extends WebSocketBackend[F] {
 
   override def connect(
     uri:          Uri,
@@ -29,14 +27,14 @@ final class Http4sJDKWSBackend[F[_]: Async](client: WSClient[F]) extends WebSock
   ): F[PersistentConnection[F, WebSocketCloseParams]] =
     client
       .connectHighLevel(
-        WSRequest(uri, headers = Headers("Sec-WebSocket-Protocol" -> "graphql-ws"))
+        WSRequest(uri).withHeaders(Headers("Sec-WebSocket-Protocol" -> "graphql-ws"))
       )
-      .allocated
+      .allocated // TODO replace with allocatedCase
       .flatMap { case (connection, release) =>
         connection.receiveStream
           .evalTap {
             case WSFrame.Text(data, _) => handler.onMessage(connectionId, data)
-            case WSFrame.Binary(_, _)  => Async[F].unit
+            case WSFrame.Binary(_, _)  => Concurrent[F].unit
           }
           .onFinalizeCase {
             case ExitCase.Succeeded  =>
@@ -48,31 +46,27 @@ final class Http4sJDKWSBackend[F[_]: Async](client: WSClient[F]) extends WebSock
                       s"Unexpected clean close for WS without close frame. URI: [$uri]"
                     )
                   )
-                handler.onClose(connectionId, event) >> release
+                handler.onClose(connectionId, event) >> release // TODO
               }
-            case ExitCase.Errored(t) => handler.onClose(connectionId, t.asLeft) >> release
+            case ExitCase.Errored(t) => handler.onClose(connectionId, t.asLeft) >> release // TODO
             case ExitCase.Canceled   =>
-              connection.sendClose() >>
                 handler.onClose(connectionId,
                                 new GraphQLException(s"WS listener canceled. URI: [$uri]").asLeft
-                ) >> release
+                ) >> release // TODO
           }
           .compile
           .drain
           .start
-          .as(new Http4sJDKWSConnection(connection))
+          .as(new Http4sWSConnection(connection))
       }
 }
 
-object Http4sJDKWSBackend {
-  def apply[F[_]: Async]: Resource[F, Http4sJDKWSBackend[F]] =
-    JdkWSClient.simple[F].map(new Http4sJDKWSBackend(_))
-
-  def fromHttpClient[F[_]: Async](client: HttpClient): Resource[F, Http4sJDKWSBackend[F]] =
-    JdkWSClient[F](client).map(new Http4sJDKWSBackend(_))
+object Http4sWSBackend {
+  def apply[F[_]: Concurrent](client: WSClient[F]): Http4sWSBackend[F] =
+    new Http4sWSBackend(client)
 }
 
-final class Http4sJDKWSConnection[F[_] /*: Sync: Logger*/ ](
+final class Http4sWSConnection[F[_]: Concurrent /*: Sync: Logger*/ ](
   private val conn: WSConnectionHighLevel[F]
 ) extends WebSocketConnection[F] {
   override def send(msg: StreamingMessage.FromClient): F[Unit] =
@@ -80,7 +74,6 @@ final class Http4sJDKWSConnection[F[_] /*: Sync: Logger*/ ](
 
   // In high-level WS, we cannot specify close code.
   override def closeInternal(closeParameters: Option[WebSocketCloseParams]): F[Unit] = {
-    val params = closeParameters.getOrElse(WebSocketCloseParams())
-    conn.sendClose(params.reason.orEmpty)
+    Concurrent[F].unit // TODO
   }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -13,7 +13,7 @@ object Settings {
     val grackle                  = "0.1.9"
     val http4s                   = "0.23.11"
     val http4sDom                = "0.2.1"
-    val http4sJDKClient          = "0.7-b81862c-SNAPSHOT"
+    val http4sJDKClient          = "0.7.0"
     val jawn                     = "1.3.2"
     val log4Cats                 = "2.2.0"
     val monocle                  = "3.1.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -13,7 +13,7 @@ object Settings {
     val grackle                  = "0.1.9"
     val http4s                   = "0.23.11"
     val http4sDom                = "0.2.1"
-    val http4sJDKClient          = "0.5.0"
+    val http4sJDKClient          = "0.7-b81862c-SNAPSHOT"
     val jawn                     = "1.3.2"
     val log4Cats                 = "2.2.0"
     val monocle                  = "3.1.0"
@@ -80,6 +80,12 @@ object Settings {
     val Http4sCore = Def.setting(
       Seq(
         "org.http4s" %%% "http4s-core" % http4s
+      )
+    )
+
+    val Http4sClient = Def.setting(
+      Seq(
+        "org.http4s" %%% "http4s-client" % http4s
       )
     )
 


### PR DESCRIPTION
The http4s-jdk-client module now becomes an http4s module implemented purely in terms of the `Client` and `WSClient` interfaces which are shared between the http4s-jdk-http-client and http4s-dom.