### PR TITLE
Specific exceptions, async cancel propagation, effectful init payload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,10 +170,11 @@ lazy val sbtPlugin = project
     addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.2"),
     addSbtPlugin("org.portable-scala" % "sbt-crossproject"  % "1.3.2"),
     buildInfoPackage   := "clue.sbt",
-    buildInfoKeys      := Seq[BuildInfoKey](version,
-                                       organization,
-                                       "rulesModule" -> (genRules / moduleName).value,
-                                       "coreModule"  -> (core.jvm / moduleName).value
+    buildInfoKeys      := Seq[BuildInfoKey](
+      version,
+      organization,
+      "rulesModule" -> (genRules / moduleName).value,
+      "coreModule"  -> (core.jvm / moduleName).value
     ),
     buildInfoOptions += BuildInfoOption.PackagePrivate,
     Test / test        := {

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val scala3Version      = "3.4.2"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
-ThisBuild / tlBaseVersion              := "0.38"
+ThisBuild / tlBaseVersion              := "0.39"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))

--- a/core/src/main/scala/clue/GraphQLException.scala
+++ b/core/src/main/scala/clue/GraphQLException.scala
@@ -8,15 +8,36 @@ import io.circe.JsonObject
 
 class GraphQLException(msg: String) extends Exception(msg)
 
-case class ConnectionException() extends GraphQLException("Could not establish connection")
+case class ConnectionException(msg: String) extends GraphQLException(msg)
 
 case class RemoteInitializationException(payload: JsonObject)
     extends GraphQLException(s"The server returned an error on initialization: [$payload]")
 
-case class DisconnectedException() extends GraphQLException("Connection was closed")
+case object ConnectionNotInitializedException extends GraphQLException("Connection not initialized")
 
-case class InvalidSubscriptionIdException(id: String)
-    extends GraphQLException(s"Invalid subscription id: $id")
+case class UnexpectedInternalStateException[S](when: String, state: S)
+    extends GraphQLException(
+      s"Unexpected internal state when [$when]. Cannot recover. State is [$state]"
+    )
+
+case object DisconnectedException extends GraphQLException("Connection was closed")
+
+case class InvalidSubscriptionOperationException(operation: String, subscriptionId: String)
+    extends GraphQLException(
+      s"Attempted [$operation] on non-existent subscription with id: [$subscriptionId]"
+    )
+
+case class InvalidInvocationException(msg: String)
+    extends GraphQLException(s"Invalid invocation on the current state: $msg")
+
+case class ServerMessageDecodingException(cause: io.circe.Error)
+    extends GraphQLException(
+      s"Exception decoding message received from server: [${cause.getMessage}]"
+    )
+case class UnexpectedServerMessageException[M, S](msg: M, state: S)
+    extends GraphQLException(
+      s"Unexpected message received from server. Message received: [$msg], current state: [$state]"
+    )
 
 case class ResponseException[D](errors: GraphQLErrors, data: Option[D])
     extends GraphQLException(errors.map(_.message).toList.mkString(", "))

--- a/core/src/main/scala/clue/clients.scala
+++ b/core/src/main/scala/clue/clients.scala
@@ -125,7 +125,8 @@ trait PersistentClient[F[_], CP, CE] {
   def statusStream: fs2.Stream[F, PersistentClientStatus]
 
   def connect(): F[Unit]
-  def initialize(payload: Map[String, Json] = Map.empty): F[Unit]
+  // Initialization may repeat upon reconnection, that's why the payload is effectful since it may change over time (eg: auth tokens).
+  def initialize(payload: F[Map[String, Json]]): F[Unit]
 
   def terminate(): F[Unit]
   def disconnect(closeParameters: CP): F[Unit]

--- a/core/src/main/scala/clue/package.scala
+++ b/core/src/main/scala/clue/package.scala
@@ -13,7 +13,8 @@ import org.typelevel.log4cats.Logger
 package object clue {
   type FetchClient[F[_], S] = FetchClientWithPars[F, ?, S]
 
-  // None = canceled, Some(Right(())) = done, Some(Some(Left(t)) = error
+  // The Latch value is interpreted as:
+  //   None = canceled, Some(Right(())) = done, Some(Left(t)) = error
   protected[clue] type Latch[F[_]] = Deferred[F, Option[Either[Throwable, Unit]]]
 
   final implicit class LatchOps[F[_]](val latch: Latch[F]) extends AnyVal {

--- a/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
+++ b/scalajs/src/main/scala/clue/js/WebSocketJSBackend.scala
@@ -67,7 +67,7 @@ final class WebSocketJSBackend[F[_]: Async: Logger](dispatcher: Dispatcher[F])
                 _    <- s"Error on WebSocket for [$uri]".errorF
                 _    <- isErrored.set(true)
                 open <- isOpen.get
-              } yield if (!open) cb(ConnectionException().asLeft)
+              } yield if (!open) cb(ConnectionException("Could not establish connection").asLeft)
             ).uncancelable
             dispatcher.unsafeRunAndForget(error)
           }
@@ -79,7 +79,7 @@ final class WebSocketJSBackend[F[_]: Async: Logger](dispatcher: Dispatcher[F])
                 errored <- isErrored.get
                 _       <- handler.onClose(
                              connectionId,
-                             if (errored) DisconnectedException().asLeft
+                             if (errored) DisconnectedException.asLeft
                              else CloseParams(e.code, e.reason).asRight
                            )
               } yield ()


### PR DESCRIPTION
- More specific exceptions to allow better handling.
- Propagate main fiber cancelation across async boundaries (connect and initialize latches).
- Effectful payload for initialization. Allows getting updated values when retry mechanism kicks in.
- Downgrade some detailed log messages from debug to trace.