### PR TITLE
Fix ConnectionError payload type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val scala3Version      = "3.4.2"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
-ThisBuild / tlBaseVersion              := "0.37"
+ThisBuild / tlBaseVersion              := "0.38"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))

--- a/model/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/src/main/scala/clue/model/StreamingMessage.scala
@@ -122,7 +122,9 @@ object StreamingMessage {
      * @param payload
      *   error information
      */
-    final case class ConnectionError(payload: Json) extends FromServer with Payload[Json]
+    final case class ConnectionError(payload: JsonObject)
+        extends FromServer
+        with Payload[JsonObject]
 
     object ConnectionError {
       implicit val EqConnectionError: Eq[ConnectionError] =

--- a/model/src/main/scala/clue/model/json/package.scala
+++ b/model/src/main/scala/clue/model/json/package.scala
@@ -136,7 +136,7 @@ package object json {
     Decoder.instance(c =>
       for {
         _ <- checkType(c, "connection_error")
-        p <- c.get[Json]("payload")
+        p <- c.get[JsonObject]("payload")
       } yield ConnectionError(p)
     )
 
@@ -273,16 +273,14 @@ package object json {
       } yield GraphQLError.Location(line, column)
     )
 
-  implicit val EncoderGraphQLError: Encoder[GraphQLError] =
-    Encoder.instance(a =>
-      Json
-        .obj(
-          "message"    -> a.message.asJson,
-          "path"       -> a.path.asJson,
-          "locations"  -> a.locations.asJson,
-          "extensions" -> a.extensions.asJson
-        )
-        .dropNullValues
+  implicit val EncoderGraphQLError: Encoder.AsObject[GraphQLError] =
+    Encoder.AsObject.instance(a =>
+      JsonObject(
+        "message"    -> a.message.asJson,
+        "path"       -> a.path.asJson,
+        "locations"  -> a.locations.asJson,
+        "extensions" -> a.extensions.asJson
+      ).filter { case (_, v) => !v.isNull }
     )
 
   implicit val DecoderGraphQLError: Decoder[GraphQLError] =

--- a/model/src/test/scala/clue/model/arb/ArbFromServer.scala
+++ b/model/src/test/scala/clue/model/arb/ArbFromServer.scala
@@ -10,6 +10,7 @@ import clue.model.GraphQLResponse
 import clue.model.StreamingMessage.FromServer
 import clue.model.StreamingMessage.FromServer.*
 import io.circe.Json
+import io.circe.JsonObject
 import io.circe.testing.instances.*
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*
@@ -73,7 +74,7 @@ trait ArbFromServer {
 
   implicit val arbConnectionError: Arbitrary[ConnectionError] =
     Arbitrary {
-      arbitrary[Json](arbJsonString).map(ConnectionError(_))
+      arbitrary[JsonObject](arbitraryJsonObject).map(ConnectionError(_))
     }
 
   implicit val arbData: Arbitrary[Data] =


### PR DESCRIPTION
According to [spec](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_error), the payload of `ConnectionError` is an `Object`.