### PR TITLE
Validate subquery variables, introduce gql interpolator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ node_modules
 # direnv
 .direnv/
 .pi/
+
+#Claude
+*PLAN.md

--- a/README.md
+++ b/README.md
@@ -124,6 +124,38 @@ Hand-written subqueries may declare **multiple** types (the selection is validat
 `@GraphQLType("Human", "Droid")`). A subquery processed by the generator (`@GraphQL`) must declare
 **exactly one** type. `@GraphQLType` is only valid on a subquery, not on a `GraphQLOperation`.
 
+##### Subquery variables
+
+A subquery that references GraphQL variables declares them in a `type Variables` member, written in
+operation-header syntax:
+
+```scala
+@GraphQLType("Query")
+abstract class HeroByEpisode extends GraphQLSubquery.Typed[StarWars, Json] {
+  type Variables = "($ep: Episode!)"
+  val subquery   = "{ hero(episode: $ep) { name } }"
+}
+```
+
+The declaration is checked against usage (here `$ep` feeds `hero(episode: Episode!)`); a variable
+used but not declared, or declared with an incompatible type, is a scalafix error. For subqueries
+processed by the generator (`@GraphQL`), `type Variables` is **inferred from usage and emitted
+automatically** when you don't write it; hand-written subqueries declare it explicitly.
+
+To splice a subquery into an operation *and* have the operation's variables checked against it, build
+the `document` with the `gql` interpolator (from `clue`) instead of `s`:
+
+```scala
+trait MyQuery extends GraphQLOperation[StarWars] {
+  val document = gql"query ($$ep: Episode!) $HeroByEpisode"
+}
+```
+
+`gql` produces exactly the string `s` would, but at **compile time** it verifies the operation
+declares every variable required by each spliced subquery, with a compatible ("usable as") type. It
+reads the requirement from the subquery's `type Variables` directly, so the check works even when the
+subquery comes from a dependency jar; a missing or wrong-typed variable is a compile error.
+
 The schema location is configured (once) in `.scalafix.conf`:
 
 ```hocon

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Either:
 They must extend `GraphQLOperation[S]`, defining the following members:
 
 ``` scala
-  val document: String
+  val document: GraphQLDocument   // built with the `gql` interpolator (see below)
 
   type Variables
   type Data
@@ -69,6 +69,12 @@ They must extend `GraphQLOperation[S]`, defining the following members:
   val dataDecoder: io.circe.Decoder[Data]
 ```
 
+The `document` is built with the `gql` string interpolator (`import clue.gql`) rather than a plain
+`String`/`s"..."`. `gql` produces the same text at runtime, but its type (`GraphQLDocument`) can only
+be obtained through `gql`, so every operation goes through the compile-time check that splices its
+subqueries correctly (see [Subquery variables](#subquery-variables) below). For a document built by
+other means, `GraphQLDocument.unsafeFromString(...)` is the explicit (check-skipping) escape hatch.
+
 #### Example
 
 ``` scala
@@ -76,9 +82,9 @@ They must extend `GraphQLOperation[S]`, defining the following members:
   import io.circe.generic.semiauto._
 
   object CharacterQuery extends GraphQLOperation[StarWars] {
-    val document = """
-        query (charId: ID!) {
-          character(id: $charId) {
+    val document = gql"""
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             id
             name
           }

