### PR TITLE
Increase maxInputValueDepth for grackle parser

### DIFF
--- a/gen/rules/src/main/scala/clue/gen/package.scala
+++ b/gen/rules/src/main/scala/clue/gen/package.scala
@@ -13,5 +13,7 @@ package object gen {
 
   def log(msg: String): IO[Unit] = IO(println(msg))
 
-  val GQLParser: QueryParser = QueryParser(GraphQLParser(GraphQLParser.defaultConfig))
+  private val config = GraphQLParser.defaultConfig.copy(maxInputValueDepth = 16)
+
+  val GQLParser: QueryParser = QueryParser(GraphQLParser(config))
 }


### PR DESCRIPTION
This matches what was already done in the ODB and is required to parse the bigger input objects in the odb queries.