### PR TITLE
Propagate response extensions, allow empty data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val scala3Version      = "3.3.1"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
-ThisBuild / tlBaseVersion              := "0.33"
+ThisBuild / tlBaseVersion              := "0.34"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))

--- a/core/src/main/scala/clue/FetchClientImpl.scala
+++ b/core/src/main/scala/clue/FetchClientImpl.scala
@@ -5,8 +5,8 @@ package clue
 
 import cats.MonadThrow
 import cats.syntax.all._
-import clue.model.GraphQLCombinedResponse
 import clue.model.GraphQLRequest
+import clue.model.GraphQLResponse
 import clue.model.json._
 import io.circe._
 import io.circe.parser._
@@ -29,7 +29,7 @@ class FetchClientImpl[F[_]: MonadThrow: Logger, P, S](requestParams: P)(implicit
   ): F[R] =
     backend
       .request(GraphQLRequest(document, operationName, variables), modParams(requestParams))
-      .map(decode[GraphQLCombinedResponse[D]])
+      .map(decode[GraphQLResponse[D]])
       .rethrow
       .flatMap(errorPolicy.process(_))
       .onError(_.warnF("Error executing query:"))

--- a/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
+++ b/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
@@ -114,7 +114,8 @@ object Demo extends IOApp.Simple {
           subscription   <- client.subscribe(Subscription).allocated
           (stream, close) = subscription
           fiber          <- stream.evalTap(_ => IO.println("UPDATE!")).compile.drain.start
-          _              <- mutator(client, (result.right.get \\ "id").map(_.as[String].toOption.get)).start
+          _              <-
+            mutator(client, (result.result.right.get \\ "id").map(_.as[String].toOption.get)).start
           _              <- IO.sleep(10.seconds)
           _              <- close
           _              <- fiber.join

--- a/model/src/main/scala/clue/model/GraphQLDataResponse.scala
+++ b/model/src/main/scala/clue/model/GraphQLDataResponse.scala
@@ -9,7 +9,7 @@ import cats.syntax.option._
 /**
  * A GraphQL response with data.
  *
- * For a general response that may or may not contain data, use `GraphQLCombinedResponse`.
+ * For a general response that may or may not contain data, use `GraphQLResponse`.
  *
  * See https://spec.graphql.org/October2021/#sec-Response-Format
  *

--- a/model/src/main/scala/clue/model/GraphQLResponse.scala
+++ b/model/src/main/scala/clue/model/GraphQLResponse.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model
+
+import cats.Eq
+import cats.data.Ior
+import cats.syntax.all.*
+import cats.Applicative
+import cats.Traverse
+import cats.Eval
+
+/**
+ * A GraphQL response.
+ *
+ * See https://spec.graphql.org/October2021/#sec-Response-Format
+ *
+ * @param result
+ *   request result with possible data and errors raised by the request
+ * @param extensions
+ *   values for protocol extension
+ */
+final case class GraphQLResponse[D](
+  result:     Ior[GraphQLErrors, D],
+  extensions: Option[GraphQLExtensions] = none
+) {
+  final lazy val data: Option[D]               = result.right
+  final lazy val errors: Option[GraphQLErrors] = result.left
+
+  final def traverse[F[_], E](
+    g: D => F[E]
+  )(implicit F: Applicative[F]): F[GraphQLResponse[E]] =
+    this.result match {
+      case Ior.Left(a)    => F.pure(GraphQLResponse(Ior.left(a), extensions))
+      case Ior.Right(b)   => F.map(g(b))(e => GraphQLResponse(Ior.right(e), extensions))
+      case Ior.Both(a, b) => F.map(g(b))(e => GraphQLResponse(Ior.both(a, e), extensions))
+    }
+
+  final def foldLeft[E](e: E)(f: (E, D) => E): E =
+    result.foldLeft(e)(f)
+
+  final def foldRight[E](lc: Eval[E])(f: (D, Eval[E]) => Eval[E]): Eval[E] =
+    result.foldRight(lc)(f)
+}
+
+object GraphQLResponse {
+  def errors[D](e: GraphQLErrors): GraphQLResponse[D] =
+    GraphQLResponse(Ior.left(e))
+
+  implicit def eqGraphQLResponse[D: Eq]: Eq[GraphQLResponse[D]] =
+    Eq.by(x => (x.result, x.extensions))
+
+  implicit val traverseGraphQLResponse: Traverse[GraphQLResponse] =
+    new Traverse[GraphQLResponse] {
+      def traverse[G[_], A, B](fa: GraphQLResponse[A])(f: A => G[B])(implicit
+        G: Applicative[G]
+      ): G[GraphQLResponse[B]] =
+        fa.traverse(f)
+
+      def foldLeft[D, E](fa: GraphQLResponse[D], e: E)(f: (E, D) => E): E =
+        fa.foldLeft(e)(f)
+
+      def foldRight[D, E](fa: GraphQLResponse[D], lb: cats.Eval[E])(
+        f: (D, cats.Eval[E]) => cats.Eval[E]
+      ): cats.Eval[E] =
+        fa.foldRight(lb)(f)
+    }
+}

--- a/model/src/main/scala/clue/model/GraphQLResponse.scala
+++ b/model/src/main/scala/clue/model/GraphQLResponse.scala
@@ -3,12 +3,12 @@
 
 package clue.model
 
+import cats.Applicative
 import cats.Eq
+import cats.Eval
+import cats.Traverse
 import cats.data.Ior
 import cats.syntax.all.*
-import cats.Applicative
-import cats.Traverse
-import cats.Eval
 
 /**
  * A GraphQL response.

--- a/model/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/src/main/scala/clue/model/StreamingMessage.scala
@@ -143,10 +143,10 @@ object StreamingMessage {
      * @param payload
      *   GraphQL result
      */
-    final case class Data(id: String, payload: GraphQLDataResponse[Json])
+    final case class Data(id: String, payload: GraphQLResponse[Json])
         extends FromServer
         with Identifier
-        with Payload[GraphQLDataResponse[Json]]
+        with Payload[GraphQLResponse[Json]]
 
     object Data {
       implicit val EqData: Eq[Data] =

--- a/model/src/main/scala/clue/model/package.scala
+++ b/model/src/main/scala/clue/model/package.scala
@@ -3,14 +3,11 @@
 
 package clue
 
-import cats.data.Ior
 import cats.data.NonEmptyList
 import io.circe.Json
 
 package object model {
   type GraphQLErrors = NonEmptyList[GraphQLError]
-
-  type GraphQLCombinedResponse[D] = Ior[GraphQLErrors, D]
 
   type GraphQLExtensions = Map[String, Json]
 }

--- a/model/src/test/scala/clue/ListLimitingDisciplineSuite.scala
+++ b/model/src/test/scala/clue/ListLimitingDisciplineSuite.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package clue.model.json
+package clue
 
 import munit.DisciplineSuite
 import org.scalacheck
 
 trait ListLimitingDisciplineSuite extends DisciplineSuite {
-  override val scalaCheckTestParameters = scalacheck.Test.Parameters.default.withMaxSize(10)
+  override lazy val scalaCheckTestParameters = scalacheck.Test.Parameters.default.withMaxSize(10)
 }

--- a/model/src/test/scala/clue/model/GraphQLResponseSpec.scala
+++ b/model/src/test/scala/clue/model/GraphQLResponseSpec.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model
+
+import cats.laws.discipline.TraverseTests
+import clue.ListLimitingDisciplineSuite
+import clue.model.arb._
+
+final class GraphQLResponseSpec extends ListLimitingDisciplineSuite {
+  import ArbGraphQLResponse._
+
+  checkAll(
+    "Traversable[GraphQLResponse]",
+    TraverseTests[GraphQLResponse].traverse[Int, Int, Int, Int, Option, Option]
+  )
+}

--- a/model/src/test/scala/clue/model/arb/ArbFromServer.scala
+++ b/model/src/test/scala/clue/model/arb/ArbFromServer.scala
@@ -4,9 +4,9 @@
 package clue.model.arb
 
 import cats.data.NonEmptyList
-import clue.model.GraphQLDataResponse
 import clue.model.GraphQLError
 import clue.model.GraphQLExtensions
+import clue.model.GraphQLResponse
 import clue.model.StreamingMessage.FromServer
 import clue.model.StreamingMessage.FromServer._
 import io.circe.Json
@@ -17,6 +17,7 @@ import org.scalacheck.Gen
 
 trait ArbFromServer {
   import ArbJson._
+  import ArbGraphQLResponse._
 
   val arbErrorJson: Arbitrary[Json] =
     Arbitrary {
@@ -75,20 +76,11 @@ trait ArbFromServer {
       arbitrary[Json](arbJsonString).map(ConnectionError(_))
     }
 
-  implicit val arbDataWrapper: Arbitrary[GraphQLDataResponse[Json]] =
-    Arbitrary {
-      for {
-        data       <- arbitrary[Json](arbJsonString)
-        errors     <- arbitrary[List[GraphQLError]]
-        extensions <- arbitrary[Option[GraphQLExtensions]]
-      } yield GraphQLDataResponse(data, NonEmptyList.fromList(errors), extensions)
-    }
-
   implicit val arbData: Arbitrary[Data] =
     Arbitrary {
       for {
         i <- arbitrary[String]
-        p <- arbitrary[GraphQLDataResponse[Json]]
+        p <- arbitrary[GraphQLResponse[Json]](arbCombinedResponse(arbJsonString))
       } yield Data(i, p)
     }
 

--- a/model/src/test/scala/clue/model/arb/ArbGraphQLError.scala
+++ b/model/src/test/scala/clue/model/arb/ArbGraphQLError.scala
@@ -5,6 +5,7 @@ package clue.model
 package arb
 
 import cats.data.NonEmptyList
+import clue.model.GraphQLErrors
 import io.circe.testing.instances._
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
@@ -43,6 +44,11 @@ trait ArbGraphQLError {
         extensions
       )
     }
+
+  implicit val arbGraphQLErrors: Arbitrary[GraphQLErrors] =
+    Arbitrary(
+      arbitrary[List[GraphQLError]].withFilter(_.nonEmpty).map(NonEmptyList.fromListUnsafe)
+    )
 
 }
 

--- a/model/src/test/scala/clue/model/arb/ArbGraphQLResponse.scala
+++ b/model/src/test/scala/clue/model/arb/ArbGraphQLResponse.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model.arb
+
+import cats.data.Ior
+import clue.model.GraphQLErrors
+import clue.model.GraphQLExtensions
+import clue.model.GraphQLResponse
+import clue.model.arb.ArbGraphQLError._
+import io.circe.testing.instances._
+import org.scalacheck.Arbitrary._
+import org.scalacheck._
+
+trait ArbGraphQLResponse {
+
+  implicit def arbIor[A: Arbitrary, B: Arbitrary]: Arbitrary[Ior[A, B]] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[A].map(Ior.left(_)),
+        arbitrary[B].map(Ior.right(_)),
+        for {
+          a <- arbitrary[A]
+          b <- arbitrary[B]
+        } yield Ior.both(a, b)
+      )
+    }
+
+  implicit def arbCombinedResponse[D: Arbitrary]: Arbitrary[GraphQLResponse[D]] =
+    Arbitrary {
+      for {
+        result     <- arbitrary[Ior[GraphQLErrors, D]]
+        extensions <- arbitrary[Option[GraphQLExtensions]]
+      } yield GraphQLResponse(result, extensions)
+    }
+
+}
+
+object ArbGraphQLResponse extends ArbGraphQLResponse