--- a/README.md
+++ b/README.md
@@ -132,20 +132,21 @@ Hand-written subqueries may declare **multiple** types (the selection is validat
 
 ##### Subquery variables
 
-A subquery that references GraphQL variables declares them in a `type Variables` member, written in
-operation-header syntax:
+A subquery that references GraphQL variables declares them in a `type VariableDefs` member, written
+in operation-header syntax (the GraphQL spec's `VariablesDefinition`). It is a declaration only —
+there is no runtime value, case class or encoder behind it, unlike an operation's `Variables`:
 
 ```scala
 @GraphQLType("Query")
 abstract class HeroByEpisode extends GraphQLSubquery.Typed[StarWars, Json] {
-  type Variables = "($ep: Episode!)"
-  val subquery   = "{ hero(episode: $ep) { name } }"
+  type VariableDefs = "($ep: Episode!)"
+  val subquery      = "{ hero(episode: $ep) { name } }"
 }
 ```
 
 The declaration is checked against usage (here `$ep` feeds `hero(episode: Episode!)`); a variable
 used but not declared, or declared with an incompatible type, is a scalafix error. For subqueries
-processed by the generator (`@GraphQL`), `type Variables` is **inferred from usage and emitted
+processed by the generator (`@GraphQL`), `type VariableDefs` is **inferred from usage and emitted
 automatically** when you don't write it; hand-written subqueries declare it explicitly.
 
 To splice a subquery into an operation *and* have the operation's variables checked against it, build
@@ -159,8 +160,8 @@ trait MyQuery extends GraphQLOperation[StarWars] {
 
 `gql` produces exactly the string `s` would, but at **compile time** it verifies the operation
 declares every variable required by each spliced subquery, with a compatible ("usable as") type. It
-reads the requirement from the subquery's `type Variables` directly, so the check works even when the
-subquery comes from a dependency jar; a missing or wrong-typed variable is a compile error.
+reads the requirement from the subquery's `type VariableDefs` directly, so the check works even when
+the subquery comes from a dependency jar; a missing or wrong-typed variable is a compile error.
 
 The schema location is configured (once) in `.scalafix.conf`:
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,12 @@ A subquery declares the GraphQL root type(s) its selection applies to with a
 ```scala
 @GraphQLType("Character")
 abstract class FriendFields extends GraphQLSubquery.Typed[StarWars, Json] {
-  val subquery = "{ id name }"
+  val subquery = gql"{ id name }"
 }
 ```
+
+A subquery's `subquery` is a `GraphQLDocument` too, so it is built with `gql` for the same reason a
+`document` is (see [Subquery variables](#subquery-variables)).
 
 Hand-written subqueries may declare **multiple** types (the selection is validated against each:
 `@GraphQLType("Human", "Droid")`). A subquery processed by the generator (`@GraphQL`) must declare
@@ -132,22 +135,34 @@ Hand-written subqueries may declare **multiple** types (the selection is validat
 
 ##### Subquery variables
 
-A subquery that references GraphQL variables declares them in a `type VariableDefs` member, written
-in operation-header syntax (the GraphQL spec's `VariablesDefinition`). It is a declaration only —
-there is no runtime value, case class or encoder behind it, unlike an operation's `Variables`:
+A subquery that references GraphQL variables **must** declare them in a `type VariableDefs` member,
+written in operation-header syntax (the GraphQL spec's `VariablesDefinition`). A subquery that
+references none omits it — the member is not part of `GraphQLSubquery`, so there is nothing to write.
+It is a declaration only: no runtime value, case class or encoder behind it, unlike an operation's
+`Variables`:
 
 ```scala
 @GraphQLType("Query")
 abstract class HeroByEpisode extends GraphQLSubquery.Typed[StarWars, Json] {
   type VariableDefs = "($ep: Episode!)"
-  val subquery      = "{ hero(episode: $ep) { name } }"
+  val subquery      = gql"{ hero(episode: $$ep) { name } }"
 }
 ```
 
+(`$` is escaped as `$$` inside `gql`, as in any interpolated string. The `VariableDefs` literal is a
+plain string, so it is written with a single `$`.)
+
 The declaration is checked against usage (here `$ep` feeds `hero(episode: Episode!)`); a variable
-used but not declared, or declared with an incompatible type, is a scalafix error. For subqueries
-processed by the generator (`@GraphQL`), `type VariableDefs` is **inferred from usage and emitted
-automatically** when you don't write it; hand-written subqueries declare it explicitly.
+used but not declared, or declared with an incompatible type, is a scalafix error. Declaring a
+variable the subquery doesn't use is currently accepted (unused-variable detection is disabled, see
+`validateParsed`). For subqueries processed by the generator (`@GraphQL`), `type VariableDefs` is
+**inferred from usage and emitted automatically** when you don't write it; hand-written subqueries
+declare it explicitly.
+
+Note that the declaration is what the caller-check below keys on: a subquery that uses a variable
+without declaring it reads as "requires nothing" to callers. That omission is an error wherever the
+subquery is validated (it needs `@GraphQLType` and a configured schema), so keep validation enabled
+on projects that publish subqueries.
 
 To splice a subquery into an operation *and* have the operation's variables checked against it, build
 the `document` with the `gql` interpolator (from `clue`) instead of `s`:
@@ -162,6 +177,21 @@ trait MyQuery extends GraphQLOperation[StarWars] {
 declares every variable required by each spliced subquery, with a compatible ("usable as") type. It
 reads the requirement from the subquery's `type VariableDefs` directly, so the check works even when
 the subquery comes from a dependency jar; a missing or wrong-typed variable is a compile error.
+
+A subquery splicing another subquery is checked the same way, against its own `VariableDefs` instead
+of an operation header:
+
+```scala
+@GraphQLType("Character")
+object FriendsWithHero extends GraphQLSubquery.Typed[StarWars, Json] {
+  type VariableDefs = "($ep: Episode!)"       // required: `HeroByEpisode` needs it
+  val subquery      = gql"{ id friends $HeroByEpisode }"
+}
+```
+
+Because each level has to declare what the level below requires, the requirement reaches the
+operation transitively — an operation splicing `FriendsWithHero` must declare `$ep` as well. Nesting
+is checked one level at a time; no whole-tree analysis is involved.
 
 The schema location is configured (once) in `.scalafix.conf`:
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ They must extend `GraphQLOperation[S]`, defining the following members:
 The `document` is built with the `gql` string interpolator (`import clue.gql`) rather than a plain
 `String`/`s"..."`. `gql` produces the same text at runtime, but its type (`GraphQLDocument`) can only
 be obtained through `gql`, so every operation goes through the compile-time check that splices its
-subqueries correctly (see [Subquery variables](#subquery-variables) below). For a document built by
-other means, `GraphQLDocument.unsafeFromString(...)` is the explicit (check-skipping) escape hatch.
+subqueries correctly (see [Subquery variables](#subquery-variables) below). `.stripMargin` works on a
+`GraphQLDocument` as it does on a `String`. For a document built by other means,
+`GraphQLDocument.unsafeFromString(...)` is the explicit (check-skipping) escape hatch.
 
 #### Example
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
-ThisBuild / tlBaseVersion               := "0.56"
+ThisBuild / tlBaseVersion               := "0.57"
 ThisBuild / tlJdkRelease                := Some(17)
 ThisBuild / githubWorkflowJavaVersions  := Seq("25", "17").map(JavaSpec.temurin(_))
 ThisBuild / scalaVersion                := "3.8.4"

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -51,6 +51,17 @@ extension (inline sc:         StringContext)
    */
   inline def gql(inline args: Any*): GraphQLDocument = ${ GraphQLInterpolator.gqlImpl('sc, 'args) }
 
+/**
+ * Makes `gql` available inside operation/subquery bodies without an import. `protected`, so it
+ * doesn't leak into the public API of the operations and subqueries that inherit it.
+ */
+trait GraphQLTextSyntax {
+  extension (inline sc: StringContext)
+    protected inline def gql(inline args: Any*): GraphQLDocument = ${
+      GraphQLInterpolator.gqlImpl('sc, 'args)
+    }
+}
+
 private[clue] object GraphQLInterpolator {
 
   def gqlImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -24,7 +24,7 @@ extension (inline sc:         StringContext)
    * Builds a GraphQL operation `document`, splicing subqueries inline. At runtime it produces
    * exactly the string the standard `s"..."` interpolator would. At compile time it runs the
    * *caller-check*: for every spliced value that declares variables (a `GraphQLSubquery` with a
-   * `type Variables` member), it verifies the operation's `query (...)` header declares each
+   * `type VariableDefs` member), it verifies the operation's `query (...)` header declares each
    * required variable with a compatible ("usable as") type — reading the requirement straight from
    * the subquery's type, so it works even when the subquery is shipped in a dependency jar.
    */
@@ -48,10 +48,10 @@ private[clue] object GraphQLInterpolator {
       case _           => report.errorAndAbort("gql: splice arguments must be explicit")
     }
 
-    // Read a spliced value's `Variables` literal-type member, if it has one (a `GraphQLSubquery`).
-    def variablesOf(arg: Expr[Any]): Option[String] = {
+    // Read a spliced value's `VariableDefs` literal-type member, if it has one (a `GraphQLSubquery`).
+    def variableDefsOf(arg: Expr[Any]): Option[String] = {
       val tpe = arg.asTerm.tpe
-      val sym = tpe.typeSymbol.typeMember("Variables")
+      val sym = tpe.typeSymbol.typeMember("VariableDefs")
       if (sym.isNoSymbol) None
       else {
         // A type alias surfaces as `TypeBounds(lo, hi)` with `lo == hi`; read `hi`.
@@ -126,7 +126,7 @@ private[clue] object GraphQLInterpolator {
     val opVars: Map[String, String] = parts.headOption.map(operationVars).getOrElse(Map.empty)
 
     argExprs.foreach { arg =>
-      variablesOf(arg).foreach { required =>
+      variableDefsOf(arg).foreach { required =>
         parseVarDefs(required).foreach { case (name, reqType) =>
           opVars.get(name) match {
             case None                                       =>

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -6,27 +6,34 @@ package clue
 import scala.quoted.*
 
 /**
- * An assembled GraphQL operation document. The only way to obtain one is the `gql` interpolator, so
- * an operation's `document` is always run through the compile-time caller-check — a plain `String`
- * or `s"..."` does not type-check as a `GraphQLDocument`. Read the underlying string with `.value`.
+ * Assembled GraphQL text: an operation's `document`, or a subquery's `subquery` selection set. The
+ * only way to obtain one is the `gql` interpolator, so both are always run through the compile-time
+ * caller-check — a plain `String` or `s"..."` does not type-check as a `GraphQLDocument`. Read the
+ * underlying string with `.value`.
  */
 opaque type GraphQLDocument = String
 object GraphQLDocument {
-  // `gql"..."` is the validated way to build a document — a plain `String`/`s"..."` won't type-check
-  // as a `GraphQLDocument`. `unsafeFromString` is the explicit escape hatch for documents built by
-  // other means; it skips the caller-check, so prefer `gql`.
+  // `gql"..."` is the validated way to build one — a plain `String`/`s"..."` won't type-check as a
+  // `GraphQLDocument`. `unsafeFromString` is the explicit escape hatch for text built by other
+  // means; it skips the caller-check, so prefer `gql`.
   def unsafeFromString(value: String): GraphQLDocument           = value
   extension (document:        GraphQLDocument) def value: String = document
 }
 
 extension (inline sc:         StringContext)
   /**
-   * Builds a GraphQL operation `document`, splicing subqueries inline. At runtime it produces
-   * exactly the string the standard `s"..."` interpolator would. At compile time it runs the
-   * *caller-check*: for every spliced value that declares variables (a `GraphQLSubquery` with a
-   * `type VariableDefs` member), it verifies the operation's `query (...)` header declares each
-   * required variable with a compatible ("usable as") type — reading the requirement straight from
-   * the subquery's type, so it works even when the subquery is shipped in a dependency jar.
+   * Builds an operation `document` or a subquery's `subquery`, splicing subqueries inline. At
+   * runtime it produces exactly the string the standard `s"..."` interpolator would.
+   *
+   * At compile time it runs the *caller-check*: for every spliced value that declares variables (a
+   * `GraphQLSubquery` with a `type VariableDefs` member), it verifies that the variables are
+   * declared where the splice happens, with a compatible ("usable as") type. The declaration is
+   * read from the operation's `query (...)` header, or — when the splice happens inside a
+   * `GraphQLSubquery` — from that subquery's own `type VariableDefs`, so nesting is checked one
+   * level at a time and holds transitively.
+   *
+   * Requirements are read straight off the spliced subquery's type, so the check also works when
+   * the subquery is shipped in a dependency jar.
    */
   inline def gql(inline args: Any*): GraphQLDocument = ${ GraphQLInterpolator.gqlImpl('sc, 'args) }
 
@@ -48,22 +55,36 @@ private[clue] object GraphQLInterpolator {
       case _           => report.errorAndAbort("gql: splice arguments must be explicit")
     }
 
-    // Read a spliced value's `VariableDefs` literal-type member, if it has one (a `GraphQLSubquery`).
-    def variableDefsOf(arg: Expr[Any]): Option[String] = {
-      val tpe = arg.asTerm.tpe
+    // The variables a type declares in its `VariableDefs` member (i.e. it is a `GraphQLSubquery`
+    // that references variables). Works for the enclosing class too, even though it is still being
+    // typed while this splice expands: a literal type alias doesn't depend on the rest of the body.
+    def variableDefsOf(tpe: TypeRepr): Option[String] = {
       val sym = tpe.typeSymbol.typeMember("VariableDefs")
       if (sym.isNoSymbol) None
-      else {
+      else
         // A type alias surfaces as `TypeBounds(lo, hi)` with `lo == hi`; read `hi`.
-        val resolved = tpe.memberType(sym) match {
+        (tpe.memberType(sym) match {
           case TypeBounds(_, hi) => hi.dealias
           case other             => other.dealias
-        }
-        resolved match {
+        }) match {
           case ConstantType(StringConstant(s)) => Some(s)
           case _                               => None
         }
-      }
+    }
+
+    // The `GraphQLSubquery` this splice is being expanded inside, if any: walking owners outwards,
+    // the first class that is one. This is what makes subquery-into-subquery splices checkable — the
+    // enclosing subquery's `VariableDefs` is the declaration the requirements are checked against.
+    val enclosingSubquery: Option[Symbol] = {
+      val subqueryClass = TypeRepr.of[GraphQLSubquery[?]].typeSymbol
+
+      @scala.annotation.tailrec
+      def loop(sym: Symbol): Option[Symbol] =
+        if (sym.isNoSymbol) None
+        else if (sym.isClassDef && sym.typeRef.baseClasses.contains(subqueryClass)) Some(sym)
+        else loop(sym.owner)
+
+      loop(Symbol.spliceOwner)
     }
 
     def splitTopLevel(s: String): List[String] = {
@@ -116,30 +137,45 @@ private[clue] object GraphQLInterpolator {
       }
     }
 
-    // GraphQL "is variable usage allowed": the provided type must be usable where the required type
-    // is expected. Same base type, and a non-null requirement needs a non-null provided type.
-    def usableAs(opType: String, reqType: String): Boolean = {
-      val o = opType.trim; val r = reqType.trim
-      o.stripSuffix("!").trim == r.stripSuffix("!").trim && (!r.endsWith("!") || o.endsWith("!"))
+    // GraphQL "is variable usage allowed": the declared type must be usable where the required type
+    // is expected. Same base type, and a non-null requirement needs a non-null declared type.
+    def usableAs(declaredType: String, reqType: String): Boolean = {
+      val d = declaredType.trim; val r = reqType.trim
+      d.stripSuffix("!").trim == r.stripSuffix("!").trim && (!r.endsWith("!") || d.endsWith("!"))
     }
 
-    val opVars: Map[String, String] = parts.headOption.map(operationVars).getOrElse(Map.empty)
+    // What the splice site declares. An operation declares its variables in the document header; a
+    // subquery declares them in `type VariableDefs`. Both are read (they are never both populated in
+    // practice), so a splice is checked against everything in scope where it happens.
+    val enclosingVariableDefs: Map[String, String] =
+      enclosingSubquery
+        .flatMap(cls => variableDefsOf(cls.typeRef))
+        .map(parseVarDefs)
+        .getOrElse(Map.empty)
+
+    val declaredVars: Map[String, String] =
+      enclosingVariableDefs ++ parts.headOption.map(operationVars).getOrElse(Map.empty)
+
+    // Where the missing declaration has to be added. `name` keeps the module-class `$` suffix for an
+    // `object` subquery, which would only confuse the reader.
+    val declarationSite: String =
+      enclosingSubquery.fold("operation")(cls => s"subquery [${cls.name.stripSuffix("$")}]")
 
     argExprs.foreach { arg =>
-      variableDefsOf(arg).foreach { required =>
+      variableDefsOf(arg.asTerm.tpe).foreach { required =>
         parseVarDefs(required).foreach { case (name, reqType) =>
-          opVars.get(name) match {
-            case None                                       =>
+          declaredVars.get(name) match {
+            case None                                           =>
               report.errorAndAbort(
-                s"gql: operation does not declare variable $$$name required by a spliced subquery (needs $reqType)",
+                s"gql: $declarationSite does not declare variable $$$name required by a spliced subquery (needs $reqType)",
                 arg.asTerm.pos
               )
-            case Some(opType) if !usableAs(opType, reqType) =>
+            case Some(declared) if !usableAs(declared, reqType) =>
               report.errorAndAbort(
-                s"gql: operation declares $$$name: $opType but a spliced subquery requires it usable as $reqType",
+                s"gql: $declarationSite declares $$$name: $declared but a spliced subquery requires it usable as $reqType",
                 arg.asTerm.pos
               )
-            case _                                          => ()
+            case _                                              => ()
           }
         }
       }

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -1,0 +1,135 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import scala.quoted.*
+
+extension (inline sc: StringContext)
+  /**
+   * Builds a GraphQL operation `document`, splicing subqueries inline. At runtime it produces exactly
+   * the string the standard `s"..."` interpolator would. At compile time it runs the *caller-check*:
+   * for every spliced value that declares variables (a `GraphQLSubquery` with a `type Variables`
+   * member), it verifies the operation's `query (...)` header declares each required variable with a
+   * compatible ("usable as") type — reading the requirement straight from the subquery's type, so it
+   * works even when the subquery is shipped in a dependency jar.
+   */
+  inline def gql(inline args: Any*): String = ${ GraphQLInterpolator.gqlImpl('sc, 'args) }
+
+private[clue] object GraphQLInterpolator {
+
+  def gqlImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes): Expr[String] = {
+    import quotes.reflect.*
+
+    val parts: List[String] = scExpr match {
+      case '{ StringContext(${ Varargs(ps) }*) } => ps.map(_.valueOrAbort).toList
+      case _                                     =>
+        report.errorAndAbort("gql: the string parts must be literals")
+    }
+
+    val argExprs: List[Expr[Any]] = argsExpr match {
+      case Varargs(es) => es.toList
+      case _           => report.errorAndAbort("gql: splice arguments must be explicit")
+    }
+
+    // Read a spliced value's `Variables` literal-type member, if it has one (a `GraphQLSubquery`).
+    def variablesOf(arg: Expr[Any]): Option[String] = {
+      val tpe = arg.asTerm.tpe
+      val sym = tpe.typeSymbol.typeMember("Variables")
+      if (sym.isNoSymbol) None
+      else {
+        // A type alias surfaces as `TypeBounds(lo, hi)` with `lo == hi`; read `hi`.
+        val resolved = tpe.memberType(sym) match {
+          case TypeBounds(_, hi) => hi.dealias
+          case other             => other.dealias
+        }
+        resolved match {
+          case ConstantType(StringConstant(s)) => Some(s)
+          case _                               => None
+        }
+      }
+    }
+
+    def splitTopLevel(s: String): List[String] = {
+      val out   = scala.collection.mutable.ListBuffer.empty[String]
+      val cur   = new StringBuilder
+      var depth = 0
+      s.foreach {
+        case '['               => depth += 1; cur += '['
+        case ']'               => depth -= 1; cur += ']'
+        case ',' if depth == 0 => out += cur.toString; cur.clear()
+        case c                 => cur += c
+      }
+      if (cur.nonEmpty) out += cur.toString
+      out.toList
+    }
+
+    // Parse a parenthesized var-def list `($a: T, $b: U)` into name -> GraphQL type.
+    def parseVarDefs(s0: String): Map[String, String] = {
+      val s = s0.trim.stripPrefix("(").stripSuffix(")").trim.replace("$$", "$")
+      if (s.isEmpty) Map.empty
+      else
+        splitTopLevel(s).flatMap { entry =>
+          val e       = entry.trim
+          val nameEnd = e.indexOf(':')
+          if (nameEnd < 0 || !e.startsWith("$")) None
+          else {
+            val name = e.substring(1, nameEnd).trim
+            val tpe  = e.substring(nameEnd + 1).takeWhile(_ != '=').trim
+            Some(name -> tpe)
+          }
+        }.toMap
+    }
+
+    // Extract and parse the operation header `(...)` from `query (...) ...` (the first literal part).
+    def operationVars(header: String): Map[String, String] = {
+      val h    = header.replace("$$", "$")
+      val open = h.indexOf('(')
+      if (open < 0) Map.empty
+      else {
+        var depth = 0; var i = open; var end = -1
+        while (i < h.length && end < 0) {
+          h.charAt(i) match {
+            case '(' => depth += 1
+            case ')' => depth -= 1; if (depth == 0) end = i
+            case _   => ()
+          }
+          i += 1
+        }
+        if (end < 0) Map.empty else parseVarDefs(h.substring(open, end + 1))
+      }
+    }
+
+    // GraphQL "is variable usage allowed": the provided type must be usable where the required type
+    // is expected. Same base type, and a non-null requirement needs a non-null provided type.
+    def usableAs(opType: String, reqType: String): Boolean = {
+      val o = opType.trim; val r = reqType.trim
+      o.stripSuffix("!").trim == r.stripSuffix("!").trim && (!r.endsWith("!") || o.endsWith("!"))
+    }
+
+    val opVars: Map[String, String] = parts.headOption.map(operationVars).getOrElse(Map.empty)
+
+    argExprs.foreach { arg =>
+      variablesOf(arg).foreach { required =>
+        parseVarDefs(required).foreach { case (name, reqType) =>
+          opVars.get(name) match {
+            case None                                       =>
+              report.errorAndAbort(
+                s"gql: operation does not declare variable $$$name required by a spliced subquery (needs $reqType)",
+                arg.asTerm.pos
+              )
+            case Some(opType) if !usableAs(opType, reqType) =>
+              report.errorAndAbort(
+                s"gql: operation declares $$$name: $opType but a spliced subquery requires it usable as $reqType",
+                arg.asTerm.pos
+              )
+            case _                                          => ()
+          }
+        }
+      }
+    }
+
+    // Runtime string: identical to `s"..."`.
+    '{ $scExpr.s(${ Varargs(argExprs) }*) }
+  }
+}

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -5,20 +5,36 @@ package clue
 
 import scala.quoted.*
 
-extension (inline sc: StringContext)
+/**
+ * An assembled GraphQL operation document. The only way to obtain one is the `gql` interpolator, so
+ * an operation's `document` is always run through the compile-time caller-check — a plain `String`
+ * or `s"..."` does not type-check as a `GraphQLDocument`. Read the underlying string with `.value`.
+ */
+opaque type GraphQLDocument = String
+object GraphQLDocument {
+  // `gql"..."` is the validated way to build a document — a plain `String`/`s"..."` won't type-check
+  // as a `GraphQLDocument`. `unsafeFromString` is the explicit escape hatch for documents built by
+  // other means; it skips the caller-check, so prefer `gql`.
+  def unsafeFromString(value: String): GraphQLDocument           = value
+  extension (document:        GraphQLDocument) def value: String = document
+}
+
+extension (inline sc:         StringContext)
   /**
-   * Builds a GraphQL operation `document`, splicing subqueries inline. At runtime it produces exactly
-   * the string the standard `s"..."` interpolator would. At compile time it runs the *caller-check*:
-   * for every spliced value that declares variables (a `GraphQLSubquery` with a `type Variables`
-   * member), it verifies the operation's `query (...)` header declares each required variable with a
-   * compatible ("usable as") type — reading the requirement straight from the subquery's type, so it
-   * works even when the subquery is shipped in a dependency jar.
+   * Builds a GraphQL operation `document`, splicing subqueries inline. At runtime it produces
+   * exactly the string the standard `s"..."` interpolator would. At compile time it runs the
+   * *caller-check*: for every spliced value that declares variables (a `GraphQLSubquery` with a
+   * `type Variables` member), it verifies the operation's `query (...)` header declares each
+   * required variable with a compatible ("usable as") type — reading the requirement straight from
+   * the subquery's type, so it works even when the subquery is shipped in a dependency jar.
    */
-  inline def gql(inline args: Any*): String = ${ GraphQLInterpolator.gqlImpl('sc, 'args) }
+  inline def gql(inline args: Any*): GraphQLDocument = ${ GraphQLInterpolator.gqlImpl('sc, 'args) }
 
 private[clue] object GraphQLInterpolator {
 
-  def gqlImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes): Expr[String] = {
+  def gqlImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using
+    Quotes
+  ): Expr[GraphQLDocument] = {
     import quotes.reflect.*
 
     val parts: List[String] = scExpr match {
@@ -129,7 +145,7 @@ private[clue] object GraphQLInterpolator {
       }
     }
 
-    // Runtime string: identical to `s"..."`.
-    '{ $scExpr.s(${ Varargs(argExprs) }*) }
+    // Runtime string, identical to `s"..."`, wrapped as a GraphQLDocument.
+    '{ GraphQLDocument.unsafeFromString($scExpr.s(${ Varargs(argExprs) }*)) }
   }
 }

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -16,8 +16,22 @@ object GraphQLDocument {
   // `gql"..."` is the validated way to build one — a plain `String`/`s"..."` won't type-check as a
   // `GraphQLDocument`. `unsafeFromString` is the explicit escape hatch for text built by other
   // means; it skips the caller-check, so prefer `gql`.
-  def unsafeFromString(value: String): GraphQLDocument           = value
-  extension (document:        GraphQLDocument) def value: String = document
+  def unsafeFromString(value: String): GraphQLDocument = value
+
+  extension (document: GraphQLDocument) {
+    def value: String = document
+
+    /**
+     * As `String.stripMargin`. It runs on the assembled text, so it also strips margins inside
+     * spliced subqueries — the same as calling `.stripMargin` on an `s"..."` interpolation.
+     */
+    def stripMargin: GraphQLDocument = stripMargin('|')
+
+    def stripMargin(marginChar: Char): GraphQLDocument =
+      // Explicit `StringOps` because inside this file `GraphQLDocument` is `String`, so a bare
+      // `document.stripMargin` would resolve back to this extension.
+      new scala.collection.StringOps(document).stripMargin(marginChar)
+  }
 }
 
 extension (inline sc:         StringContext)

--- a/core/src/main/scala/clue/GraphQLOperation.scala
+++ b/core/src/main/scala/clue/GraphQLOperation.scala
@@ -9,7 +9,7 @@ import io.circe.Encoder
 /*
  * A query, mutation or subscription must extend this trait.
  */
-trait GraphQLOperation[S] {
+trait GraphQLOperation[S] extends GraphQLTextSyntax {
   val document: GraphQLDocument
   type Variables
   type Data

--- a/core/src/main/scala/clue/GraphQLOperation.scala
+++ b/core/src/main/scala/clue/GraphQLOperation.scala
@@ -10,7 +10,7 @@ import io.circe.Encoder
  * A query, mutation or subscription must extend this trait.
  */
 trait GraphQLOperation[S] {
-  val document: String
+  val document: GraphQLDocument
   type Variables
   type Data
 

--- a/core/src/main/scala/clue/GraphQLSubquery.scala
+++ b/core/src/main/scala/clue/GraphQLSubquery.scala
@@ -9,19 +9,26 @@ import io.circe.Decoder
  * A subquery must extend this trait. The GraphQL root type(s) the subquery applies to are declared
  * via the `@clue.annotation.GraphQLType` annotation (used for schema validation), not constructor
  * arguments.
+ *
+ * A subquery that references GraphQL variables declares them in a `type VariableDefs = "(...)"`
+ * member (parenthesized var-defs, operation-header syntax). The member is not declared here: absent
+ * means the subquery references no variables. It is read by name — syntactically by the generator,
+ * and at compile time by the `gql` interpolator, which checks it against every splice site.
  */
 abstract class GraphQLSubquery[S] {
   type Data
 
   val dataDecoder: Decoder[Data]
 
-  val subquery: String
+  // Built with `gql"..."`, which checks that any subquery spliced in here has its variables declared
+  // by this subquery's `VariableDefs`.
+  val subquery: GraphQLDocument
 
   object givens {
     given Decoder[Data] = dataDecoder
   }
 
-  final override def toString = subquery
+  final override def toString = subquery.value
 }
 
 object GraphQLSubquery {

--- a/core/src/main/scala/clue/GraphQLSubquery.scala
+++ b/core/src/main/scala/clue/GraphQLSubquery.scala
@@ -15,7 +15,7 @@ import io.circe.Decoder
  * means the subquery references no variables. It is read by name — syntactically by the generator,
  * and at compile time by the `gql` interpolator, which checks it against every splice site.
  */
-abstract class GraphQLSubquery[S] {
+abstract class GraphQLSubquery[S] extends GraphQLTextSyntax {
   type Data
 
   val dataDecoder: Decoder[Data]

--- a/core/src/main/scala/clue/clients.scala
+++ b/core/src/main/scala/clue/clients.scala
@@ -58,7 +58,7 @@ case class RequestApplied[
 
   def withInput(variables: V, modParams: P => P): F[GraphQLResponse[D]] =
     client.requestInternal(
-      GraphQLQuery(operation.document),
+      GraphQLQuery(operation.document.value),
       operationName,
       variables.asJsonObject.some,
       none,
@@ -68,7 +68,7 @@ case class RequestApplied[
 
   def withModParams(modParams: P => P): F[GraphQLResponse[D]] =
     client.requestInternal(
-      GraphQLQuery(operation.document),
+      GraphQLQuery(operation.document.value),
       operationName,
       none,
       none,
@@ -78,7 +78,7 @@ case class RequestApplied[
 
   def apply: F[GraphQLResponse[D]] =
     client.requestInternal(
-      GraphQLQuery(operation.document),
+      GraphQLQuery(operation.document.value),
       operationName,
       none,
       none,
@@ -139,7 +139,7 @@ case class SubscriptionApplied[
 
   def withInput(variables: V): Resource[F, fs2.Stream[F, GraphQLResponse[D]]] =
     client.subscribeInternal(
-      GraphQLQuery(subscription.document),
+      GraphQLQuery(subscription.document.value),
       operationName,
       variables.asJsonObject.some,
       none,
@@ -148,7 +148,7 @@ case class SubscriptionApplied[
 
   def apply: Resource[F, fs2.Stream[F, GraphQLResponse[D]]] =
     client.subscribeInternal(
-      GraphQLQuery(subscription.document),
+      GraphQLQuery(subscription.document.value),
       operationName,
       none,
       none,

--- a/core/src/test/scala/clue/DescriptorSpec.scala
+++ b/core/src/test/scala/clue/DescriptorSpec.scala
@@ -22,7 +22,7 @@ import munit.CatsEffectSuite
 class DescriptorSpec extends CatsEffectSuite:
 
   private object Op extends GraphQLOperation.Typed[Unit, JsonObject, Json]:
-    val document = "query NamedOp { field }"
+    val document = gql"query NamedOp { field }"
 
   // A client that records the `descriptor` it was handed and answers with an empty response.
   private class Recorder(ref: Ref[IO, Option[Option[String]]]) extends StreamingClient[IO, Unit]:

--- a/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
+++ b/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
@@ -8,13 +8,20 @@ import io.circe.Json
 // A subquery declaring a required variable, used to exercise the `gql` caller-check.
 object InterpolatorTestSub extends GraphQLSubquery.Typed[Unit, Json] {
   type VariableDefs = "($ep: Episode!)"
-  override val subquery: String = "{ hero(episode: $ep) { name } }"
+  override val subquery = gql"{ hero(episode: $$ep) { name } }"
 }
 
 // Declares a NULLABLE variable, to exercise the "usable as" relaxation.
 object InterpolatorTestSubNullable extends GraphQLSubquery.Typed[Unit, Json] {
   type VariableDefs = "($ep: Episode)"
-  override val subquery: String = "{ heroOpt(episode: $ep) { name } }"
+  override val subquery = gql"{ heroOpt(episode: $$ep) { name } }"
+}
+
+// Splices a subquery that requires `$ep`, and declares it: the subquery-into-subquery caller-check
+// reads this `VariableDefs` as the declaration site.
+object InterpolatorTestParent extends GraphQLSubquery.Typed[Unit, Json] {
+  type VariableDefs = "($ep: Episode!)"
+  override val subquery = gql"{ friends $InterpolatorTestSub }"
 }
 
 class GraphQLInterpolatorSuite extends munit.FunSuite {
@@ -43,5 +50,43 @@ class GraphQLInterpolatorSuite extends munit.FunSuite {
     // "usable as": a non-null Episode! is usable where the subquery only needs a nullable Episode.
     val doc = gql"query ($$ep: Episode!) $InterpolatorTestSubNullable"
     assertEquals(doc.value, "query ($ep: Episode!) { heroOpt(episode: $ep) { name } }")
+  }
+
+  test("a subquery splicing a subquery assembles like s-interpolation") {
+    assertEquals(InterpolatorTestParent.subquery.value,
+                 "{ friends { hero(episode: $ep) { name } } }"
+    )
+  }
+
+  test("a subquery that does not declare a spliced subquery's variable is a compile error") {
+    val errors = compileErrors("""
+      object UndeclaringParent extends GraphQLSubquery.Typed[Unit, io.circe.Json] {
+        override val subquery = gql"{ friends $InterpolatorTestSub }"
+      }
+      ()
+    """)
+    assert(errors.contains("does not declare variable $ep"), errors)
+    assert(errors.contains("subquery ["), errors)
+  }
+
+  test("a subquery declaring a spliced subquery's variable at the wrong type is a compile error") {
+    val errors = compileErrors("""
+      object WrongTypeParent extends GraphQLSubquery.Typed[Unit, io.circe.Json] {
+        type VariableDefs = "($ep: String!)"
+        override val subquery = gql"{ friends $InterpolatorTestSub }"
+      }
+      ()
+    """)
+    assert(errors.contains("usable as Episode!"), errors)
+  }
+
+  test("requirements propagate transitively through a nested subquery") {
+    // `InterpolatorTestParent` had to declare `$ep` to splice its child, so an operation splicing
+    // the parent must declare it too.
+    val errors = compileErrors("""gql"query { $InterpolatorTestParent }"""")
+    assert(errors.contains("does not declare variable $ep"), errors)
+
+    val doc = gql"query ($$ep: Episode!) $InterpolatorTestParent"
+    assertEquals(doc.value, "query ($ep: Episode!) { friends { hero(episode: $ep) { name } } }")
   }
 }

--- a/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
+++ b/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
@@ -52,6 +52,13 @@ class GraphQLInterpolatorSuite extends munit.FunSuite {
     assertEquals(doc.value, "query ($ep: Episode!) { heroOpt(episode: $ep) { name } }")
   }
 
+  test("stripMargin strips the assembled document") {
+    val doc = gql"""query {
+                   |  hero
+                   |}""".stripMargin
+    assertEquals(doc.value, "query {\n  hero\n}")
+  }
+
   test("a subquery splicing a subquery assembles like s-interpolation") {
     assertEquals(InterpolatorTestParent.subquery.value,
                  "{ friends { hero(episode: $ep) { name } } }"

--- a/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
+++ b/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
@@ -11,16 +11,22 @@ object InterpolatorTestSub extends GraphQLSubquery.Typed[Unit, Json] {
   override val subquery: String = "{ hero(episode: $ep) { name } }"
 }
 
+// Declares a NULLABLE variable, to exercise the "usable as" relaxation.
+object InterpolatorTestSubNullable extends GraphQLSubquery.Typed[Unit, Json] {
+  type Variables = "($ep: Episode)"
+  override val subquery: String = "{ heroOpt(episode: $ep) { name } }"
+}
+
 class GraphQLInterpolatorSuite extends munit.FunSuite {
 
   test("gql assembles the document like s-interpolation") {
     val doc = gql"query ($$ep: Episode!) $InterpolatorTestSub"
-    assertEquals(doc, "query ($ep: Episode!) { hero(episode: $ep) { name } }")
+    assertEquals(doc.value, "query ($ep: Episode!) { hero(episode: $ep) { name } }")
   }
 
   test("gql passes through a spliced value that declares no variables") {
     val doc = gql"query { hero } trailing ${1}"
-    assertEquals(doc, "query { hero } trailing 1")
+    assertEquals(doc.value, "query { hero } trailing 1")
   }
 
   test("a required variable the operation does not declare is a compile error") {
@@ -34,10 +40,8 @@ class GraphQLInterpolatorSuite extends munit.FunSuite {
   }
 
   test("a non-null operation variable satisfies a nullable requirement") {
-    // Sanity for the "usable as" rule: Episode! is usable where Episode is required.
-    assertEquals(usableProbe, "query ($ep: Episode!) { hero(episode: $ep) { name } }")
+    // "usable as": a non-null Episode! is usable where the subquery only needs a nullable Episode.
+    val doc = gql"query ($$ep: Episode!) $InterpolatorTestSubNullable"
+    assertEquals(doc.value, "query ($ep: Episode!) { heroOpt(episode: $ep) { name } }")
   }
-
-  private val usableProbe: String =
-    gql"query ($$ep: Episode!) $InterpolatorTestSub"
 }

--- a/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
+++ b/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import io.circe.Json
+
+// A subquery declaring a required variable, used to exercise the `gql` caller-check.
+object InterpolatorTestSub extends GraphQLSubquery.Typed[Unit, Json] {
+  type Variables = "($ep: Episode!)"
+  override val subquery: String = "{ hero(episode: $ep) { name } }"
+}
+
+class GraphQLInterpolatorSuite extends munit.FunSuite {
+
+  test("gql assembles the document like s-interpolation") {
+    val doc = gql"query ($$ep: Episode!) $InterpolatorTestSub"
+    assertEquals(doc, "query ($ep: Episode!) { hero(episode: $ep) { name } }")
+  }
+
+  test("gql passes through a spliced value that declares no variables") {
+    val doc = gql"query { hero } trailing ${1}"
+    assertEquals(doc, "query { hero } trailing 1")
+  }
+
+  test("a required variable the operation does not declare is a compile error") {
+    val errors = compileErrors("""gql"query { $InterpolatorTestSub }"""")
+    assert(errors.contains("does not declare variable $ep"), errors)
+  }
+
+  test("a required variable declared with an incompatible type is a compile error") {
+    val errors = compileErrors("""gql"query ($$ep: String!) $InterpolatorTestSub"""")
+    assert(errors.contains("usable as Episode!"), errors)
+  }
+
+  test("a non-null operation variable satisfies a nullable requirement") {
+    // Sanity for the "usable as" rule: Episode! is usable where Episode is required.
+    assertEquals(usableProbe, "query ($ep: Episode!) { hero(episode: $ep) { name } }")
+  }
+
+  private val usableProbe: String =
+    gql"query ($$ep: Episode!) $InterpolatorTestSub"
+}

--- a/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
+++ b/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
@@ -7,13 +7,13 @@ import io.circe.Json
 
 // A subquery declaring a required variable, used to exercise the `gql` caller-check.
 object InterpolatorTestSub extends GraphQLSubquery.Typed[Unit, Json] {
-  type Variables = "($ep: Episode!)"
+  type VariableDefs = "($ep: Episode!)"
   override val subquery: String = "{ hero(episode: $ep) { name } }"
 }
 
 // Declares a NULLABLE variable, to exercise the "usable as" relaxation.
 object InterpolatorTestSubNullable extends GraphQLSubquery.Typed[Unit, Json] {
-  type Variables = "($ep: Episode)"
+  type VariableDefs = "($ep: Episode)"
   override val subquery: String = "{ heroOpt(episode: $ep) { name } }"
 }
 

--- a/gen/input/src/main/scala/test/LucumaMutation.scala
+++ b/gen/input/src/main/scala/test/LucumaMutation.scala
@@ -10,12 +10,13 @@ package test
 
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
+import clue.gql
 
 @GraphQL
 trait LucumaMutation extends GraphQLOperation[LucumaODB] {
-  val document = """
-      mutation DeleteAsterism($asterismId: AsterismId!) {
-        deleteAsterism(asterismId: $asterismId) {
+  val document = gql"""
+      mutation DeleteAsterism($$asterismId: AsterismId!) {
+        deleteAsterism(asterismId: $$asterismId) {
           id
           existence
         }

--- a/gen/input/src/main/scala/test/LucumaMutation.scala
+++ b/gen/input/src/main/scala/test/LucumaMutation.scala
@@ -10,7 +10,6 @@ package test
 
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
-import clue.gql
 
 @GraphQL
 trait LucumaMutation extends GraphQLOperation[LucumaODB] {

--- a/gen/input/src/main/scala/test/LucumaQuery.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL

--- a/gen/input/src/main/scala/test/LucumaQuery.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL
 trait LucumaQuery extends GraphQLOperation[LucumaODB] {
-  val document = """
+  val document = gql"""
       query Program {
         program(programId: "p-2") {
           id

--- a/gen/input/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery2.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL

--- a/gen/input/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery2.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL
 trait LucumaQuery2 extends GraphQLOperation[LucumaODB] {
-  val document = """
+  val document = gql"""
       query Program {
         program(programId: "p-2") {
           id

--- a/gen/input/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery3.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL

--- a/gen/input/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery3.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL
 trait LucumaQuery3 extends GraphQLOperation[LucumaODB] {
-  val document = """
+  val document = gql"""
       query {
         observations(programId: "p-2", first: 2147483647) {
           nodes {

--- a/gen/input/src/main/scala/test/LucumaSubscription.scala
+++ b/gen/input/src/main/scala/test/LucumaSubscription.scala
@@ -10,7 +10,6 @@ package test
 
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
-import clue.gql
 
 @GraphQL
 trait LucumaSubscription extends GraphQLOperation[LucumaODB] {

--- a/gen/input/src/main/scala/test/LucumaSubscription.scala
+++ b/gen/input/src/main/scala/test/LucumaSubscription.scala
@@ -10,12 +10,13 @@ package test
 
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
+import clue.gql
 
 @GraphQL
 trait LucumaSubscription extends GraphQLOperation[LucumaODB] {
-  val document = """
-      subscription AsterismEdit($programId: ProgramId) {
-        asterismEdit(programId: $programId) {
+  val document = gql"""
+      subscription AsterismEdit($$programId: ProgramId) {
+        asterismEdit(programId: $$programId) {
           editType
           value {
             id

--- a/gen/input/src/main/scala/test/StarWarsAnnotatedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsAnnotatedInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 // An annotated (generated) operation with an invalid field. The generator now reports the error as

--- a/gen/input/src/main/scala/test/StarWarsAnnotatedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsAnnotatedInvalid.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 // An annotated (generated) operation with an invalid field. The generator now reports the error as
 // a diagnostic and skips code generation (no output file => linter mode), instead of aborting.
 @GraphQL
 trait StarWarsAnnotatedInvalid extends GraphQLOperation[StarWars] {
-  override val document: String = "query { invalidField }" // assert: GraphQLGen
+  override val document = gql"query { invalidField }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsAnnotatedSubqueryVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsAnnotatedSubqueryVariable.scala
@@ -9,14 +9,16 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
+import io.circe.Json
 
-// A subquery that references a variable (`$ep`), declared via `type VariableDefs`. The declaration is
-// checked against usage (`$ep` feeds `hero(episode: Episode!)`) and the selection is valid, so this
-// must NOT report any diagnostic.
+// An annotated `object` subquery: nothing is generated (it supplies its own `Data` via `.Typed`), but
+// it still references `$ep`, so the generator infers and emits `type VariableDefs` for it, exactly as
+// it does for the subqueries it generates.
+@GraphQL
 @GraphQLType("Query")
-abstract class StarWarsSubqueryWithVariable extends GraphQLSubquery[StarWars] {
-  type VariableDefs = "($ep: Episode!)"
+object StarWarsAnnotatedSubqueryVariable extends GraphQLSubquery.Typed[StarWars, Json] {
   override val subquery = gql"{ hero(episode: $$ep) { name } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsAnnotatedUnderValidate.scala
+++ b/gen/input/src/main/scala/test/StarWarsAnnotatedUnderValidate.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 // Under `GraphQLValidate` (validation only, as used by `clueCheck`), an `@GraphQL` annotation is
@@ -16,6 +17,6 @@ import clue.annotation.GraphQL
 // a warning (it never generates here).
 @GraphQL // assert: GraphQLValidate
 trait StarWarsAnnotatedUnderValidate extends GraphQLOperation[StarWars] {
-  override val document: String = "query { hero(episode: NEWHOPE) { id } }"
+  override val document = gql"query { hero(episode: NEWHOPE) { id } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsAnnotatedUnderValidate.scala
+++ b/gen/input/src/main/scala/test/StarWarsAnnotatedUnderValidate.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 // Under `GraphQLValidate` (validation only, as used by `clueCheck`), an `@GraphQL` annotation is

--- a/gen/input/src/main/scala/test/StarWarsDescriptorQuery.scala
+++ b/gen/input/src/main/scala/test/StarWarsDescriptorQuery.scala
@@ -13,7 +13,6 @@ package test
 import clue.GraphQLDocument
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
-import clue.gql
 
 @GraphQL
 trait StarWarsDescriptorQuery extends GraphQLOperation[StarWars] {

--- a/gen/input/src/main/scala/test/StarWarsDescriptorQuery.scala
+++ b/gen/input/src/main/scala/test/StarWarsDescriptorQuery.scala
@@ -10,14 +10,16 @@
  */
 package test
 
+import clue.GraphQLDocument
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
+import clue.gql
 
 @GraphQL
 trait StarWarsDescriptorQuery extends GraphQLOperation[StarWars] {
-  override val document: String = """
-        query ($charId: ID!) {
-          character(id: $charId) {
+  override val document: GraphQLDocument = gql"""
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             id
             name
           }

--- a/gen/input/src/main/scala/test/StarWarsInclude.scala
+++ b/gen/input/src/main/scala/test/StarWarsInclude.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL

--- a/gen/input/src/main/scala/test/StarWarsInclude.scala
+++ b/gen/input/src/main/scala/test/StarWarsInclude.scala
@@ -9,15 +9,16 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL
 trait StarWarsInclude extends GraphQLOperation[StarWars] {
-  override val document: String = """
-        query ($humanId: ID!, $skipId: Boolean!, $withName: Boolean!) {
-          human(id: $humanId) {
-            id @skip(if: $skipId)
-            name @include(if: $withName)
+  override val document = gql"""
+        query ($$humanId: ID!, $$skipId: Boolean!, $$withName: Boolean!) {
+          human(id: $$humanId) {
+            id @skip(if: $$skipId)
+            name @include(if: $$withName)
             homePlanet
           }
         }

--- a/gen/input/src/main/scala/test/StarWarsManualInterpolated.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualInterpolated.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // A hand-written operation composing a subquery via interpolation. This is valid:
 // `friends` is selected with the spliced subquery. Validation must NOT report an
 // error here (the spliced subquery is validated where it's defined).
 trait StarWarsManualInterpolated extends GraphQLOperation[StarWars] {
-  override val document: String =
-    s"query { hero(episode: NEWHOPE) { id friends $StarWarsSubquery } }"
+  override val document =
+    gql"query { hero(episode: NEWHOPE) { id friends $StarWarsSubquery } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualInterpolated.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualInterpolated.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // A hand-written operation composing a subquery via interpolation. This is valid:
 // `friends` is selected with the spliced subquery. Validation must NOT report an

--- a/gen/input/src/main/scala/test/StarWarsManualInterpolatedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualInterpolatedInvalid.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // A hand-written operation that splices a subquery AND has a genuine error: `invalidField`
 // doesn't exist on `Character`. Validation must still report it (the spliced subquery must not
 // mask the error), so a diagnostic is expected on the document.
 trait StarWarsManualInterpolatedInvalid extends GraphQLOperation[StarWars] {
-  override val document: String =
-    s"query ($$charId: ID!) { character(id: $$charId) { invalidField friends $StarWarsSubquery } }" // assert: GraphQLGen
+  override val document =
+    gql"query ($$charId: ID!) { character(id: $$charId) { invalidField friends $StarWarsSubquery } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualInterpolatedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualInterpolatedInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // A hand-written operation that splices a subquery AND has a genuine error: `invalidField`
 // doesn't exist on `Character`. Validation must still report it (the spliced subquery must not

--- a/gen/input/src/main/scala/test/StarWarsManualInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualInvalid.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // A hand-written operation: the code generator is NOT used here (no @GraphQL
 // annotation), but the document must still be validated against the schema.
 // The query references `invalidField`, which does not exist on the `Query`
 // type, so the validation pass must report a diagnostic.
 trait StarWarsManualInvalid extends GraphQLOperation[StarWars] {
-  override val document: String = "query { invalidField }" // assert: GraphQLGen
+  override val document = gql"query { invalidField }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // A hand-written operation: the code generator is NOT used here (no @GraphQL
 // annotation), but the document must still be validated against the schema.

--- a/gen/input/src/main/scala/test/StarWarsManualParamInterpolated.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualParamInterpolated.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // A hand-written operation with a query parameter AND a spliced subquery. The `$$`
 // escapes the GraphQL variable (so it survives interpolation), while `$StarWarsSubquery`

--- a/gen/input/src/main/scala/test/StarWarsManualParamInterpolated.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualParamInterpolated.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // A hand-written operation with a query parameter AND a spliced subquery. The `$$`
 // escapes the GraphQL variable (so it survives interpolation), while `$StarWarsSubquery`
 // is a real splice. This must validate with NO diagnostic.
 trait StarWarsManualParamInterpolated extends GraphQLOperation[StarWars] {
-  override val document: String =
-    s"query ($$charId: ID!) { character(id: $$charId) { id friends $StarWarsSubquery } }"
+  override val document =
+    gql"query ($$charId: ID!) { character(id: $$charId) { id friends $StarWarsSubquery } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryInvalid.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery using `GraphQLSubquery`. The selection set references
 // `invalidField`, which doesn't exist on `Character`, so validation must report it.
 @GraphQLType("Character")
 abstract class StarWarsManualSubqueryInvalid extends GraphQLSubquery[StarWars] {
-  override val subquery: String = "{ id invalidField }" // assert: GraphQLGen
+  override val subquery = gql"{ id invalidField }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery using `GraphQLSubquery`. The selection set references

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiType.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiType.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiType.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiType.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 
@@ -16,6 +17,6 @@ import io.circe.Json
 // selection `{ id name }` is valid on both `Human` and `Droid`, so this must NOT report a diagnostic.
 @GraphQLType("Human", "Droid")
 abstract class StarWarsManualSubqueryMultiType extends GraphQLSubquery.Typed[StarWars, Json] {
-  override val subquery: String = "{ id name }"
+  override val subquery = gql"{ id name }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiTypeInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiTypeInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiTypeInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryMultiTypeInvalid.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 
@@ -16,6 +17,6 @@ import io.circe.Json
 // `Droid`, so validating the selection against every declared type must report it for `Droid`.
 @GraphQLType("Human", "Droid")
 abstract class StarWarsManualSubqueryMultiTypeInvalid extends GraphQLSubquery.Typed[StarWars, Json] {
-  override val subquery: String = "{ id homePlanet }" // assert: GraphQLGen
+  override val subquery = gql"{ id homePlanet }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery using `GraphQLSubquery.Typed`. The selection set references

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedInvalid.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery using `GraphQLSubquery.Typed`. The selection set references
@@ -16,6 +17,6 @@ import clue.annotation.GraphQLType
 @GraphQLType("Character")
 abstract class StarWarsManualSubqueryTypedInvalid
     extends GraphQLSubquery.Typed[StarWars, Int] {
-  override val subquery: String = "{ id invalidField }" // assert: GraphQLGen
+  override val subquery = gql"{ id invalidField }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedValid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery using `GraphQLSubquery.Typed` with a valid selection set on

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryTypedValid.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery using `GraphQLSubquery.Typed` with a valid selection set on
@@ -16,6 +17,6 @@ import clue.annotation.GraphQLType
 @GraphQLType("Character")
 abstract class StarWarsManualSubqueryTypedValid
     extends GraphQLSubquery.Typed[StarWars, Int] {
-  override val subquery: String = "{ id name }"
+  override val subquery = gql"{ id name }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryValid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery with a valid selection set on `Character`. Validation must

--- a/gen/input/src/main/scala/test/StarWarsManualSubqueryValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualSubqueryValid.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // Hand-written subquery with a valid selection set on `Character`. Validation must
 // NOT report any diagnostic; an unexpected diagnostic would fail this testkit case.
 @GraphQLType("Character")
 abstract class StarWarsManualSubqueryValid extends GraphQLSubquery[StarWars] {
-  override val subquery: String = "{ id name }"
+  override val subquery = gql"{ id name }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualTypedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualTypedInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // Hand-written operation using `GraphQLOperation.Typed`. The document references
 // `invalidField`, which doesn't exist on `Query`, so validation must report it.

--- a/gen/input/src/main/scala/test/StarWarsManualTypedInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualTypedInvalid.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // Hand-written operation using `GraphQLOperation.Typed`. The document references
 // `invalidField`, which doesn't exist on `Query`, so validation must report it.
 abstract class StarWarsManualTypedInvalid
     extends GraphQLOperation.Typed[StarWars, Map[String, Int], Int] {
-  override val document: String = "query { invalidField }" // assert: GraphQLGen
+  override val document = gql"query { invalidField }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualTypedValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualTypedValid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // Hand-written operation using `GraphQLOperation.Typed` with a valid document.
 // Validation must NOT report any diagnostic.

--- a/gen/input/src/main/scala/test/StarWarsManualTypedValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualTypedValid.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // Hand-written operation using `GraphQLOperation.Typed` with a valid document.
 // Validation must NOT report any diagnostic.
 abstract class StarWarsManualTypedValid
     extends GraphQLOperation.Typed[StarWars, Map[String, Int], Int] {
-  override val document: String = "query { hero(episode: NEWHOPE) { id name } }"
+  override val document = gql"query { hero(episode: NEWHOPE) { id name } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualValid.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // A hand-written operation (no @GraphQL annotation) with a valid document.
 // The validation pass must NOT report any diagnostic; an unexpected diagnostic
 // would fail this testkit case.
 trait StarWarsManualValid extends GraphQLOperation[StarWars] {
-  override val document: String = "query { hero(episode: NEWHOPE) { id name } }"
+  override val document = gql"query { hero(episode: NEWHOPE) { id name } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsManualValid.scala
+++ b/gen/input/src/main/scala/test/StarWarsManualValid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // A hand-written operation (no @GraphQL annotation) with a valid document.
 // The validation pass must NOT report any diagnostic; an unexpected diagnostic

--- a/gen/input/src/main/scala/test/StarWarsNestedSubquery.scala
+++ b/gen/input/src/main/scala/test/StarWarsNestedSubquery.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 
@@ -16,7 +17,7 @@ import clue.annotation.GraphQLType
 @GraphQLType("Character")
 abstract class StarWarsNestedSubquery extends GraphQLSubquery[StarWars] {
 
-  override val subquery: String = s"""
+  override val subquery = gql"""
         {
           id
           name

--- a/gen/input/src/main/scala/test/StarWarsNestedSubquery.scala
+++ b/gen/input/src/main/scala/test/StarWarsNestedSubquery.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 

--- a/gen/input/src/main/scala/test/StarWarsNestedSubqueryVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsNestedSubqueryVariable.scala
@@ -10,7 +10,6 @@ package test
 
 import clue.GraphQLOperation
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 

--- a/gen/input/src/main/scala/test/StarWarsNestedSubqueryVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsNestedSubqueryVariable.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.GraphQLSubquery
+import clue.gql
+import clue.annotation.GraphQLType
+import io.circe.Json
+
+// A subquery referencing a variable (in a directive, the only argument a `Character` field takes in
+// this schema), declared via `type VariableDefs`.
+@GraphQLType("Character")
+object StarWarsSubqueryDirectiveVariable extends GraphQLSubquery.Typed[StarWars, Json] {
+  type VariableDefs = "($skipId: Boolean!)"
+  override val subquery = gql"{ id @skip(if: $$skipId) name }"
+}
+
+// A subquery that splices the one above: `gql` requires it to declare the child's variable in its own
+// `VariableDefs`, even though its own text doesn't reference it. The self-check must not report the
+// declaration as unused.
+@GraphQLType("Character")
+object StarWarsNestedSubqueryVariable extends GraphQLSubquery.Typed[StarWars, Json] {
+  type VariableDefs = "($skipId: Boolean!)"
+  override val subquery = gql"{ name friends $StarWarsSubqueryDirectiveVariable }"
+}
+
+// And the operation must declare it too: the requirement propagates transitively, because the parent
+// subquery had to declare it to splice its child.
+trait StarWarsNestedVariableQuery extends GraphQLOperation[StarWars] {
+  override val document =
+    gql"query ($$skipId: Boolean!) { hero(episode: NEWHOPE) $StarWarsNestedSubqueryVariable }"
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL // assert: GraphQLGen

--- a/gen/input/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery.scala
@@ -9,13 +9,14 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL // assert: GraphQLGen
 trait StarWarsQuery extends GraphQLOperation[StarWars] {
-  override val document: String = """
-        query ($charId: ID!) {
-          character(id: $charId) {
+  override val document = gql"""
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             id
             name
             ... on Human {

--- a/gen/input/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery2.scala
@@ -10,13 +10,14 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 // gql: import japgolly.scalajs.react.Dummy._
 
 object Wrapper /* gql: extends Something */ {
   @GraphQL // assert: GraphQLGen
   trait StarWarsQuery2 extends GraphQLOperation[StarWars] {
-  override val document: String = """
+  override val document = gql"""
         fragment fields on Character {
           id
           name
@@ -30,8 +31,8 @@ object Wrapper /* gql: extends Something */ {
             primaryFunction
           }
         }
-        query ($charId: ID!) {
-          character(id: $charId) {
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             ...fields
           }
         }

--- a/gen/input/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery2.scala
@@ -10,7 +10,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 // gql: import japgolly.scalajs.react.Dummy._
 

--- a/gen/input/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery3.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL // assert: GraphQLGen

--- a/gen/input/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery3.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL // assert: GraphQLGen
 trait StarWarsQuery3 extends GraphQLOperation[StarWars] {
-  override val document: String = s"""
+  override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) {
             id

--- a/gen/input/src/main/scala/test/StarWarsQuery4.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery4.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL

--- a/gen/input/src/main/scala/test/StarWarsQuery4.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery4.scala
@@ -9,11 +9,12 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 @GraphQL
 trait StarWarsQuery4 extends GraphQLOperation[StarWars] {
-  override val document: String = s"""
+  override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) $StarWarsNestedSubquery
         }

--- a/gen/input/src/main/scala/test/StarWarsSubquery.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubquery.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 
@@ -16,7 +17,7 @@ import clue.annotation.GraphQLType
 @GraphQLType("Character")
 abstract class StarWarsSubquery extends GraphQLSubquery[StarWars] {
 
-  override val subquery: String = """
+  override val subquery = gql"""
         {
           name
         }

--- a/gen/input/src/main/scala/test/StarWarsSubquery.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubquery.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 

--- a/gen/input/src/main/scala/test/StarWarsSubquery2.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubquery2.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 import io.circe.Json
@@ -17,7 +18,7 @@ import io.circe.Json
 @GraphQLType("Character")
 object StarWarsSubquery2 extends GraphQLSubquery.Typed[StarWars, Json] {
 
-  override val subquery: String = """
+  override val subquery = gql"""
         {
           name
         }

--- a/gen/input/src/main/scala/test/StarWarsSubquery2.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubquery2.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 import io.circe.Json

--- a/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -9,14 +9,17 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 
-// A subquery that references a variable (`$ep`), declared via `type Variables`. The declaration is
-// checked against usage (`$ep` feeds `hero(episode: Episode!)`) and the selection is valid, so this
-// must NOT report any diagnostic.
+// A generated subquery that references `$ep` without declaring it: the generator infers the variable
+// from usage (`hero(episode: Episode!)`) and emits `type Variables = "($ep: Episode!)"`.
+@GraphQL
 @GraphQLType("Query")
-abstract class StarWarsSubqueryWithVariable extends GraphQLSubquery[StarWars] {
-  type Variables = "($ep: Episode!)"
+abstract class StarWarsSubqueryInferVariable extends GraphQLSubquery[StarWars] {
   override val subquery: String = "{ hero(episode: $ep) { name } }"
 }
+
+@clue.annotation.GraphQLStub
+object StarWarsSubqueryInferVariable
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 

--- a/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -13,7 +13,7 @@ import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 
 // A generated subquery that references `$ep` without declaring it: the generator infers the variable
-// from usage (`hero(episode: Episode!)`) and emits `type Variables = "($ep: Episode!)"`.
+// from usage (`hero(episode: Episode!)`) and emits `type VariableDefs = "($ep: Episode!)"`.
 @GraphQL
 @GraphQLType("Query")
 abstract class StarWarsSubqueryInferVariable extends GraphQLSubquery[StarWars] {

--- a/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 
@@ -17,7 +18,7 @@ import clue.annotation.GraphQLType
 @GraphQL
 @GraphQLType("Query")
 abstract class StarWarsSubqueryInferVariable extends GraphQLSubquery[StarWars] {
-  override val subquery: String = "{ hero(episode: $ep) { name } }"
+  override val subquery = gql"{ hero(episode: $$ep) { name } }"
 }
 
 @clue.annotation.GraphQLStub

--- a/gen/input/src/main/scala/test/StarWarsSubqueryMultiTypeGenerated.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryMultiTypeGenerated.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 
@@ -17,6 +18,6 @@ import clue.annotation.GraphQLType
 @GraphQL // assert: GraphQLGen
 @GraphQLType("Human", "Droid")
 abstract class StarWarsSubqueryMultiTypeGenerated extends GraphQLSubquery[StarWars] {
-  override val subquery: String = "{ id name }"
+  override val subquery = gql"{ id name }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryMultiTypeGenerated.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryMultiTypeGenerated.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 

--- a/gen/input/src/main/scala/test/StarWarsSubqueryNoType.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryNoType.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import io.circe.Json
 
 // A hand-written subquery with no `@GraphQLType` annotation: the root type can't be determined, so

--- a/gen/input/src/main/scala/test/StarWarsSubqueryNoType.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryNoType.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import io.circe.Json
 
 // A hand-written subquery with no `@GraphQLType` annotation: the root type can't be determined, so
 // the selection can't be validated — a warning is reported (anchored at the definition) instead of
 // silently skipping.
 abstract class StarWarsSubqueryNoType extends GraphQLSubquery.Typed[StarWars, Json] { // assert: GraphQLGen
-  override val subquery: String = "{ id name }"
+  override val subquery = gql"{ id name }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
@@ -11,7 +11,7 @@ package test
 import clue.GraphQLSubquery
 import clue.annotation.GraphQLType
 
-// A subquery that uses `$ep` but does NOT declare it via `type Variables`. Under the stricter check
+// A subquery that uses `$ep` but does NOT declare it via `type VariableDefs`. Under the stricter check
 // (variables must be declared) this is an undefined-variable error.
 @GraphQLType("Query")
 abstract class StarWarsSubqueryUndeclaredVariable extends GraphQLSubquery[StarWars] {

--- a/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // A subquery that uses `$ep` but does NOT declare it via `type VariableDefs`. Under the stricter check

--- a/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQLType
+
+// A subquery that uses `$ep` but does NOT declare it via `type Variables`. Under the stricter check
+// (variables must be declared) this is an undefined-variable error.
+@GraphQLType("Query")
+abstract class StarWarsSubqueryUndeclaredVariable extends GraphQLSubquery[StarWars] {
+  override val subquery: String = "{ hero(episode: $ep) { name } }" // assert: GraphQLGen
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryUndeclaredVariable.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // A subquery that uses `$ep` but does NOT declare it via `type VariableDefs`. Under the stricter check
 // (variables must be declared) this is an undefined-variable error.
 @GraphQLType("Query")
 abstract class StarWarsSubqueryUndeclaredVariable extends GraphQLSubquery[StarWars] {
-  override val subquery: String = "{ hero(episode: $ep) { name } }" // assert: GraphQLGen
+  override val subquery = gql"{ hero(episode: $$ep) { name } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
@@ -11,12 +11,12 @@ package test
 import clue.GraphQLSubquery
 import clue.annotation.GraphQLType
 
-// A subquery that declares `$ep` via `type Variables` AND has a genuine error (`invalidField`
+// A subquery that declares `$ep` via `type VariableDefs` AND has a genuine error (`invalidField`
 // doesn't exist on `Character`). The declared variable is fine; field validation must still run and
 // report the invalid field (the only diagnostic).
 @GraphQLType("Query")
 abstract class StarWarsSubqueryVariableInvalidField extends GraphQLSubquery[StarWars] {
-  type Variables = "($ep: Episode!)"
+  type VariableDefs = "($ep: Episode!)"
   override val subquery: String = "{ hero(episode: $ep) { invalidField } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // A subquery that declares `$ep` via `type VariableDefs` AND has a genuine error (`invalidField`
@@ -17,6 +18,6 @@ import clue.annotation.GraphQLType
 @GraphQLType("Query")
 abstract class StarWarsSubqueryVariableInvalidField extends GraphQLSubquery[StarWars] {
   type VariableDefs = "($ep: Episode!)"
-  override val subquery: String = "{ hero(episode: $ep) { invalidField } }" // assert: GraphQLGen
+  override val subquery = gql"{ hero(episode: $$ep) { invalidField } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
@@ -11,11 +11,12 @@ package test
 import clue.GraphQLSubquery
 import clue.annotation.GraphQLType
 
-// A subquery that references a variable (`$ep`) AND has a genuine error (`invalidField` doesn't
-// exist on `Character`). The variable must not be reported as undefined, but field validation must
-// still run and report the invalid field.
+// A subquery that declares `$ep` via `type Variables` AND has a genuine error (`invalidField`
+// doesn't exist on `Character`). The declared variable is fine; field validation must still run and
+// report the invalid field (the only diagnostic).
 @GraphQLType("Query")
 abstract class StarWarsSubqueryVariableInvalidField extends GraphQLSubquery[StarWars] {
+  type Variables = "($ep: Episode!)"
   override val subquery: String = "{ hero(episode: $ep) { invalidField } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryVariableInvalidField.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // A subquery that declares `$ep` via `type VariableDefs` AND has a genuine error (`invalidField`

--- a/gen/input/src/main/scala/test/StarWarsSubqueryWithVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryWithVariable.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // A subquery that references a variable (`$ep`), declared via `type VariableDefs`. The declaration is
@@ -17,6 +18,6 @@ import clue.annotation.GraphQLType
 @GraphQLType("Query")
 abstract class StarWarsSubqueryWithVariable extends GraphQLSubquery[StarWars] {
   type VariableDefs = "($ep: Episode!)"
-  override val subquery: String = "{ hero(episode: $ep) { name } }"
+  override val subquery = gql"{ hero(episode: $$ep) { name } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryWithVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryWithVariable.scala
@@ -11,12 +11,12 @@ package test
 import clue.GraphQLSubquery
 import clue.annotation.GraphQLType
 
-// A subquery that references a variable (`$ep`), declared via `type Variables`. The declaration is
+// A subquery that references a variable (`$ep`), declared via `type VariableDefs`. The declaration is
 // checked against usage (`$ep` feeds `hero(episode: Episode!)`) and the selection is valid, so this
 // must NOT report any diagnostic.
 @GraphQLType("Query")
 abstract class StarWarsSubqueryWithVariable extends GraphQLSubquery[StarWars] {
-  type Variables = "($ep: Episode!)"
+  type VariableDefs = "($ep: Episode!)"
   override val subquery: String = "{ hero(episode: $ep) { name } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQLType
+
+// A subquery declaring `$ep: String!` but using it where `Episode!` is required (`hero(episode:)`).
+// The declared variable type is incompatible with its usage — an error.
+@GraphQLType("Query")
+abstract class StarWarsSubqueryWrongVariableType extends GraphQLSubquery[StarWars] {
+  type Variables = "($ep: String!)"
+  override val subquery: String = "{ hero(episode: $ep) { name } }" // assert: GraphQLGen
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // A subquery declaring `$ep: String!` but using it where `Episode!` is required (`hero(episode:)`).

--- a/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
@@ -15,7 +15,7 @@ import clue.annotation.GraphQLType
 // The declared variable type is incompatible with its usage — an error.
 @GraphQLType("Query")
 abstract class StarWarsSubqueryWrongVariableType extends GraphQLSubquery[StarWars] {
-  type Variables = "($ep: String!)"
+  type VariableDefs = "($ep: String!)"
   override val subquery: String = "{ hero(episode: $ep) { name } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryWrongVariableType.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // A subquery declaring `$ep: String!` but using it where `Episode!` is required (`hero(episode:)`).
@@ -16,6 +17,6 @@ import clue.annotation.GraphQLType
 @GraphQLType("Query")
 abstract class StarWarsSubqueryWrongVariableType extends GraphQLSubquery[StarWars] {
   type VariableDefs = "($ep: String!)"
-  override val subquery: String = "{ hero(episode: $ep) { name } }" // assert: GraphQLGen
+  override val subquery = gql"{ hero(episode: $$ep) { name } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsTypeOnOperation.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypeOnOperation.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQLType
 
 // `@GraphQLType` declares a subquery's root type; it is meaningless on a `GraphQLOperation` and must

--- a/gen/input/src/main/scala/test/StarWarsTypeOnOperation.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypeOnOperation.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQLType
 
 // `@GraphQLType` declares a subquery's root type; it is meaningless on a `GraphQLOperation` and must
 // be reported as an error.
 @GraphQLType("Query") // assert: GraphQLGen
 abstract class StarWarsTypeOnOperation extends GraphQLOperation[StarWars] {
-  override val document: String = "query { hero(episode: NEWHOPE) { id } }"
+  override val document = gql"query { hero(episode: NEWHOPE) { id } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 import io.circe.Json
@@ -20,7 +21,7 @@ import io.circe.Json
 @GraphQLType("Droid")
 object StarWarsTypedSubqueryAnnotatedDeprecated
     extends GraphQLSubquery.Typed[StarWars, Json] {
-  override val subquery: String = """
+  override val subquery = gql"""
         {
           primaryFunction
         }

--- a/gen/input/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 import io.circe.Json

--- a/gen/input/src/main/scala/test/StarWarsTypedSubqueryObjectInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypedSubqueryObjectInvalid.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 

--- a/gen/input/src/main/scala/test/StarWarsTypedSubqueryObjectInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypedSubqueryObjectInvalid.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 
@@ -17,6 +18,6 @@ import io.circe.Json
 // must report it.
 @GraphQLType("Character")
 object StarWarsTypedSubqueryObjectInvalid extends GraphQLSubquery.Typed[StarWars, Json] {
-  override val subquery: String = "{ id invalidField }" // assert: GraphQLGen
+  override val subquery = gql"{ id invalidField }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsTypedSubqueryScala3.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypedSubqueryScala3.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 

--- a/gen/input/src/main/scala/test/StarWarsTypedSubqueryScala3.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypedSubqueryScala3.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 
@@ -16,5 +17,5 @@ import io.circe.Json
 // real usage. `invalidField` doesn't exist on `Character`, so validation must report it.
 @GraphQLType("Character")
 object StarWarsTypedSubqueryScala3 extends GraphQLSubquery.Typed[StarWars, Json]:
-  override val subquery: String = "{ id invalidField }" // assert: GraphQLGen
+  override val subquery = gql"{ id invalidField }" // assert: GraphQLGen
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsUnusedVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsUnusedVariable.scala
@@ -9,12 +9,13 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 // Unused-variable detection is disabled because grackle's `collectValueRefs` overwrites instead of
 // accumulating variable references, falsely flagging variables that appear alongside others (e.g.
 // several `$var` fields in one input object). So even this genuinely-unused `$unused` must NOT
 // produce a diagnostic.
 trait StarWarsUnusedVariable extends GraphQLOperation[StarWars] {
-  override val document: String = "query ($unused: ID!) { hero(episode: NEWHOPE) { id } }"
+  override val document = gql"query ($$unused: ID!) { hero(episode: NEWHOPE) { id } }"
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsUnusedVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsUnusedVariable.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 // Unused-variable detection is disabled because grackle's `collectValueRefs` overwrites instead of
 // accumulating variable references, falsely flagging variables that appear alongside others (e.g.

--- a/gen/input/src/main/scala/test/UsesMissingSchema.scala
+++ b/gen/input/src/main/scala/test/UsesMissingSchema.scala
@@ -9,7 +9,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 // A schema type with no corresponding `<name>.graphql` in `schemaDirs`. Loading it fails; that is

--- a/gen/input/src/main/scala/test/UsesMissingSchema.scala
+++ b/gen/input/src/main/scala/test/UsesMissingSchema.scala
@@ -9,6 +9,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 // A schema type with no corresponding `<name>.graphql` in `schemaDirs`. Loading it fails; that is
@@ -18,6 +19,6 @@ trait NoSuchSchema
 
 @GraphQL // assert: GraphQLGen
 trait UsesMissingSchema extends GraphQLOperation[NoSuchSchema] {
-  override val document: String = "query { whatever }"
+  override val document = gql"query { whatever }"
 }
 // format: on

--- a/gen/output/src/main/scala/test/LucumaMutation.scala
+++ b/gen/output/src/main/scala/test/LucumaMutation.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object LucumaMutation extends GraphQLOperation[LucumaODB] {
@@ -15,9 +16,9 @@ object LucumaMutation extends GraphQLOperation[LucumaODB] {
   ignoreUnusedImportEnums()
   import LucumaODB.Types._
   ignoreUnusedImportTypes()
-  val document = """
-      mutation DeleteAsterism($asterismId: AsterismId!) {
-        deleteAsterism(asterismId: $asterismId) {
+  val document = gql"""
+      mutation DeleteAsterism($$asterismId: AsterismId!) {
+        deleteAsterism(asterismId: $$asterismId) {
           id
           existence
         }

--- a/gen/output/src/main/scala/test/LucumaMutation.scala
+++ b/gen/output/src/main/scala/test/LucumaMutation.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object LucumaMutation extends GraphQLOperation[LucumaODB] {

--- a/gen/output/src/main/scala/test/LucumaQuery.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object LucumaQuery extends GraphQLOperation[LucumaODB] {
@@ -15,7 +16,7 @@ object LucumaQuery extends GraphQLOperation[LucumaODB] {
   ignoreUnusedImportEnums()
   import LucumaODB.Types._
   ignoreUnusedImportTypes()
-  val document = """
+  val document = gql"""
       query Program {
         program(programId: "p-2") {
           id

--- a/gen/output/src/main/scala/test/LucumaQuery.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object LucumaQuery extends GraphQLOperation[LucumaODB] {

--- a/gen/output/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery2.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object LucumaQuery2 extends GraphQLOperation[LucumaODB] {

--- a/gen/output/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery2.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object LucumaQuery2 extends GraphQLOperation[LucumaODB] {
@@ -15,7 +16,7 @@ object LucumaQuery2 extends GraphQLOperation[LucumaODB] {
   ignoreUnusedImportEnums()
   import LucumaODB.Types._
   ignoreUnusedImportTypes()
-  val document = """
+  val document = gql"""
       query Program {
         program(programId: "p-2") {
           id

--- a/gen/output/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery3.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
@@ -15,7 +16,7 @@ object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
   ignoreUnusedImportEnums()
   import LucumaODB.Types._
   ignoreUnusedImportTypes()
-  val document = """
+  val document = gql"""
       query {
         observations(programId: "p-2", first: 2147483647) {
           nodes {

--- a/gen/output/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery3.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object LucumaQuery3 extends GraphQLOperation[LucumaODB] {

--- a/gen/output/src/main/scala/test/LucumaSubscription.scala
+++ b/gen/output/src/main/scala/test/LucumaSubscription.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object LucumaSubscription extends GraphQLOperation[LucumaODB] {

--- a/gen/output/src/main/scala/test/LucumaSubscription.scala
+++ b/gen/output/src/main/scala/test/LucumaSubscription.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object LucumaSubscription extends GraphQLOperation[LucumaODB] {
@@ -15,9 +16,9 @@ object LucumaSubscription extends GraphQLOperation[LucumaODB] {
   ignoreUnusedImportEnums()
   import LucumaODB.Types._
   ignoreUnusedImportTypes()
-  val document = """
-      subscription AsterismEdit($programId: ProgramId) {
-        asterismEdit(programId: $programId) {
+  val document = gql"""
+      subscription AsterismEdit($$programId: ProgramId) {
+        asterismEdit(programId: $$programId) {
           editType
           value {
             id

--- a/gen/output/src/main/scala/test/StarWarsAnnotatedSubqueryVariable.scala
+++ b/gen/output/src/main/scala/test/StarWarsAnnotatedSubqueryVariable.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQLType
+import io.circe.Json
+
+// An annotated `object` subquery: nothing is generated (it supplies its own `Data` via `.Typed`), but
+// it still references `$ep`, so the generator infers and emits `type VariableDefs` for it, exactly as
+// it does for the subqueries it generates.
+
+@GraphQLType("Query") object StarWarsAnnotatedSubqueryVariable extends GraphQLSubquery.Typed[StarWars, Json] {
+  type VariableDefs = "($ep: Episode!)"
+  override val subquery = gql"{ hero(episode: $$ep) { name } }"
+}
+// format: on

--- a/gen/output/src/main/scala/test/StarWarsDescriptorQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsDescriptorQuery.scala
@@ -7,7 +7,6 @@ package test
 
 import clue.GraphQLDocument
 import clue.GraphQLOperation
-import clue.gql
 
 
 object StarWarsDescriptorQuery extends GraphQLOperation[StarWars] {

--- a/gen/output/src/main/scala/test/StarWarsDescriptorQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsDescriptorQuery.scala
@@ -5,7 +5,9 @@
 
 package test
 
+import clue.GraphQLDocument
 import clue.GraphQLOperation
+import clue.gql
 
 
 object StarWarsDescriptorQuery extends GraphQLOperation[StarWars] {
@@ -15,9 +17,9 @@ object StarWarsDescriptorQuery extends GraphQLOperation[StarWars] {
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  override val document: String = """
-        query ($charId: ID!) {
-          character(id: $charId) {
+  override val document: GraphQLDocument = gql"""
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             id
             name
           }

--- a/gen/output/src/main/scala/test/StarWarsInclude.scala
+++ b/gen/output/src/main/scala/test/StarWarsInclude.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object StarWarsInclude extends GraphQLOperation[StarWars] {
@@ -15,11 +16,11 @@ object StarWarsInclude extends GraphQLOperation[StarWars] {
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  override val document: String = """
-        query ($humanId: ID!, $skipId: Boolean!, $withName: Boolean!) {
-          human(id: $humanId) {
-            id @skip(if: $skipId)
-            name @include(if: $withName)
+  override val document = gql"""
+        query ($$humanId: ID!, $$skipId: Boolean!, $$withName: Boolean!) {
+          human(id: $$humanId) {
+            id @skip(if: $$skipId)
+            name @include(if: $$withName)
             homePlanet
           }
         }

--- a/gen/output/src/main/scala/test/StarWarsInclude.scala
+++ b/gen/output/src/main/scala/test/StarWarsInclude.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object StarWarsInclude extends GraphQLOperation[StarWars] {

--- a/gen/output/src/main/scala/test/StarWarsNestedSubquery.scala
+++ b/gen/output/src/main/scala/test/StarWarsNestedSubquery.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 

--- a/gen/output/src/main/scala/test/StarWarsNestedSubquery.scala
+++ b/gen/output/src/main/scala/test/StarWarsNestedSubquery.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 
@@ -16,7 +17,7 @@ import clue.annotation.GraphQLType
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  override val subquery: String = s"""
+  override val subquery = gql"""
         {
           id
           name

--- a/gen/output/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object StarWarsQuery extends GraphQLOperation[StarWars] {

--- a/gen/output/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object StarWarsQuery extends GraphQLOperation[StarWars] {
@@ -15,9 +16,9 @@ object StarWarsQuery extends GraphQLOperation[StarWars] {
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  override val document: String = """
-        query ($charId: ID!) {
-          character(id: $charId) {
+  override val document = gql"""
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             id
             name
             ... on Human {

--- a/gen/output/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery2.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import japgolly.scalajs.react.Dummy._
 
 object Wrapper extends Something {
@@ -17,7 +18,7 @@ object Wrapper extends Something {
     ignoreUnusedImportEnums()
     import StarWars.Types._
     ignoreUnusedImportTypes()
-    override val document: String = """
+    override val document = gql"""
           fragment fields on Character {
             id
             name
@@ -31,8 +32,8 @@ object Wrapper extends Something {
               primaryFunction
             }
           }
-          query ($charId: ID!) {
-            character(id: $charId) {
+          query ($$charId: ID!) {
+            character(id: $$charId) {
               ...fields
             }
           }

--- a/gen/output/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery2.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import japgolly.scalajs.react.Dummy._
 
 object Wrapper extends Something {

--- a/gen/output/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery3.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object StarWarsQuery3 extends GraphQLOperation[StarWars] {

--- a/gen/output/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery3.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object StarWarsQuery3 extends GraphQLOperation[StarWars] {
@@ -15,7 +16,7 @@ object StarWarsQuery3 extends GraphQLOperation[StarWars] {
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  override val document: String = s"""
+  override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) {
             id

--- a/gen/output/src/main/scala/test/StarWarsQuery4.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery4.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 
 
 object StarWarsQuery4 extends GraphQLOperation[StarWars] {
@@ -15,7 +16,7 @@ object StarWarsQuery4 extends GraphQLOperation[StarWars] {
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  override val document: String = s"""
+  override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) $StarWarsNestedSubquery
         }

--- a/gen/output/src/main/scala/test/StarWarsQuery4.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery4.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 
 
 object StarWarsQuery4 extends GraphQLOperation[StarWars] {

--- a/gen/output/src/main/scala/test/StarWarsSubquery.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubquery.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 

--- a/gen/output/src/main/scala/test/StarWarsSubquery.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubquery.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 
@@ -16,7 +17,7 @@ import clue.annotation.GraphQLType
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  override val subquery: String = """
+  override val subquery = gql"""
         {
           name
         }

--- a/gen/output/src/main/scala/test/StarWarsSubquery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubquery2.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 

--- a/gen/output/src/main/scala/test/StarWarsSubquery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubquery2.scala
@@ -6,12 +6,13 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 
 
 @GraphQLType("Character") object StarWarsSubquery2 extends GraphQLSubquery.Typed[StarWars, Json] {
-  override val subquery: String = """
+  override val subquery = gql"""
         {
           name
         }

--- a/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 // A generated subquery that references `$ep` without declaring it: the generator infers the variable

--- a/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 // A generated subquery that references `$ep` without declaring it: the generator infers the variable
@@ -19,7 +20,7 @@ import clue.annotation.GraphQLType
   import StarWars.Types._
   ignoreUnusedImportTypes()
   type VariableDefs = "($ep: Episode!)"
-  override val subquery: String = "{ hero(episode: $ep) { name } }"
+  override val subquery = gql"{ hero(episode: $$ep) { name } }"
   case class Data(val hero: Data.Hero)
   object Data {
     case class Hero(val name: Option[String] = None)

--- a/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -9,7 +9,7 @@ import clue.GraphQLSubquery
 import clue.annotation.GraphQLType
 
 // A generated subquery that references `$ep` without declaring it: the generator infers the variable
-// from usage (`hero(episode: Episode!)`) and emits `type Variables = "($ep: Episode!)"`.
+// from usage (`hero(episode: Episode!)`) and emits `type VariableDefs = "($ep: Episode!)"`.
 
 @GraphQLType("Query") object StarWarsSubqueryInferVariable extends GraphQLSubquery[StarWars] {
   import StarWars.Scalars._
@@ -18,7 +18,7 @@ import clue.annotation.GraphQLType
   ignoreUnusedImportEnums()
   import StarWars.Types._
   ignoreUnusedImportTypes()
-  type Variables = "($ep: Episode!)"
+  type VariableDefs = "($ep: Episode!)"
   override val subquery: String = "{ hero(episode: $ep) { name } }"
   case class Data(val hero: Data.Hero)
   object Data {

--- a/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
+++ b/gen/output/src/main/scala/test/StarWarsSubqueryInferVariable.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQLType
+
+// A generated subquery that references `$ep` without declaring it: the generator infers the variable
+// from usage (`hero(episode: Episode!)`) and emits `type Variables = "($ep: Episode!)"`.
+
+@GraphQLType("Query") object StarWarsSubqueryInferVariable extends GraphQLSubquery[StarWars] {
+  import StarWars.Scalars._
+  ignoreUnusedImportScalars()
+  import StarWars.Enums._
+  ignoreUnusedImportEnums()
+  import StarWars.Types._
+  ignoreUnusedImportTypes()
+  type Variables = "($ep: Episode!)"
+  override val subquery: String = "{ hero(episode: $ep) { name } }"
+  case class Data(val hero: Data.Hero)
+  object Data {
+    case class Hero(val name: Option[String] = None)
+    object Hero {
+      val name: monocle.Iso[Data.Hero, Option[String]] = monocle.Focus[Data.Hero](_.name)
+      implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
+      implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
+      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.generic.semiauto.deriveDecoder[Data.Hero]
+    }
+    val hero: monocle.Iso[Data, Data.Hero] = monocle.Focus[Data](_.hero)
+    implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
+    implicit val showData: cats.Show[Data] = cats.Show.fromToString
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+  }
+  val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
+}
+
+
+// format: on

--- a/gen/output/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
+++ b/gen/output/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 

--- a/gen/output/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
+++ b/gen/output/src/main/scala/test/StarWarsTypedSubqueryAnnotatedDeprecated.scala
@@ -6,6 +6,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 import io.circe.Json
 
@@ -14,7 +15,7 @@ import io.circe.Json
 // a warning is reported (proving validation now runs on annotated `.Typed` objects).
 
 @GraphQLType("Droid") object StarWarsTypedSubqueryAnnotatedDeprecated extends GraphQLSubquery.Typed[StarWars, Json] {
-  override val subquery: String = """
+  override val subquery = gql"""
         {
           primaryFunction
         }

--- a/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
@@ -243,11 +243,18 @@ class GraphQLGen(val config: GraphQLGenConfig)
                     )
                   case Some(subquery) =>
                     withSchema(schemaType.value, obj.pos) { schema =>
+                      val explicitVariables: Option[String] = extractVariables(stats)
+                      // For @GraphQL subqueries, infer the referenced variables from usage when the
+                      // author didn't declare them; the inferred set is emitted as `type Variables`.
+                      val variables: String                 =
+                        explicitVariables.getOrElse(
+                          inferSubqueryVariables(schema, rootTypeName, subquery.render)
+                        )
                       // Validate the subquery against its root type first, reporting all problems
                       // as diagnostics (errors at the subquery, warnings at the definition).
-                      val validation: Result[Unit] =
-                        validateSubquery(schema, rootTypeName, subquery.render)
-                      val diagnostics: Patch       =
+                      val validation: Result[Unit]          =
+                        validateSubquery(schema, rootTypeName, variables, subquery.render)
+                      val diagnostics: Patch                =
                         lintResult(
                           validation,
                           gqlValuePos("subquery", stats).getOrElse(obj.pos),
@@ -258,13 +265,14 @@ class GraphQLGen(val config: GraphQLGenConfig)
                       else {
                         // Validation passed, so parsing and variable-type resolution below succeed.
                         val (operations, fragments) =
-                          GQLParser.parseText(s"query ${subquery.render}").toOption.get
+                          GQLParser.parseText(s"query $variables ${subquery.render}").toOption.get
                         // TODO Support multi-operation queries?
                         val operation               = operations.head
 
                         // Modifications to add the missing definitions.
                         val modObjDefs = scala.Function.chain(
                           List(
+                            addVariablesTypeAlias(explicitVariables, variables),
                             addImports(schemaType.value),
                             addData(
                               schema,

--- a/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
@@ -134,7 +134,7 @@ class GraphQLGen(val config: GraphQLGenConfig)
                   case None           =>
                     IO.pure(
                       errorDiagnostic(
-                        "The GraphQLOperation must define a 'val document: String' with a literal value.",
+                        "The GraphQLOperation must define a 'val document' with a literal or `gql\"...\"` value.",
                         obj.pos
                       )
                     )

--- a/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
@@ -52,17 +52,43 @@ class GraphQLGen(val config: GraphQLGenConfig)
               ) =>
             // Annotated objects already supply their own Variables/Data (e.g. via
             // GraphQLOperation.Typed or GraphQLSubquery.Typed), so there's nothing to generate. We
-            // still validate the document/subquery, then copy the object stripping the @GraphQL
-            // annotation (keeping any others, such as @GraphQLType).
+            // still validate the document/subquery, add the inferred `VariableDefs` if it's a
+            // subquery that needs one, then copy the object stripping the @GraphQL annotation
+            // (keeping any others, such as @GraphQLType).
             val newMods = GraphQLAnnotation.removeFrom(mods)
-            val copied  =
+
+            def copied(body: List[Stat]): Patch =
               Patch.replaceTree(
                 obj,
                 indented(obj)(
-                  q"..$newMods object $name ${buildTemplate(early, inits, (self.some, stats))}".toString
+                  q"..$newMods object $name ${buildTemplate(early, inits, (self.some, body))}".toString
                 )
               ) + Patch.removeGlobalImport(GraphQLAnnotation.symbol)
-            validateGraphQLDefn(mods, inits, stats, obj.pos, generating = true).map(_ + copied)
+
+            // Like a generated subquery, an annotated one gets its referenced variables inferred and
+            // emitted as `type VariableDefs`, so the `gql` caller-check sees what it requires.
+            val body: IO[List[Stat]] =
+              (extractSubquerySchemaType(inits),
+               extractSubquery(stats),
+               extractRootTypes(mods)
+              ) match {
+                case (Some(schemaType), Some(subquery), rootTypeName :: Nil)
+                    if extractVariableDefs(stats).isEmpty =>
+                  config
+                    .getSchema(schemaType.value)
+                    .map(
+                      _.toOption.fold(stats)(schema =>
+                        addVariableDefsTypeAlias(
+                          none,
+                          inferSubqueryVariableDefs(schema, rootTypeName, subquery.render)
+                        )(stats)
+                      )
+                    )
+                case _ => IO.pure(stats)
+              }
+
+            (validateGraphQLDefn(mods, inits, stats, obj.pos, generating = true), body)
+              .mapN((diagnostics, newBody) => diagnostics + copied(newBody))
           case obj @ Defn.Object(
                 GraphQLStubAnnotation(_),
                 _,

--- a/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
@@ -243,18 +243,19 @@ class GraphQLGen(val config: GraphQLGenConfig)
                     )
                   case Some(subquery) =>
                     withSchema(schemaType.value, obj.pos) { schema =>
-                      val explicitVariables: Option[String] = extractVariables(stats)
+                      val explicitVariableDefs: Option[String] = extractVariableDefs(stats)
                       // For @GraphQL subqueries, infer the referenced variables from usage when the
-                      // author didn't declare them; the inferred set is emitted as `type Variables`.
-                      val variables: String                 =
-                        explicitVariables.getOrElse(
-                          inferSubqueryVariables(schema, rootTypeName, subquery.render)
+                      // author didn't declare them; the inferred set is emitted as
+                      // `type VariableDefs`.
+                      val variableDefs: String                 =
+                        explicitVariableDefs.getOrElse(
+                          inferSubqueryVariableDefs(schema, rootTypeName, subquery.render)
                         )
                       // Validate the subquery against its root type first, reporting all problems
                       // as diagnostics (errors at the subquery, warnings at the definition).
-                      val validation: Result[Unit]          =
-                        validateSubquery(schema, rootTypeName, variables, subquery.render)
-                      val diagnostics: Patch                =
+                      val validation: Result[Unit]             =
+                        validateSubquery(schema, rootTypeName, variableDefs, subquery.render)
+                      val diagnostics: Patch                   =
                         lintResult(
                           validation,
                           gqlValuePos("subquery", stats).getOrElse(obj.pos),
@@ -265,14 +266,17 @@ class GraphQLGen(val config: GraphQLGenConfig)
                       else {
                         // Validation passed, so parsing and variable-type resolution below succeed.
                         val (operations, fragments) =
-                          GQLParser.parseText(s"query $variables ${subquery.render}").toOption.get
+                          GQLParser
+                            .parseText(s"query $variableDefs ${subquery.render}")
+                            .toOption
+                            .get
                         // TODO Support multi-operation queries?
                         val operation               = operations.head
 
                         // Modifications to add the missing definitions.
                         val modObjDefs = scala.Function.chain(
                           List(
-                            addVariablesTypeAlias(explicitVariables, variables),
+                            addVariableDefsTypeAlias(explicitVariableDefs, variableDefs),
                             addImports(schemaType.value),
                             addData(
                               schema,

--- a/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
@@ -237,7 +237,7 @@ class GraphQLGen(val config: GraphQLGenConfig)
                   case None           =>
                     IO.pure(
                       errorDiagnostic(
-                        "The GraphQLOperation must define a 'val subquery' with a literal String value.",
+                        "The GraphQLSubquery must define a 'val subquery' with a literal or `gql\"...\"` value.",
                         obj.pos
                       )
                     )

--- a/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
@@ -163,7 +163,12 @@ trait GraphQLValidation extends QueryGen {
                   validateSubqueryTypes(
                     schema,
                     rootTypes,
-                    extractVariableDefs(stats).getOrElse(""),
+                    subqueryVariableDefs(schema,
+                                         rootTypes,
+                                         stats,
+                                         subquery.render,
+                                         infer = generating
+                    ),
                     subquery.render
                   ),
                   gqlValuePos("subquery", stats).getOrElse(defnPos),

--- a/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
@@ -163,7 +163,7 @@ trait GraphQLValidation extends QueryGen {
                   validateSubqueryTypes(
                     schema,
                     rootTypes,
-                    extractVariables(stats).getOrElse(""),
+                    extractVariableDefs(stats).getOrElse(""),
                     subquery.render
                   ),
                   gqlValuePos("subquery", stats).getOrElse(defnPos),

--- a/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
@@ -160,7 +160,12 @@ trait GraphQLValidation extends QueryGen {
             else
               withSchema(schemaType.value, defnPos) { schema =>
                 lintResult(
-                  validateSubqueryTypes(schema, rootTypes, subquery.render),
+                  validateSubqueryTypes(
+                    schema,
+                    rootTypes,
+                    extractVariables(stats).getOrElse(""),
+                    subquery.render
+                  ),
                   gqlValuePos("subquery", stats).getOrElse(defnPos),
                   defnPos
                 )

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -385,6 +385,28 @@ trait QueryGen extends Generator {
       }
       .getOrElse("")
 
+  /**
+   * The variables to validate a subquery against: the declared `type VariableDefs`, or — when the
+   * generator processes the subquery (`@GraphQL`), which also emits the declaration for it — the
+   * set inferred from usage. A hand-written subquery must declare them itself, so `infer` is false
+   * there and an undeclared variable is reported.
+   */
+  protected def subqueryVariableDefs(
+    schema:        Schema,
+    rootTypeNames: List[String],
+    stats:         List[Stat],
+    subquery:      String,
+    infer:         Boolean
+  ): String =
+    extractVariableDefs(stats).getOrElse {
+      rootTypeNames match {
+        // Inference needs a single unambiguous root type, which is what `@GraphQL` requires anyway.
+        case rootTypeName :: Nil if infer =>
+          inferSubqueryVariableDefs(schema, rootTypeName, subquery)
+        case _                            => ""
+      }
+    }
+
   // Emit `type VariableDefs = "(...)"` into a generated subquery object when its variables were
   // inferred (the author didn't declare them) and it references at least one. When the author wrote
   // an explicit `type VariableDefs`, it is already in the body and carried through, so nothing is

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -99,11 +99,11 @@ trait QueryGen extends Generator {
   protected def extractSubquery(stats: List[Stat]): Option[InterpolatedGql] =
     extractGql("subquery", stats)
 
-  // The declared GraphQL variables of a subquery, from its `type Variables = "(...)"` member
+  // The declared GraphQL variables of a subquery, from its `type VariableDefs = "(...)"` member
   // (parenthesized var-defs in operation-header syntax). Absent ⇒ the subquery references no
   // variables. Uses the type test + field accessors to avoid the deprecated `Defn.Type` extractor.
-  protected def extractVariables(stats: List[Stat]): Option[String] =
-    stats.collectFirst { case d: Defn.Type if d.name.value == "Variables" => d.body }.collect {
+  protected def extractVariableDefs(stats: List[Stat]): Option[String] =
+    stats.collectFirst { case d: Defn.Type if d.name.value == "VariableDefs" => d.body }.collect {
       case Lit.String(value) => value
     }
 
@@ -360,10 +360,10 @@ trait QueryGen extends Generator {
   /**
    * Infer the GraphQL variables a subquery references, from their usage, rendered as a
    * parenthesized var-def list (`($a: T, $b: U)`) in operation-header syntax, sorted by name for
-   * deterministic output. Empty if the subquery references none. Used to auto-emit `type Variables`
-   * for `@GraphQL` subqueries that don't declare it explicitly.
+   * deterministic output. Empty if the subquery references none. Used to auto-emit
+   * `type VariableDefs` for `@GraphQL` subqueries that don't declare it explicitly.
    */
-  protected def inferSubqueryVariables(
+  protected def inferSubqueryVariableDefs(
     schema:       Schema,
     rootTypeName: String,
     subquery:     String
@@ -389,23 +389,24 @@ trait QueryGen extends Generator {
       }
       .getOrElse("")
 
-  // Emit `type Variables = "(...)"` into a generated subquery object when its variables were inferred
-  // (the author didn't declare them) and it references at least one. When the author wrote an explicit
-  // `type Variables`, it is already in the body and carried through, so nothing is added.
-  protected def addVariablesTypeAlias(
-    explicitVariables: Option[String],
-    variables:         String
+  // Emit `type VariableDefs = "(...)"` into a generated subquery object when its variables were
+  // inferred (the author didn't declare them) and it references at least one. When the author wrote
+  // an explicit `type VariableDefs`, it is already in the body and carried through, so nothing is
+  // added.
+  protected def addVariableDefsTypeAlias(
+    explicitVariableDefs: Option[String],
+    variableDefs:         String
   ): List[Stat] => List[Stat] =
     parentBody =>
-      if (explicitVariables.isDefined || variables.isEmpty) parentBody
-      else q"type Variables = ${Lit.String(variables)}" :: parentBody
+      if (explicitVariableDefs.isDefined || variableDefs.isEmpty) parentBody
+      else q"type VariableDefs = ${Lit.String(variableDefs)}" :: parentBody
 
   /**
    * Validate a subquery (a selection set on `rootTypeName`) against the `schema`. Grackle's
    * `compile` always roots a document at the schema's operation types, so the root type is supplied
    * explicitly here.
    *
-   * `variables` is the subquery's declared variables (from its `type Variables` member),
+   * `variableDefs` is the subquery's declared variables (from its `type VariableDefs` member),
    * parenthesized in operation-header syntax (e.g. `($ep: Episode!)`), or empty if it declares
    * none. They are spliced into the wrapper operation so the standard variable checks apply: a
    * variable used but not declared is reported, and each declared type is checked against its
@@ -414,7 +415,7 @@ trait QueryGen extends Generator {
   protected def validateSubquery(
     schema:       Schema,
     rootTypeName: String,
-    variables:    String,
+    variableDefs: String,
     subquery:     String
   ): Result[Unit] =
     Result
@@ -423,8 +424,9 @@ trait QueryGen extends Generator {
         s"Undefined root type [$rootTypeName] for subquery"
       )
       .flatMap { rootType =>
-        GQLParser.parseText(s"query $variables $subquery").flatMap { case (operations, fragments) =>
-          validateParsed(schema, _ => Result.success(rootType), operations, fragments)
+        GQLParser.parseText(s"query $variableDefs $subquery").flatMap {
+          case (operations, fragments) =>
+            validateParsed(schema, _ => Result.success(rootType), operations, fragments)
         }
       }
 
@@ -435,10 +437,10 @@ trait QueryGen extends Generator {
   protected def validateSubqueryTypes(
     schema:        Schema,
     rootTypeNames: List[String],
-    variables:     String,
+    variableDefs:  String,
     subquery:      String
   ): Result[Unit] =
-    rootTypeNames.parTraverse_(validateSubquery(schema, _, variables, subquery))
+    rootTypeNames.parTraverse_(validateSubquery(schema, _, variableDefs, subquery))
 
   import DefineType._
   protected def addVars(

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -194,12 +194,10 @@ trait QueryGen extends Generator {
    * All errors and warnings are accumulated into the [[Result]] (nothing is thrown).
    */
   private def validateParsed(
-    schema:         Schema,
-    rootTypeOf:     UntypedOperation => Result[NamedType],
-    operations:     List[UntypedOperation],
-    fragments:      List[UntypedFragment],
-    extraVars:      Query.Vars = Map.empty,
-    checkVariables: Boolean = true
+    schema:     Schema,
+    rootTypeOf: UntypedOperation => Result[NamedType],
+    operations: List[UntypedOperation],
+    fragments:  List[UntypedFragment]
   ): Result[Unit] = {
     val compiler = new QueryCompiler(GQLParser, schema, List.empty)
     val phases   =
@@ -212,18 +210,16 @@ trait QueryGen extends Generator {
     val fragMap  = fragments.map(f => f.name -> f).toMap
 
     for {
-      // The variable/fragment checks are skipped for subqueries (see [[validateSubquery]]): they
-      // reference variables they don't declare, which this check would wrongly report as undefined.
-      // `reportUnused = false` regardless: grackle's unused detection is unreliable — its
-      // `collectValueRefs` overwrites instead of accumulating variable refs (`loop(values,
-      // Set(nme))`), so when one value holds several variables (e.g. an input object with multiple
-      // `$var` fields) all but the last are falsely reported as unused.
+      // `reportUnused = false`: grackle's unused detection is unreliable — its `collectValueRefs`
+      // overwrites instead of accumulating variable refs (`loop(values, Set(nme))`), so when one
+      // value holds several variables (e.g. an input object with multiple `$var` fields) all but the
+      // last are falsely reported as unused. Note that re-enabling it would also need an exemption
+      // for subqueries: a subquery legitimately declares variables that only a subquery it splices
+      // uses, and a splice is rendered as `__typename` here (see [[InterpolatedGql.render]]).
       // TODO Re-enable unused detection when grackle releases the bug fix for `collectValueRefs`.
-      _ <- if (checkVariables)
-             Result.fromProblems(
-               compiler.validateVariablesAndFragments(operations, fragments, reportUnused = false)
-             )
-           else Result.success(())
+      _ <- Result.fromProblems(
+             compiler.validateVariablesAndFragments(operations, fragments, reportUnused = false)
+           )
       _ <- Result.fromProblems(compiler.validateFieldMergeability(operations, fragments))
       _ <- operations.traverse_ { op =>
              for {
@@ -238,7 +234,7 @@ trait QueryGen extends Generator {
                                  None,
                                  schema,
                                  Context(rootType),
-                                 createDummyVars(varDefs) ++ extraVars,
+                                 createDummyVars(varDefs),
                                  fragMap,
                                  op.query,
                                  Env.empty,

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -99,6 +99,14 @@ trait QueryGen extends Generator {
   protected def extractSubquery(stats: List[Stat]): Option[InterpolatedGql] =
     extractGql("subquery", stats)
 
+  // The declared GraphQL variables of a subquery, from its `type Variables = "(...)"` member
+  // (parenthesized var-defs in operation-header syntax). Absent ⇒ the subquery references no
+  // variables. Uses the type test + field accessors to avoid the deprecated `Defn.Type` extractor.
+  protected def extractVariables(stats: List[Stat]): Option[String] =
+    stats.collectFirst { case d: Defn.Type if d.name.value == "Variables" => d.body }.collect {
+      case Lit.String(value) => value
+    }
+
   // TODO Support concatenation and stripMargin?
   // Actually when we support gql"" that should delimit things...
   // Actually(2)... Scalafix runs in a completely different context than the actual code.
@@ -332,14 +340,81 @@ trait QueryGen extends Generator {
     go(query, rootType.some)
   }
 
+  // Render a grackle type back to GraphQL type syntax (e.g. `Episode!`, `[String!]`, `ID`). grackle
+  // types are non-null by default; `NullableType` marks the nullable positions.
+  private def renderGraphQLType(tpe: GType): String =
+    tpe match {
+      case NullableType(inner) => renderNullableGraphQLType(inner)
+      case ListType(inner)     => s"[${renderGraphQLType(inner)}]!"
+      case named: NamedType    => s"${named.name}!"
+      case other               => throw new Exception(s"Cannot render GraphQL type [$other]")
+    }
+
+  private def renderNullableGraphQLType(tpe: GType): String =
+    tpe match {
+      case ListType(inner)  => s"[${renderGraphQLType(inner)}]"
+      case named: NamedType => named.name
+      case other            => throw new Exception(s"Cannot render GraphQL type [$other]")
+    }
+
+  /**
+   * Infer the GraphQL variables a subquery references, from their usage, rendered as a
+   * parenthesized var-def list (`($a: T, $b: U)`) in operation-header syntax, sorted by name for
+   * deterministic output. Empty if the subquery references none. Used to auto-emit `type Variables`
+   * for `@GraphQL` subqueries that don't declare it explicitly.
+   */
+  protected def inferSubqueryVariables(
+    schema:       Schema,
+    rootTypeName: String,
+    subquery:     String
+  ): String =
+    scala.util
+      .Try {
+        (for {
+          rootType <- schema.definition(rootTypeName)
+          parsed   <- GQLParser.parseText(s"query $subquery").toOption
+        } yield {
+          val (operations, fragments) = parsed
+          val inferred: Query.Vars    =
+            operations.foldLeft(Map.empty[String, (GType, Value)])((acc, op) =>
+              acc ++ inferVariableVars(schema, rootType, op.query, fragments)
+            )
+          if (inferred.isEmpty) ""
+          else
+            inferred.toList
+              .sortBy(_._1)
+              .map { case (name, (tpe, _)) => s"$$$name: ${renderGraphQLType(tpe)}" }
+              .mkString("(", ", ", ")")
+        }).getOrElse("")
+      }
+      .getOrElse("")
+
+  // Emit `type Variables = "(...)"` into a generated subquery object when its variables were inferred
+  // (the author didn't declare them) and it references at least one. When the author wrote an explicit
+  // `type Variables`, it is already in the body and carried through, so nothing is added.
+  protected def addVariablesTypeAlias(
+    explicitVariables: Option[String],
+    variables:         String
+  ): List[Stat] => List[Stat] =
+    parentBody =>
+      if (explicitVariables.isDefined || variables.isEmpty) parentBody
+      else q"type Variables = ${Lit.String(variables)}" :: parentBody
+
   /**
    * Validate a subquery (a selection set on `rootTypeName`) against the `schema`. Grackle's
    * `compile` always roots a document at the schema's operation types, so the root type is supplied
    * explicitly here.
+   *
+   * `variables` is the subquery's declared variables (from its `type Variables` member),
+   * parenthesized in operation-header syntax (e.g. `($ep: Episode!)`), or empty if it declares
+   * none. They are spliced into the wrapper operation so the standard variable checks apply: a
+   * variable used but not declared is reported, and each declared type is checked against its
+   * usage.
    */
   protected def validateSubquery(
     schema:       Schema,
     rootTypeName: String,
+    variables:    String,
     subquery:     String
   ): Result[Unit] =
     Result
@@ -348,24 +423,8 @@ trait QueryGen extends Generator {
         s"Undefined root type [$rootTypeName] for subquery"
       )
       .flatMap { rootType =>
-        GQLParser.parseText(s"query $subquery").flatMap { case (operations, fragments) =>
-          // A subquery references variables declared by the enclosing operation, not itself. We
-          // infer dummy values for them from their usage so the subquery is still validated without
-          // reporting them as undefined, and skip the variable-declaration check for the same reason.
-          // TODO Replace with real variable propagation through subqueries.
-          val inferredVars: Query.Vars =
-            operations.foldLeft(Map.empty[String, (GType, Value)]) { (acc, op) =>
-              acc ++ inferVariableVars(schema, rootType, op.query, fragments)
-            }
-
-          validateParsed(
-            schema,
-            _ => Result.success(rootType),
-            operations,
-            fragments,
-            inferredVars,
-            checkVariables = false
-          )
+        GQLParser.parseText(s"query $variables $subquery").flatMap { case (operations, fragments) =>
+          validateParsed(schema, _ => Result.success(rootType), operations, fragments)
         }
       }
 
@@ -376,9 +435,10 @@ trait QueryGen extends Generator {
   protected def validateSubqueryTypes(
     schema:        Schema,
     rootTypeNames: List[String],
+    variables:     String,
     subquery:      String
   ): Result[Unit] =
-    rootTypeNames.parTraverse_(validateSubquery(schema, _, subquery))
+    rootTypeNames.parTraverse_(validateSubquery(schema, _, variables, subquery))
 
   import DefineType._
   protected def addVars(

--- a/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
+++ b/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
@@ -34,26 +34,26 @@ object Demo extends IOApp.Simple {
 
   object Query extends GraphQLOperation.Typed.NoInput[DemoDB, Json] {
     override val document = gql"""
-      query {
-        observations(WHERE: {program: {id: {EQ: "p-2"}}}) {
-          matches {
-            id
-            title
-            subtitle
-          }
-        }
-      }"""
+      |query {
+      |  observations(WHERE: {program: {id: {EQ: "p-2"}}}) {
+      |    matches {
+      |      id
+      |      title
+      |      subtitle
+      |    }
+      |  }
+      |}""".stripMargin
   }
 
   object Subscription extends GraphQLOperation.Typed.NoInput[DemoDB, Json] {
     override val document = gql"""
-      subscription {
-        observationEdit(input: {programId: "p-2"}) {
-          value {
-            id
-          }
-        }
-      }"""
+      |subscription {
+      |  observationEdit(input: {programId: "p-2"}) {
+      |    value {
+      |      id
+      |    }
+      |  }
+      |}""".stripMargin
   }
 
   object Mutation extends GraphQLOperation[DemoDB] {
@@ -61,13 +61,13 @@ object Demo extends IOApp.Simple {
     case class Variables(observationId: String, subtitle: String)
 
     override val document                                = gql"""
-      mutation ($$observationId: ObservationId!, $$subtitle: String){
-        updateObservations(input: {WHERE: {id: {EQ: $$observationId}}, SET: {subtitle: $$subtitle}}) {
-          observations {
-            id
-          }
-        }
-      }"""
+    |mutation ($$observationId: ObservationId!, $$subtitle: String){
+    |  updateObservations(input: {WHERE: {id: {EQ: $$observationId}}, SET: {subtitle: $$subtitle}}) {
+    |    observations {
+    |      id
+    |    }
+    |  }
+    |}""".stripMargin
     override val varEncoder: Encoder.AsObject[Variables] = deriveEncoder
 
     override val dataDecoder: Decoder[Data] = Decoder[Json]

--- a/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
+++ b/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
@@ -13,6 +13,7 @@ import cats.effect.std.SecureRandom
 import cats.syntax.all.*
 import clue.FetchClient
 import clue.GraphQLOperation
+import clue.gql
 import clue.http4s.Http4sWebSocketBackend
 import clue.http4s.Http4sWebSocketClient
 import clue.websocket.WebSocketClient
@@ -32,41 +33,41 @@ object Demo extends IOApp.Simple {
   type DemoDB
 
   object Query extends GraphQLOperation.Typed.NoInput[DemoDB, Json] {
-    override val document: String = """
-      |query {
-      |  observations(WHERE: {program: {id: {EQ: "p-2"}}}) {
-      |    matches {
-      |      id
-      |      title
-      |      subtitle
-      |    }
-      |  }
-      |}""".stripMargin
+    override val document = gql"""
+      query {
+        observations(WHERE: {program: {id: {EQ: "p-2"}}}) {
+          matches {
+            id
+            title
+            subtitle
+          }
+        }
+      }"""
   }
 
   object Subscription extends GraphQLOperation.Typed.NoInput[DemoDB, Json] {
-    override val document: String = """
-      |subscription {
-      |  observationEdit(input: {programId: "p-2"}) {
-      |    value {
-      |      id
-      |    }
-      |  }
-      |}""".stripMargin
+    override val document = gql"""
+      subscription {
+        observationEdit(input: {programId: "p-2"}) {
+          value {
+            id
+          }
+        }
+      }"""
   }
 
   object Mutation extends GraphQLOperation[DemoDB] {
     type Data = Json
     case class Variables(observationId: String, subtitle: String)
 
-    override val document: String                        = """
-    |mutation ($observationId: ObservationId!, $subtitle: String){
-    |  updateObservations(input: {WHERE: {id: {EQ: $observationId}}, SET: {subtitle: $subtitle}}) {
-    |    observations {
-    |      id
-    |    }
-    |  }
-    |}""".stripMargin
+    override val document                                = gql"""
+      mutation ($$observationId: ObservationId!, $$subtitle: String){
+        updateObservations(input: {WHERE: {id: {EQ: $$observationId}}, SET: {subtitle: $$subtitle}}) {
+          observations {
+            id
+          }
+        }
+      }"""
     override val varEncoder: Encoder.AsObject[Variables] = deriveEncoder
 
     override val dataDecoder: Decoder[Data] = Decoder[Json]

--- a/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
+++ b/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
@@ -13,7 +13,6 @@ import cats.effect.std.SecureRandom
 import cats.syntax.all.*
 import clue.FetchClient
 import clue.GraphQLOperation
-import clue.gql
 import clue.http4s.Http4sWebSocketBackend
 import clue.http4s.Http4sWebSocketClient
 import clue.websocket.WebSocketClient

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/app/src/clue/scala/StarWarsQuery.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/app/src/clue/scala/StarWarsQuery.scala
@@ -6,14 +6,15 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 import test.StarWars
 
 @GraphQL
 trait StarWarsQuery extends GraphQLOperation[StarWars] {
-  override val document: String = """
-        query ($charId: ID!) {
-          character(id: $charId) {
+  override val document = gql"""
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             id
             name
             ... on Human {

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/app/src/clue/scala/StarWarsQuery.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/app/src/clue/scala/StarWarsQuery.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 import test.StarWars
 

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars/app/src/clue/scala/StarWarsQuery.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars/app/src/clue/scala/StarWarsQuery.scala
@@ -6,14 +6,15 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 import test.StarWars
 
 @GraphQL
 trait StarWarsQuery extends GraphQLOperation[StarWars] {
-  override val document: String = """
-        query ($charId: ID!) {
-          character(id: $charId) {
+  override val document = gql"""
+        query ($$charId: ID!) {
+          character(id: $$charId) {
             id
             name
             ... on Human {

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars/app/src/clue/scala/StarWarsQuery.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars/app/src/clue/scala/StarWarsQuery.scala
@@ -6,7 +6,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 import test.StarWars
 

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/app/src/main/scala/Handwritten.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/app/src/main/scala/Handwritten.scala
@@ -1,6 +1,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 trait StarWars
@@ -9,5 +10,5 @@ trait StarWars
 // `clueCheck` should validate it against the schema. This version is valid.
 @GraphQLType("Character")
 abstract class HandwrittenSubquery extends GraphQLSubquery[StarWars] {
-  override val subquery: String = "{ id name }"
+  override val subquery = gql"{ id name }"
 }

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/app/src/main/scala/Handwritten.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/app/src/main/scala/Handwritten.scala
@@ -1,7 +1,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 trait StarWars

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Annotated.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Annotated.scala
@@ -1,7 +1,6 @@
 package test
 
 import clue.GraphQLOperation
-import clue.gql
 import clue.annotation.GraphQL
 
 trait StarWars

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Annotated.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Annotated.scala
@@ -1,6 +1,7 @@
 package test
 
 import clue.GraphQLOperation
+import clue.gql
 import clue.annotation.GraphQL
 
 trait StarWars
@@ -10,5 +11,5 @@ trait StarWars
 // and `clueCheck` still succeed.
 @GraphQL
 trait AnnotatedInMain extends GraphQLOperation[StarWars] {
-  override val document: String = "query { hero(episode: NEWHOPE) { id } }"
+  override val document = gql"query { hero(episode: NEWHOPE) { id } }"
 }

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Invalid.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Invalid.scala
@@ -1,6 +1,7 @@
 package test
 
 import clue.GraphQLSubquery
+import clue.gql
 import clue.annotation.GraphQLType
 
 trait StarWars
@@ -9,5 +10,5 @@ trait StarWars
 // `Character`. `clueCheck` must fail.
 @GraphQLType("Character")
 abstract class HandwrittenSubquery extends GraphQLSubquery[StarWars] {
-  override val subquery: String = "{ id invalidField }"
+  override val subquery = gql"{ id invalidField }"
 }

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Invalid.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/changes/Invalid.scala
@@ -1,7 +1,6 @@
 package test
 
 import clue.GraphQLSubquery
-import clue.gql
 import clue.annotation.GraphQLType
 
 trait StarWars


### PR DESCRIPTION
## The problem

Subqueries are allowed to reference variables. These variables must be declared at the call site, but there was no compile-time validation of that.

Inside the subquery, the variables weren't checked either. Everything else was — fields, arguments, deprecations — but because a subquery is validated in isolation and its variables belong to whatever operation splices it, the generator inferred them from usage and turned grackle's variable checks off. So an undefined variable inside a subquery was silently accepted, and an operation splicing that subquery could omit the variable entirely, or declare it at the wrong type. Either way the failure only showed up at runtime, as a server error.

## The solution

A subquery now declares the variables it references, in GraphQL header syntax:

```scala
@GraphQLType("Query")
object HeroByEpisode extends GraphQLSubquery.Typed[StarWars, Json]:
  type VariableDefs = "($ep: Episode!)"
  val subquery      = gql"{ hero(episode: $$ep) { name } }"
```

The declaration exists only for validation — no runtime value, no case class, no encoder. It's mandatory when the subquery references a variable and omitted when it doesn't. Generated subqueries (`@GraphQL`) infer it from usage and emit it, so they need no changes.

It's a *type* precisely because the information is only needed at compile time: a string-literal type costs nothing at runtime and is preserved in TASTy, which is what lets the macro read it back out of a dependency jar.

Two checks then apply:
1) Scalafix validates the declaration against the schema: a variable that is used but not declared, or declared at a type incompatible with its usage, is an error.
2) All queries, mutations, subscriptions and subqueries are now built with the new `gql` interpolator, which checks at compile time that the call site declares everything the spliced subqueries require:

```scala
val document = gql"query ($$ep: Episode!) $HeroByEpisode"
// drop $ep and you get:
// gql: operation does not declare variable $ep required by a spliced subquery (needs Episode!)
```

Types are matched with GraphQL's "usable as" rule, so `Episode!` satisfies a nullable `Episode` requirement but not the reverse.

Subqueries can splice other subqueries. Those are checked the same way, against the enclosing subquery's own declaration:

```scala
type VariableDefs = "($ep: Episode!)"   // required, because HeroByEpisode needs it
val subquery      = gql"{ id friends $HeroByEpisode }"
```

Since each level has to declare what the level below requires, the requirement reaches the operation transitively. Every `gql` only looks one level down.

`gql` is mandatory. `document` and `subquery` are an opaque type over `String` that only `gql` can produce, so a plain string or `s"..."` doesn't compile and the check can't be skipped by accident. `GraphQLDocument.unsafeFromString` is the explicit way out when you need one.

## Why a macro

The natural place for the call-site check is the existing scalafix rule, but scalafix can't do it.

It never sees the spliced subquery: each splice is rendered as `{ subqueryN: __typename }`, because the rule can't resolve a term defined in another file. `Symbol.info` doesn't help — it resolves only Java symbols, and every Scala symbol, including `scala/Option#`, comes back undefined. That was verified both in the testkit and under the real sbt-scalafix plugin. Parsing `.semanticdb` files directly does work across files of the same project, but a published jar contains none, so it could never check a subquery coming from a dependency such as lucuma-schemas — which is how subqueries are normally shared.

But the compiler can read a class TASTy, even from a JAR, and the type for a singleton type is encoded there as the actual value. The `gql` macro then reads `VariableDefs` straight off the spliced subquery's type, so a subquery from a jar is checked exactly like a local one. It needs no schema: `core` stays grackle-free and only lexes variable declarations.

## Breaking changes

The required downstream changes are mechanical and can be easily implemented with AI:
- `document` and `subquery` must be built with `gql"..."` (`import clue.gql`), and `$` becomes `$$`. `.stripMargin` still works. Queries that didn't use `s` interpolator and used `$` instead of `$$` must now use `$$`. I think it's a good thing to enforce a consistent style.
- Reading either as a `String` needs `.value`.
- Hand-written subqueries that reference variables must declare `VariableDefs`.
