### PR TITLE
Switch to debug for Complete on Disconnected

### DIFF
--- a/core/src/main/scala/clue/ApolloClient.scala
+++ b/core/src/main/scala/clue/ApolloClient.scala
@@ -312,6 +312,8 @@ class ApolloClient[F[_], S, CP, CE](
             F.unit
           case Initialized(stateConnectionId, _, _, _) if connectionId =!= stateConnectionId =>
             F.unit
+          case s @ Disconnected(_)                                                           =>
+            s"Complete RECEIVED for subscription [$subscriptionId] on Disconnected state: [$s]".debugF
           case s @ _                                                                         =>
             s"UNEXPECTED Complete RECEIVED for subscription [$subscriptionId]. State is: [$s]".warnF
         }


### PR DESCRIPTION
It seems like it should be okay to ignore a `Complete` message from the server when already disconnected? 