### PR TITLE
Change Maps to JsonObject

### DIFF
--- a/core/src/main/scala/clue/clients.scala
+++ b/core/src/main/scala/clue/clients.scala
@@ -148,8 +148,8 @@ trait PersistentClient[F[_], CP, CE] {
   def statusStream: fs2.Stream[F, PersistentClientStatus]
 
   // Initialization may repeat upon reconnection, that's why the payload is effectful since it may change over time (eg: auth tokens).
-  def connect(payload: F[Map[String, Json]]): F[Map[String, Json]]
-  def connect(): F[Map[String, Json]]
+  def connect[A: Encoder.AsObject](payload: F[A]): F[JsonObject]
+  def connect(): F[JsonObject]
 
   def disconnect(closeParameters: CP): F[Unit]
   def disconnect(): F[Unit]

--- a/core/src/main/scala/clue/websocket/State.scala
+++ b/core/src/main/scala/clue/websocket/State.scala
@@ -20,15 +20,15 @@ protected object State {
   final case class Connecting[F[_]](
     connectionId:  ConnectionId,
     connection:    Option[WebSocketConnection[F]],
-    initPayload:   F[Map[String, Json]],
+    initPayload:   F[JsonObject],
     subscriptions: Map[String, Emitter[F]],
-    latch:         Latch[F, Map[String, Json]]
+    latch:         Latch[F, JsonObject]
   ) extends State[F](PersistentClientStatus.Connecting)
 
   final case class Connected[F[_]](
     connectionId:  ConnectionId,
     connection:    WebSocketConnection[F],
-    initPayload:   F[Map[String, Json]],
+    initPayload:   F[JsonObject],
     subscriptions: Map[String, Emitter[F]]
   ) extends State[F](PersistentClientStatus.Connected)
 }

--- a/model/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/src/main/scala/clue/model/StreamingMessage.scala
@@ -42,12 +42,12 @@ object StreamingMessage:
      * @param payload
      *   any connection parameters that the client wishes to send
      */
-    final case class ConnectionInit(payload: Option[Map[String, Json]] = none)
+    final case class ConnectionInit(payload: Option[JsonObject] = none)
         extends FromClient
-        with Payload[Option[Map[String, Json]]] derives Eq
+        with Payload[Option[JsonObject]] derives Eq
 
     object ConnectionInit:
-      inline def apply(payload: Map[String, Json]) = new ConnectionInit(payload.some)
+      inline def apply(payload: JsonObject) = new ConnectionInit(payload.some)
 
     /**
      * Client initiated message that keeps the client connection alive.
@@ -55,12 +55,12 @@ object StreamingMessage:
      * @param payload
      *   optional field can be used to transfer additional details about the pong
      */
-    final case class Pong(payload: Option[Map[String, Json]] = none)
+    final case class Pong(payload: Option[JsonObject] = none)
         extends FromClient
-        with Payload[Option[Map[String, Json]]] derives Eq
+        with Payload[Option[JsonObject]] derives Eq
 
     object Pong:
-      inline def apply(payload: Map[String, Json]) = new Pong(payload.some)
+      inline def apply(payload: JsonObject) = new Pong(payload.some)
 
     /**
      * Starts a GraphQL operation. The operation contains an id so that it can be explicitly stopped
@@ -95,12 +95,12 @@ object StreamingMessage:
     /**
      * A server acknowledgement and acceptance of a `ConnectionInit` request.
      */
-    final case class ConnectionAck(payload: Option[Map[String, Json]] = none)
+    final case class ConnectionAck(payload: Option[JsonObject] = none)
         extends FromServer
-        with Payload[Option[Map[String, Json]]] derives Eq
+        with Payload[Option[JsonObject]] derives Eq
 
     object ConnectionAck:
-      inline def apply(payload: Map[String, Json]) = new ConnectionAck(payload.some)
+      inline def apply(payload: JsonObject) = new ConnectionAck(payload.some)
 
     /**
      * Server initiated message that keeps the client connection alive.
@@ -108,12 +108,12 @@ object StreamingMessage:
      * @param payload
      *   optional field can be used to transfer additional details about the ping
      */
-    final case class Ping(payload: Option[Map[String, Json]] = none)
+    final case class Ping(payload: Option[JsonObject] = none)
         extends FromServer
-        with Payload[Option[Map[String, Json]]] derives Eq
+        with Payload[Option[JsonObject]] derives Eq
 
     object Ping:
-      inline def apply(payload: Map[String, Json]) = new Ping(payload.some)
+      inline def apply(payload: JsonObject) = new Ping(payload.some)
 
     /**
      * GraphQL execution result from the server. The result is associated with an operation that was

--- a/model/src/main/scala/clue/model/json/package.scala
+++ b/model/src/main/scala/clue/model/json/package.scala
@@ -52,7 +52,7 @@ package object json {
     Decoder.instance: c =>
       for
         _ <- checkType(c, "connection_init")
-        p <- c.get[Option[Map[String, Json]]]("payload")
+        p <- c.get[Option[JsonObject]]("payload")
       yield FromClient.ConnectionInit(p)
 
   given Encoder[FromClient.Pong] =
@@ -68,7 +68,7 @@ package object json {
     Decoder.instance: c =>
       for
         _ <- checkType(c, "pong")
-        p <- c.get[Option[Map[String, Json]]]("payload")
+        p <- c.get[Option[JsonObject]]("payload")
       yield FromClient.Pong(p)
 
   given Encoder[FromClient.Subscribe] =
@@ -137,7 +137,7 @@ package object json {
     Decoder.instance: c =>
       for
         _ <- checkType(c, "connection_ack")
-        p <- c.get[Option[Map[String, Json]]]("payload")
+        p <- c.get[Option[JsonObject]]("payload")
       yield FromServer.ConnectionAck(p)
 
   given Encoder[FromServer.Ping] =
@@ -153,7 +153,7 @@ package object json {
     Decoder.instance: c =>
       for
         _ <- checkType(c, "ping")
-        p <- c.get[Option[Map[String, Json]]]("payload")
+        p <- c.get[Option[JsonObject]]("payload")
       yield FromServer.Ping(p)
 
   given Encoder[GraphQLError.PathElement] =

--- a/model/src/main/scala/clue/model/package.scala
+++ b/model/src/main/scala/clue/model/package.scala
@@ -4,8 +4,8 @@
 package clue.model
 
 import cats.data.NonEmptyList
-import io.circe.Json
+import io.circe.JsonObject
 
 type GraphQLErrors = NonEmptyList[GraphQLError]
 
-type GraphQLExtensions = Map[String, Json]
+type GraphQLExtensions = JsonObject

--- a/model/src/test/scala/clue/model/arb/ArbFromClient.scala
+++ b/model/src/test/scala/clue/model/arb/ArbFromClient.scala
@@ -6,7 +6,6 @@ package clue.model.arb
 import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.FromClient
 import clue.model.StreamingMessage.FromClient.*
-import io.circe.Json
 import io.circe.JsonObject
 import io.circe.testing.instances.*
 import org.scalacheck.Arbitrary
@@ -19,11 +18,11 @@ trait ArbFromClient:
 
   given Arbitrary[ConnectionInit] =
     Arbitrary:
-      arbitrary[Option[Map[String, Json]]](using arbOptJsonStringMap).map(ConnectionInit(_))
+      arbitrary[Option[JsonObject]](using arbOptJsonObject).map(ConnectionInit(_))
 
   given Arbitrary[Pong] =
     Arbitrary:
-      arbitrary[Option[Map[String, Json]]](using arbOptJsonStringMap).map(Pong(_))
+      arbitrary[Option[JsonObject]](using arbOptJsonObject).map(Pong(_))
 
   given Arbitrary[Subscribe] =
     Arbitrary:

--- a/model/src/test/scala/clue/model/arb/ArbFromServer.scala
+++ b/model/src/test/scala/clue/model/arb/ArbFromServer.scala
@@ -10,6 +10,7 @@ import clue.model.GraphQLResponse
 import clue.model.StreamingMessage.FromServer
 import clue.model.StreamingMessage.FromServer.*
 import io.circe.Json
+import io.circe.JsonObject
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*
 import org.scalacheck.Gen
@@ -57,7 +58,7 @@ trait ArbFromServer:
         message    <- arbitrary[String]
         path       <- arbitrary[List[GraphQLError.PathElement]]
         locations  <- arbitrary[List[GraphQLError.Location]]
-        extensions <- arbitrary[Option[GraphQLExtensions]]
+        extensions <- arbitrary[Option[GraphQLExtensions]](using arbOptJsonObject)
       yield GraphQLError(
         message,
         NonEmptyList.fromList(path),
@@ -67,12 +68,12 @@ trait ArbFromServer:
 
   given Arbitrary[ConnectionAck] =
     Arbitrary:
-      for p <- arbitrary[Option[Map[String, Json]]](using arbOptJsonStringMap)
+      for p <- arbitrary[Option[JsonObject]](using arbOptJsonObject)
       yield ConnectionAck(p)
 
   given Arbitrary[Ping] =
     Arbitrary:
-      for p <- arbitrary[Option[Map[String, Json]]](using arbOptJsonStringMap)
+      for p <- arbitrary[Option[JsonObject]](using arbOptJsonObject)
       yield Ping(p)
 
   given Arbitrary[Next] =

--- a/model/src/test/scala/clue/model/arb/ArbJson.scala
+++ b/model/src/test/scala/clue/model/arb/ArbJson.scala
@@ -5,6 +5,8 @@ package clue.model.arb
 
 import cats.syntax.option.*
 import io.circe.Json
+import io.circe.JsonObject
+import io.circe.syntax.*
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*
 import org.scalacheck.Gen
@@ -20,15 +22,15 @@ trait ArbJson:
       jsonStr <- arbitrary[Json](using arbJsonString)
     yield (str, jsonStr)
 
-  val arbJsonStringMap: Arbitrary[Map[String, Json]] =
+  val arbJsonObject: Arbitrary[JsonObject] =
     Arbitrary:
-      Gen.mapOf[String, Json](genJsonStringJsonTuple)
+      Gen.mapOf[String, Json](genJsonStringJsonTuple).map(_.asJsonObject)
 
-  val arbOptJsonStringMap: Arbitrary[Option[Map[String, Json]]] =
+  val arbOptJsonObject: Arbitrary[Option[JsonObject]] =
     Arbitrary:
-      Gen.oneOf(
-        Gen.const(none),
-        arbJsonStringMap.arbitrary.map(_.some)
+      Gen.frequency(
+        1 -> Gen.const(none),
+        9 -> arbJsonObject.arbitrary.map(_.some)
       )
 
 object ArbJson extends ArbJson


### PR DESCRIPTION
This might be a good time to make this other breaking change. I find it's cleaner to pass JsonObjects around than Map[String, Json], and it saves an encoding/decoding step.