### PR TITLE
Remove cancellation cleanup on single-shot queries over Apollo protocol

### DIFF
--- a/core/src/main/scala/clue/websocket/ApolloClient.scala
+++ b/core/src/main/scala/clue/websocket/ApolloClient.scala
@@ -246,7 +246,7 @@ class ApolloClient[F[_], P, S](
         .evalMap(result => F.delay(cb(result)))
         .compile
         .drain
-        .as(subscription.stop().some)
+        .as(none)
     )
   )
   // </FetchClient>


### PR DESCRIPTION
Single shot queries clean up after themselves when `stop` is received from the server. There's no need for actively cleaning up if the fiber is cancelled.

This resulted in `Invalid subscription id` errors if the fiber was cancelled right after the query ended.