--- a/model/src/test/scala/clue/model/json/GraphQLDataResponseJsonSpec.scala
+++ b/model/src/test/scala/clue/model/json/GraphQLDataResponseJsonSpec.scala
@@ -3,8 +3,9 @@
 
 package clue.model.json
 
+import clue.ListLimitingDisciplineSuite
 import clue.model.GraphQLDataResponse
-import clue.model.arb._
+import clue.model.arb.ArbGraphQLDataResponse
 import io.circe.Json
 import io.circe.testing.CodecTests
 import io.circe.testing.instances._

--- a/model/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
+++ b/model/src/test/scala/clue/model/json/GraphQLErrorJsonSpec.scala
@@ -3,7 +3,9 @@
 
 package clue.model.json
 
+import clue.ListLimitingDisciplineSuite
 import clue.model.GraphQLError
+import clue.model.GraphQLErrors
 import clue.model.arb._
 import io.circe.testing.CodecTests
 import io.circe.testing.instances._
@@ -14,4 +16,5 @@ final class GraphQLErrorJsonSpec extends ListLimitingDisciplineSuite {
   checkAll("GraphQLError.PathElement", CodecTests[GraphQLError.PathElement].codec)
   checkAll("GraphQLError.Location", CodecTests[GraphQLError.Location].codec)
   checkAll("GraphQLError", CodecTests[GraphQLError].codec)
+  checkAll("GraphQLErrors", CodecTests[GraphQLErrors].codec)
 }

--- a/model/src/test/scala/clue/model/json/GraphQLRequestJsonSpec.scala
+++ b/model/src/test/scala/clue/model/json/GraphQLRequestJsonSpec.scala
@@ -3,6 +3,7 @@
 
 package clue.model.json
 
+import clue.ListLimitingDisciplineSuite
 import clue.model.GraphQLRequest
 import clue.model.arb._
 import io.circe.JsonObject

--- a/model/src/test/scala/clue/model/json/StreamingMessageJsonSpec.scala
+++ b/model/src/test/scala/clue/model/json/StreamingMessageJsonSpec.scala
@@ -3,6 +3,7 @@
 
 package clue.model.json
 
+import clue.ListLimitingDisciplineSuite
 import clue.model.StreamingMessage.FromClient
 import clue.model.StreamingMessage.FromServer
 import clue.model.arb._


### PR DESCRIPTION
An exception was being raised when a `data: null` element was present in a response, which is valid. Also, response `extensions` were not propagated.

This PR fixes both issues by an internal refactor in the representation of the responses, now using `GraphQLResponse`.