### PR TITLE
Validate `Typed` operations and subqueries

### DIFF
--- a/gen/output/src/main/scala/test/StarWarsSubquery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubquery2.scala
@@ -9,7 +9,6 @@ import clue.GraphQLSubquery
 import io.circe.Json
 import test.StarWars
 
-
 object StarWarsSubquery2 extends GraphQLSubquery.Typed[StarWars, Json]("Character") {
   override val subquery: String = """
         {

--- a/gen/output/src/main/scala/test/StarWarsSubquery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubquery2.scala
@@ -9,6 +9,7 @@ import clue.GraphQLSubquery
 import io.circe.Json
 import test.StarWars
 
+
 object StarWarsSubquery2 extends GraphQLSubquery.Typed[StarWars, Json]("Character") {
   override val subquery: String = """
         {

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -27,7 +27,7 @@ trait QueryGen extends Generator {
   protected def extractSchemaAndRootTypes(list: List[Init]): Option[(Type.Name, String)] =
     list.collect {
       case Init(
-            Type.Apply(Type.Name("GraphQLSubquery"), List(tpe @ Type.Name(_))),
+            Type.Apply(_, (tpe @ Type.Name(_)) :: _),
             _,
             List(List(Lit.String(rootType)))
           ) =>


### PR DESCRIPTION
`GraphQLOperation.Typed` and `GraphQLSubquery.Typed` are now pre-processed through the same codegen pipeline as their non-`Typed` counterparts and thus fully validated against the schema. However no modifications are applied in this case, since everything is already defined on the `Typed` superclass.