### PR TITLE
Add quoting encoders for Long, BigInt and BigDecimal

### DIFF
--- a/core/src/main/scala/clue/BigNumberEncoders.scala
+++ b/core/src/main/scala/clue/BigNumberEncoders.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import io.circe.Encoder
+
+// Long, BigInt and BigDecimal types can exceed the size of the graphQL number types,
+// so we need to send them quoted.
+// To use these encoders instead of the default circe ones, in your GraphQLSchema file,
+// include `// gql: import clue.BigNumberEncoders._`
+// For some reason, Sangria seemed to be able to handle them unquoted, but Grackle can't.
+object BigNumberEncoders {
+  implicit val longEncoder: Encoder[Long]             = Encoder.encodeString.contramap[Long](_.toString)
+  implicit val bigIntEncoder: Encoder[BigInt]         = Encoder.encodeString.contramap[BigInt](_.toString)
+  implicit val bigDecimalEncoder: Encoder[BigDecimal] =
+    Encoder.encodeString.contramap[BigDecimal](_.toString)
+}


### PR DESCRIPTION
I had a problem with sending Long values to the new ODB based on Grackle. Apparently, when the Long value exceeds the size of a GraphQL integral type, Grackle falls back to treating it as a floating point. This caused a validation error because the API expected in integral value. The same thing could happen for BigInt and BigDecimal. The solution is to send these types quoted like strings. 
This currently requires a specific inclusion in the GraphGLSchema file, but I wonder if we should make these the default since the number sizes are part of the GraphQL spec?