### PR TITLE
Allow client code to handle errors in subscription events.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
 lazy val scala2Version      = V.scala213
-lazy val scala3Version      = "3.6.0"
+lazy val scala3Version      = "3.6.2"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 


### PR DESCRIPTION
The build will fail because it is broken for other reasons... See #653 

The purpose of this PR is to allow subscriptions that filter out errors so that an error in a subscription doesn't break things. It allows the user to decide what to do when an error does occur, such as log it.

This is an alternate solution to the initial attempt in https://github.com/gemini-hlsw/explore/pull/4473, which was not very ergonomic.