### PR TITLE
Use `tlJdkRelease` setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
 ThisBuild / tlBaseVersion              := "0.21"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
+ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))
 ThisBuild / scalaVersion               := scala2Version
 Global / onChangedBuildSource          := ReloadOnSourceChanges
@@ -100,7 +101,8 @@ lazy val http4sJDKDemo = projectMatrix
   .in(file("http4s-jdk-demo"))
   .enablePlugins(NoPublishPlugin)
   .settings(
-    moduleName := "clue-http4s-jdk-client-demo",
+    moduleName   := "clue-http4s-jdk-client-demo",
+    tlJdkRelease := Some(11),
     libraryDependencies ++= Seq(
       "org.typelevel" %% "log4cats-slf4j" % Settings.LibraryVersions.log4Cats,
       "org.slf4j"      % "slf4j-simple"   % "1.6.4"

--- a/gen/rules/src/main/scala/clue/gen/Generator.scala
+++ b/gen/rules/src/main/scala/clue/gen/Generator.scala
@@ -430,9 +430,14 @@ trait Generator {
       }
 
   protected def snakeToCamel(s: String): String = {
-    val wordPattern: Pattern = Pattern.compile("[a-zA-Z0-9]+(_|$)")
+    val wordPattern: Pattern = Pattern.compile("([a-zA-Z0-9]+)(?:_|$)")
     val unscream             = if (!s.exists(_.isLower)) s.toLowerCase else s
-    wordPattern.matcher(unscream).replaceAll(_.group.stripSuffix("_").capitalize)
+    val matcher              = wordPattern.matcher(unscream)
+    val sb                   = new StringBuffer
+    while (matcher.find())
+      matcher.appendReplacement(sb, matcher.group(1).capitalize)
+    matcher.appendTail(sb)
+    sb.toString
   }
 
   protected case class EnumValue(asString: String, className: String)


### PR DESCRIPTION
We added a new setting to sbt-typelevel so that you can safely compile an artifact for JDK 8 even if you are running in a newer JDK. So we can use that to publish for JDK 8 without changing CI.

Closes https://github.com/gemini-hlsw/clue/issues/326.