### PR TITLE
Improve ergonomics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val scala3Version      = "3.6.2"
 lazy val rulesCrossVersions = Seq(V.scala213)
 lazy val allVersions        = rulesCrossVersions :+ scala3Version
 
-ThisBuild / tlBaseVersion              := "0.41"
+ThisBuild / tlBaseVersion              := "0.42"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))

--- a/core/src/main/scala/clue/FetchClientImpl.scala
+++ b/core/src/main/scala/clue/FetchClientImpl.scala
@@ -21,7 +21,7 @@ import org.typelevel.log4cats.Logger
 class FetchClientImpl[F[_]: MonadThrow: Logger, P, S](requestParams: P)(implicit
   backend: FetchBackend[F, P]
 ) extends clue.FetchClientWithPars[F, P, S] {
-  override protected def requestInternal[D: Decoder](
+  override protected[clue] def requestInternal[D: Decoder](
     document:      String,
     operationName: Option[String],
     variables:     Option[JsonObject],

--- a/core/src/main/scala/clue/websocket/ApolloClient.scala
+++ b/core/src/main/scala/clue/websocket/ApolloClient.scala
@@ -112,7 +112,7 @@ class ApolloClient[F[_], P, S](
   }
 
   // <StreamingClient>
-  override protected def subscribeInternal[D: Decoder](
+  override protected[clue] def subscribeInternal[D: Decoder](
     subscription:  String,
     operationName: Option[String],
     variables:     Option[JsonObject]
@@ -120,7 +120,7 @@ class ApolloClient[F[_], P, S](
     subscriptionResource(subscription, operationName, variables)
 
   // <FetchClient>
-  override protected def requestInternal[D: Decoder](
+  override protected[clue] def requestInternal[D: Decoder](
     document:      String,
     operationName: Option[String],
     variables:     Option[JsonObject],

--- a/model/src/main/scala/clue/model/GraphQLResponse.scala
+++ b/model/src/main/scala/clue/model/GraphQLResponse.scala
@@ -73,6 +73,8 @@ object GraphQLResponse {
   final implicit class GraphQLResponseOps[F[_], D](
     val response: F[GraphQLResponse[D]]
   ) extends AnyVal {
+    // If you add methods here, be sure to add them too to the proxies in
+    // clue.syntax and clients.RequestApplied
     def raiseGraphQLErrors(implicit F: MonadThrow[F]): F[D] =
       response.map(_.result).flatMap {
         case Ior.Right(b)   => F.pure(b)
@@ -91,6 +93,8 @@ object GraphQLResponse {
   final implicit class GraphQLResponseResourceStreamOps[F[_], D](
     val streamResource: Resource[F, fs2.Stream[F, GraphQLResponse[D]]]
   ) extends AnyVal {
+    // If you add methods here, be sure to add them too to the proxies in
+    // clue.syntax and clients.SubscriptionApplied
     def ignoreGraphQLErrors: Resource[F, fs2.Stream[F, D]] =
       streamResource.map(
         _.through(


### PR DESCRIPTION
Avoids having to explicitly call `apply` when we have a query or subscription without input variables and we want to apply the new extension methods.

Also, update Demo. It now works again.