### PR TITLE
Validate query arguments - Take 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
-ThisBuild / tlBaseVersion              := "0.48"
+ThisBuild / tlBaseVersion              := "0.49"
 ThisBuild / tlCiReleaseBranches        := Seq("master")
 ThisBuild / tlJdkRelease               := Some(8)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))


### PR DESCRIPTION
This PR will check that:

- Arguments to queries and fields are declared in the schema.
- Check their type is compatible.
- All required arguments without default values are declared.

This is a revised edition of https://github.com/gemini-hlsw/clue/pull/722 which recurses into objects and lists, and uses simpler logic by co-opting grackle's variable resolver.