### PR TITLE
Friendlier type params

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val scala3Version      = "3.2.2"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
-ThisBuild / tlBaseVersion              := "0.28"
+ThisBuild / tlBaseVersion              := "0.29"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))

--- a/core/src/main/scala/clue/ClientAppliedF.scala
+++ b/core/src/main/scala/clue/ClientAppliedF.scala
@@ -5,14 +5,14 @@ package clue
 
 // Used to build convenience methods in generated queries.
 abstract class ClientAppliedF[F[_], S, AFP[_[_], _]] {
-  def applyP[P](client: FetchClient[F, P, S]): AFP[F, P]
+  def applyP[P](client: FetchClientWithPars[F, P, S]): AFP[F, P]
 }
 
 object ClientAppliedF {
   implicit def clientApplyP[F[_], P, S, AFP[_[_], _]](
     applied: ClientAppliedF[F, S, AFP]
   )(implicit
-    client:  clue.FetchClient[F, P, S]
+    client:  clue.FetchClientWithPars[F, P, S]
   ): AFP[F, P] =
     applied.applyP(client)
 }

--- a/core/src/main/scala/clue/FetchClientImpl.scala
+++ b/core/src/main/scala/clue/FetchClientImpl.scala
@@ -20,7 +20,7 @@ import org.typelevel.log4cats.Logger
 // }
 class FetchClientImpl[F[_]: MonadThrow: Logger, P, S](requestParams: P)(implicit
   backend: FetchBackend[F, P]
-) extends clue.FetchClient[F, P, S] {
+) extends clue.FetchClientWithPars[F, P, S] {
   override protected def requestInternal[D: Decoder, R](
     document:      String,
     operationName: Option[String],

--- a/core/src/main/scala/clue/GraphQLOperation.scala
+++ b/core/src/main/scala/clue/GraphQLOperation.scala
@@ -22,3 +22,17 @@ trait GraphQLOperation[S] {
     implicit val implicitDataDecoder: Decoder[Data]              = dataDecoder
   }
 }
+
+object GraphQLOperation {
+  abstract class Typed[S, V: Encoder.AsObject, T: Decoder] extends GraphQLOperation[S] {
+    override type Variables = V
+    override type Data      = T
+
+    override val varEncoder  = implicitly[Encoder.AsObject[V]]
+    override val dataDecoder = implicitly[Decoder[T]]
+  }
+
+  object Typed {
+    abstract class NoInput[S, T: Decoder] extends Typed[S, Unit, T]
+  }
+}

--- a/core/src/main/scala/clue/clients.scala
+++ b/core/src/main/scala/clue/clients.scala
@@ -12,13 +12,16 @@ import io.circe.syntax._
 /**
  * A client that allows one-shot queries and mutations.
  */
-trait FetchClient[F[_], P, S] {
-  case class RequestApplied[V: Encoder.AsObject, D: Decoder, R] protected[FetchClient] (
+trait FetchClientWithPars[F[_], P, S] {
+  case class RequestApplied[V: Encoder.AsObject, D: Decoder, R] protected[FetchClientWithPars] (
     operation:     GraphQLOperation[S],
     operationName: Option[String],
     errorPolicy:   ErrorPolicyProcessor[D, R]
   ) {
-    def apply(variables: V, modParams: P => P = identity): F[R] =
+    def apply(variables: V): F[R] =
+      apply(variables, identity)
+
+    def apply(variables: V, modParams: P => P): F[R] =
       requestInternal(
         operation.document,
         operationName,
@@ -66,7 +69,7 @@ trait FetchClient[F[_], P, S] {
 /**
  * A client that allows subscriptions in addition to one-shot queries and mutations.
  */
-trait StreamingClient[F[_], S] extends FetchClient[F, Unit, S] {
+trait StreamingClient[F[_], S] extends FetchClientWithPars[F, Unit, S] {
   case class SubscriptionApplied[V: Encoder.AsObject, D: Decoder, R] protected[StreamingClient] (
     subscription:  GraphQLOperation[S],
     operationName: Option[String] = none,

--- a/core/src/main/scala/clue/package.scala
+++ b/core/src/main/scala/clue/package.scala
@@ -9,6 +9,8 @@ import cats.syntax.all._
 import org.typelevel.log4cats.Logger
 
 package object clue {
+  type FetchClient[F[_], S] = FetchClientWithPars[F, _, S]
+
   protected[clue] type Latch[F[_]] = Deferred[F, Either[Throwable, Unit]]
 
   final implicit class StringOps(val str: String) extends AnyVal {

--- a/gen/output/src/main/scala/test/LucumaQuery.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery.scala
@@ -96,7 +96,7 @@ object LucumaQuery extends GraphQLOperation[LucumaODB] {
   }
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
-  def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClient[F, P, LucumaODB]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery)(errorPolicy)(Variables(), modParams) }
+  def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, LucumaODB]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery)(errorPolicy)(Variables(), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery2.scala
@@ -80,7 +80,7 @@ object LucumaQuery2 extends GraphQLOperation[LucumaODB] {
   }
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
-  def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClient[F, P, LucumaODB]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery2)(errorPolicy)(Variables(), modParams) }
+  def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, LucumaODB]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery2)(errorPolicy)(Variables(), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery3.scala
@@ -85,7 +85,7 @@ object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
   }
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
-  def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClient[F, P, LucumaODB]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery3)(errorPolicy)(Variables(), modParams) }
+  def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, LucumaODB]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery3)(errorPolicy)(Variables(), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery.scala
@@ -110,7 +110,7 @@ object StarWarsQuery extends GraphQLOperation[StarWars] {
   }
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
-  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClient[F, P, StarWars]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery)(errorPolicy)(Variables(charId), modParams) }
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery)(errorPolicy)(Variables(charId), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery2.scala
@@ -132,8 +132,8 @@ object Wrapper extends Something {
     }
     val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
     val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
-    def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClient[F, P, StarWars]) = new ClientAppliedFP(client) }
-    class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery2)(errorPolicy)(Variables(charId), modParams) }
+    def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+    class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery2)(errorPolicy)(Variables(charId), modParams) }
   }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery3.scala
