### PR TITLE
Improve syntax when invoking queries

### DIFF
--- a/core/src/main/scala/clue/clients.scala
+++ b/core/src/main/scala/clue/clients.scala
@@ -18,10 +18,10 @@ trait FetchClientWithPars[F[_], P, S] {
     operationName: Option[String],
     errorPolicy:   ErrorPolicyProcessor[D, R]
   ) {
-    def apply(variables: V): F[R] =
-      apply(variables, identity)
+    def withInput(variables: V): F[R] =
+      withInput(variables, identity)
 
-    def apply(variables: V, modParams: P => P): F[R] =
+    def withInput(variables: V, modParams: P => P): F[R] =
       requestInternal(
         operation.document,
         operationName,
@@ -30,7 +30,7 @@ trait FetchClientWithPars[F[_], P, S] {
         errorPolicy
       )
 
-    def apply(modParams: P => P): F[R] =
+    def withModParams(modParams: P => P): F[R] =
       requestInternal(operation.document, operationName, none, modParams, errorPolicy)
 
     def apply: F[R] =
@@ -75,7 +75,7 @@ trait StreamingClient[F[_], S] extends FetchClientWithPars[F, Unit, S] {
     operationName: Option[String] = none,
     errorPolicy:   ErrorPolicyProcessor[D, R]
   ) {
-    def apply(variables: V): Resource[F, fs2.Stream[F, R]] =
+    def withInput(variables: V): Resource[F, fs2.Stream[F, R]] =
       subscribeInternal(
         subscription.document,
         operationName,

--- a/gen/output/src/main/scala/test/LucumaQuery.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery.scala
@@ -97,6 +97,6 @@ object LucumaQuery extends GraphQLOperation[LucumaODB] {
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
   def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, LucumaODB]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery)(errorPolicy)(Variables(), modParams) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery).withInput(Variables(), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery2.scala
@@ -81,6 +81,6 @@ object LucumaQuery2 extends GraphQLOperation[LucumaODB] {
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
   def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, LucumaODB]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery2)(errorPolicy)(Variables(), modParams) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery2).withInput(Variables(), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery3.scala
@@ -86,6 +86,6 @@ object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
   def apply[F[_]]: clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] = new clue.ClientAppliedF[F, LucumaODB, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, LucumaODB]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery3)(errorPolicy)(Variables(), modParams) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, LucumaODB]) { def query(modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(LucumaQuery3).withInput(Variables(), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery.scala
@@ -111,6 +111,6 @@ object StarWarsQuery extends GraphQLOperation[StarWars] {
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
   def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery)(errorPolicy)(Variables(charId), modParams) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery).withInput(Variables(charId), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery2.scala
@@ -133,7 +133,7 @@ object Wrapper extends Something {
     val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
     val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
     def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
-    class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery2)(errorPolicy)(Variables(charId), modParams) }
+    class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery2).withInput(Variables(charId), modParams) }
   }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery3.scala
@@ -102,6 +102,6 @@ object StarWarsQuery3 extends GraphQLOperation[StarWars] {
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
   def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery3)(errorPolicy)(Variables(charId), modParams) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery3).withInput(Variables(charId), modParams) }
 }
 // format: on

--- a/gen/output/src/main/scala/test/StarWarsQuery4.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery4.scala
@@ -38,6 +38,6 @@ object StarWarsQuery4 extends GraphQLOperation[StarWars] {
   val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
   def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
-  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery4)(errorPolicy)(Variables(charId), modParams) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(charId: String, modParams: P => P = identity)(implicit errorPolicy: clue.ErrorPolicy) = client.request(StarWarsQuery4).withInput(Variables(charId), modParams) }
 }
 // format: on

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -513,7 +513,7 @@ trait QueryGen extends Generator {
                   q"""class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, $schemaType]) {
                       def query(...${(paramss.head :+ param"modParams: P => P = identity") +: paramss.tail :+ epiParam}) =
                         client.request(${Term
-                      .Name(objName)})(errorPolicy)(Variables(...$variablesNames), modParams)
+                      .Name(objName)}).withInput(Variables(...$variablesNames), modParams)
                     }
                   """
                 )
@@ -524,7 +524,7 @@ trait QueryGen extends Generator {
                   q"""class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, $schemaType]) {
                       def execute(...${(paramss.head :+ param"modParams: P => P = identity") +: paramss.tail :+ epiParam}) =
                         client.request(${Term
-                      .Name(objName)})(errorPolicy)(Variables(...$variablesNames), modParams)
+                      .Name(objName)}).withInput(Variables(...$variablesNames), modParams)
                     }
                   """
                 )
@@ -532,7 +532,7 @@ trait QueryGen extends Generator {
                 val epiParam    = param"implicit errorPolicy: clue.ErrorPolicy"
                 val clientParam = param"implicit client: clue.StreamingClient[F, $schemaType]"
                 List(
-                  q"def subscribe[F[_]](...${paramss :+ List(clientParam, epiParam)}) = client.subscribe(this)(errorPolicy)(Variables(...$variablesNames))"
+                  q"def subscribe[F[_]](...${paramss :+ List(clientParam, epiParam)}) = client.subscribe(this).withInput(Variables(...$variablesNames))"
                 )
             })
         }

--- a/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
+++ b/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
@@ -92,11 +92,7 @@ object Demo extends IOApp.Simple {
       id     <- IO(ids(Random.between(0, ids.length)))
       status <- IO(allStatus(Random.between(0, allStatus.length)))
       _      <-
-        client.request(Mutation)(
-          implicitly[ErrorPolicy]
-        )( // FIXME How can we avoid that implicitly here??? I guess contexts params in Scala 3 can help
-          Mutation.Variables(id, status)
-        )
+        client.request(Mutation).withInput(Mutation.Variables(id, status))
     } yield ()
 
   def mutator(client: FetchClient[IO, DemoDB], ids: List[String]) =


### PR DESCRIPTION
If we use `apply`, the `ErrorPolicy` implicit parameter gets in the way. Therefore, renaming the method to `withInput`.