### PR TITLE
Include data (if present) in response exceptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val scala3Version      = "3.2.2"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
-ThisBuild / tlBaseVersion              := "0.30"
+ThisBuild / tlBaseVersion              := "0.31"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))

--- a/core/src/main/scala/clue/GraphQLException.scala
+++ b/core/src/main/scala/clue/GraphQLException.scala
@@ -14,4 +14,5 @@ case class DisconnectedException() extends GraphQLException("Connection was clos
 case class InvalidSubscriptionIdException(id: String)
     extends GraphQLException(s"Invalid subscription id: $id")
 
-case class ResponseException(errors: GraphQLErrors) extends GraphQLException(errors.toString)
+case class ResponseException[D](errors: GraphQLErrors, data: Option[D])
+    extends GraphQLException(errors.toString)

--- a/model/src/main/scala/clue/model/json/package.scala
+++ b/model/src/main/scala/clue/model/json/package.scala
@@ -250,12 +250,12 @@ package object json {
     (a: GraphQLError.PathElement) => a.fold(_.asJson, _.asJson)
 
   implicit val DecoderGraphQLErrorPathElement: Decoder[GraphQLError.PathElement] =
-    Decoder.instance(c =>
-      c.as[Int]
-        .map(GraphQLError.PathElement.int)
-        .orElse(c.as[String].map(GraphQLError.PathElement.string))
-        .orElse(DecodingFailure(s"Unexpected PathElement", c.history).asLeft)
-    )
+    Decoder.instance { c =>
+      if (c.value.isNumber)
+        c.as[Int].map(GraphQLError.PathElement.int)
+      else
+        c.as[String].map(GraphQLError.PathElement.string)
+    }
 
   implicit val EncoderGraphQLErrorLocation: Encoder[GraphQLError.Location] =
     Encoder.instance(a =>


### PR DESCRIPTION
The `RaiseAlways` error policy raises an error if `errors` are present in the response. `data` can also be present, but it was discarded until now. Now it is included in the exception if present.