@@ -101,7 +101,7 @@ object StarWarsQuery3 extends GraphQLOperation[StarWars] {
   }
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
-  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClient[F, P, StarWars]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery3)(errorPolicy)(Variables(charId), modParams) }
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery3)(errorPolicy)(Variables(charId), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery4.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery4.scala
@@ -37,7 +37,7 @@ object StarWarsQuery4 extends GraphQLOperation[StarWars] {
   }
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
-  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClient[F, P, StarWars]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery4)(errorPolicy)(Variables(charId), modParams) }
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery4)(errorPolicy)(Variables(charId), modParams) }
 }
 // format: on

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -503,14 +503,14 @@ trait QueryGen extends Generator {
           val applied        =
             q"""def apply[F[_]]: clue.ClientAppliedF[F, $schemaType, ClientAppliedFP] =
                   new clue.ClientAppliedF[F, $schemaType, ClientAppliedFP] {
-                    def applyP[P](client: clue.FetchClient[F, P, $schemaType]) = new ClientAppliedFP(client)
+                    def applyP[P](client: clue.FetchClientWithPars[F, P, $schemaType]) = new ClientAppliedFP(client)
                   }"""
           parentBody ++
             (operation match {
               case _: UntypedQuery =>
                 List(
                   applied,
-                  q"""class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, $schemaType]) {
+                  q"""class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, $schemaType]) {
                       def query(...${(paramss.head :+ param"modParams: P => P = identity") +: paramss.tail :+ epiParam}) =
                         client.request(${Term
                       .Name(objName)})(errorPolicy)(Variables(...$variablesNames), modParams)
@@ -521,7 +521,7 @@ trait QueryGen extends Generator {
               case _: UntypedMutation     =>
                 List(
                   applied,
-                  q"""class ClientAppliedFP[F[_], P](val client: clue.FetchClient[F, P, $schemaType]) {
+                  q"""class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, $schemaType]) {
                       def execute(...${(paramss.head :+ param"modParams: P => P = identity") +: paramss.tail :+ epiParam}) =
                         client.request(${Term
                       .Name(objName)})(errorPolicy)(Variables(...$variablesNames), modParams)

--- a/http4s/src/main/scala/clue/http4s/Http4sHttpClient.scala
+++ b/http4s/src/main/scala/clue/http4s/Http4sHttpClient.scala
@@ -18,7 +18,7 @@ object Http4sHttpClient {
     backend: Http4sHttpBackend[F],
     logger:  Logger[F]
   ): F[Http4sHttpClient[F, S]] = {
-    val logPrefix = s"clue.FetchClient[${if (name.isEmpty) uri else name}]"
+    val logPrefix = s"clue.FetchClientWithPars[${if (name.isEmpty) uri else name}]"
 
     val internalLogger = logger.withModifiedString(s => s"$logPrefix $s")
 

--- a/http4s/src/main/scala/clue/http4s/package.scala
+++ b/http4s/src/main/scala/clue/http4s/package.scala
@@ -6,5 +6,5 @@ package clue
 import org.http4s.Request
 
 package object http4s {
-  type Http4sHttpClient[F[_], S] = FetchClient[F, Request[F], S]
+  type Http4sHttpClient[F[_], S] = FetchClientWithPars[F, Request[F], S]
 }

--- a/scalajs/src/main/scala/clue/js/package.scala
+++ b/scalajs/src/main/scala/clue/js/package.scala
@@ -6,7 +6,7 @@ package clue
 import clue.websocket.ApolloClient
 
 package object js {
-  type FetchJSClient[F[_], S] = FetchClient[F, FetchJSRequest, S]
+  type FetchJSClient[F[_], S] = FetchClientWithPars[F, FetchJSRequest, S]
 
   type WebSocketJSClient[F[_], S] = ApolloClient[F, String, S]
 }


### PR DESCRIPTION
- In fetch requests, the common case is that we don't want to manipulate the underlying transport layer request (with type `P`). The old `FetchClient[F, P, S]` is therefore renamed to `FetchClientWithPars[F, P, S]` and a type alias is introduced `FetchClient[F, S]` for the common case.
- Introduce `GraphQLOperation.Typed[S, V, T]` and `GraphQLOperation.Typed.NoInput[S, T]` to easily define self-contained operations when there are implicit data decoders and variable encoders available.
- Demo was updated to use the changes.