### PR TITLE
Better cancelation

### DIFF
--- a/core/src/main/scala/clue/websocket/ApolloClient.scala
+++ b/core/src/main/scala/clue/websocket/ApolloClient.scala
@@ -242,15 +242,15 @@ class ApolloClient[F[_], P, S](
     variables:     Option[JsonObject],
     modParams:     Unit => Unit,
     errorPolicy:   ErrorPolicyProcessor[D, R]
-  ): F[R] = F.async[R] { cb =>
-    startSubscription[D, R](document, operationName, variables, errorPolicy).flatMap(
-      _.stream.attempt
+  ): F[R] = F.async[R](cb =>
+    startSubscription[D, R](document, operationName, variables, errorPolicy).flatMap(subscription =>
+      subscription.stream.attempt
         .evalMap(result => F.delay(cb(result)))
         .compile
         .drain
-        .as(none)
+        .as(subscription.stop().some)
     )
-  }
+  )
   // </FetchClient>
   // </StreamingClient>
   // </ApolloClient>

--- a/scalajs/src/main/scala/clue/js/FetchJSBackend.scala
+++ b/scalajs/src/main/scala/clue/js/FetchJSBackend.scala
@@ -3,6 +3,7 @@
 
 package clue.js
 
+import cats.Applicative
 import cats.effect._
 import cats.syntax.all._
 import clue._
@@ -10,6 +11,7 @@ import clue.model.GraphQLRequest
 import clue.model.json._
 import io.circe.Encoder
 import io.circe.syntax._
+import org.scalajs.dom.AbortController
 import org.scalajs.dom.Fetch
 import org.scalajs.dom.Headers
 import org.scalajs.dom.HttpMethod
@@ -19,8 +21,6 @@ import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
 import scala.scalajs.js.URIUtils
 import scala.util.Failure
 import scala.util.Success
-import org.scalajs.dom.AbortController
-import cats.Applicative
 
 sealed trait FetchMethod extends Product with Serializable
 object FetchMethod {

--- a/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
+++ b/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
@@ -3,6 +3,7 @@
 
 package clue.js
 
+import cats.Applicative
 import cats.effect.Ref
 import cats.effect._
 import cats.effect.implicits._
@@ -18,7 +19,6 @@ import org.scalajs.dom.Event
 import org.scalajs.dom.MessageEvent
 import org.scalajs.dom.WebSocket
 import org.typelevel.log4cats.Logger
-import cats.Applicative
 
 /**
  * Streaming backend for JS WebSocket.

--- a/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
+++ b/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
@@ -87,7 +87,7 @@ final class WebSocketJSBackend[F[_]: Async: Logger](dispatcher: Dispatcher[F])
           }
 
           Applicative[F].pure(
-            Sync[F].delay(ws.close(1001, "Web Socket initialization canceled by client")).some
+            Sync[F].delay(ws.close(1000, "Web Socket initialization canceled by client")).some
           )
         }
     } yield connection


### PR DESCRIPTION
The new `async` cancelation semantics of `cats-effect` (see https://github.com/typelevel/cats-effect/releases/tag/v3.5.0) prompted a revision of the uses of `.async`, which led to this PR where we implment now proper handling of cancelation.