### PR TITLE
Handle a pong message from the server

### DIFF
--- a/core/src/main/scala/clue/websocket/ApolloClient.scala
+++ b/core/src/main/scala/clue/websocket/ApolloClient.scala
@@ -212,6 +212,10 @@ class ApolloClient[F[_], P, S](
           case Connecting(_, Some(connection), _, _, _) =>
             connection.send(StreamingMessage.FromClient.Pong(payload)) // Respond the same payload.
           case _ => F.unit
+      case Right(StreamingMessage.FromServer.Pong(payload))                        =>
+        // A Pong is either the answer to our Ping or a unidirectional heartbeat.
+        // Either way, no reply is due.
+        s"Pong received from server with payload [$payload].".traceF
       case _                                                                       => s"Unexpected message received from server: [$msg]".warnF
     }
 

--- a/core/src/test/scala/clue/websocket/ApolloClientPongSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientPongSuite.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.websocket
+
+import cats.data.Ior
+import cats.effect.*
+import cats.effect.std.SecureRandom
+import cats.syntax.all.*
+import clue.PersistentClientStatus
+import clue.model.GraphQLQuery
+import clue.model.GraphQLResponse
+import clue.model.StreamingMessage
+import io.circe.Json
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+
+final class ApolloClientPongSuite extends CatsEffectSuite:
+
+  private given Logger[IO] = TestingLogger.impl[IO]()
+
+  private def connectedClient(
+    backend: TestWebSocketBackend[IO]
+  ): IO[ApolloClient[IO, String, Unit]] =
+    for
+      given SecureRandom[IO]            <- SecureRandom.javaSecuritySecureRandom[IO]
+      given WebSocketBackend[IO, String] = backend
+      client                            <- ApolloClient.of[IO, String, Unit]("ws://test")
+      _                                 <- client.connect()
+    yield client
+
+  test("A pong from the server leaves the client connected"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- connectedClient(backend)
+      _       <- backend.emitRaw("""{"type":"pong"}""")
+      status  <- client.status
+    yield assertEquals(status, PersistentClientStatus.Connected)
+
+  test("A pong with a payload leaves the client connected"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- connectedClient(backend)
+      _       <- backend.emitRaw("""{"type":"pong","payload":{"ok":true}}""")
+      status  <- client.status
+    yield assertEquals(status, PersistentClientStatus.Connected)
+
+  test("A pong from the server draws no reply"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- connectedClient(backend)
+      before  <- backend.sent
+      _       <- backend.emitRaw("""{"type":"pong"}""")
+      after   <- backend.sent
+    yield assertEquals(after, before)
+
+  test("A pong from the server does not disturb an active subscription"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- connectedClient(backend)
+      result  <- client
+                   .subscribeInternal[Json](GraphQLQuery("subscription { x }"))
+                   .use: stream =>
+                     for
+                       id    <- backend.sent.map(
+                                  _.collectFirst { case StreamingMessage.FromClient.Subscribe(i, _) =>
+                                    i
+                                  }.get
+                                )
+                       fiber <- stream.head.compile.lastOrError.start
+                       _     <- backend.emitRaw("""{"type":"pong"}""")
+                       _     <- backend.emit(
+                                  StreamingMessage.FromServer
+                                    .Next(id, GraphQLResponse(Ior.right(Json.fromInt(1))))
+                                )
+                       r     <- fiber.joinWithNever
+                     yield r
+    yield assertEquals(result.data, Json.fromInt(1).some)

--- a/core/src/test/scala/clue/websocket/TestWebSocketBackend.scala
+++ b/core/src/test/scala/clue/websocket/TestWebSocketBackend.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.websocket
+
+import cats.effect.*
+import cats.syntax.all.*
+import clue.ConnectionId
+import clue.PersistentBackendHandler
+import clue.PersistentConnection
+import clue.model.StreamingMessage
+import clue.model.json.given
+import io.circe.syntax.*
+
+/**
+ * In-memory WebSocket backend for tests. The test drives the client through it. It records the
+ * messages that the client sends. It feeds server messages and close events to the client.
+ *
+ * @param autoAck
+ *   if true, the backend answers a `connection_init` with a `connection_ack`
+ */
+final class TestWebSocketBackend[F[_]: Async] private (
+  sentRef:    Ref[F, Vector[StreamingMessage.FromClient]],
+  currentRef: Ref[F, Option[(PersistentBackendHandler[F, CloseEvent], ConnectionId)]],
+  closesRef:  Ref[F, Vector[Option[CloseParams]]],
+  autoAck:    Boolean
+) extends WebSocketBackend[F, String]:
+
+  /** The messages that the client sent, in order. */
+  val sent: F[List[StreamingMessage.FromClient]] = sentRef.get.map(_.toList)
+
+  /** The close parameters of every `closeInternal` call, in order. */
+  val closes: F[List[Option[CloseParams]]] = closesRef.get.map(_.toList)
+
+  /** Sends a message from the server to the client. */
+  def emit(msg: StreamingMessage.FromServer): F[Unit] = emitRaw(msg.asJson.noSpaces)
+
+  /** Sends raw text from the server to the client. */
+  def emitRaw(msg: String): F[Unit] =
+    currentRef.get.flatMap(_.traverse_((handler, id) => handler.onMessage(id, msg)))
+
+  /** Closes the connection from the server side. */
+  def closeFromServer(event: CloseEvent): F[Unit] =
+    currentRef.get.flatMap(_.traverse_((handler, id) => handler.onClose(id, event)))
+
+  override def connect(
+    connectionParams: String,
+    handler:          PersistentBackendHandler[F, CloseEvent],
+    connectionId:     ConnectionId
+  ): F[WebSocketConnection[F]] =
+    currentRef
+      .set((handler, connectionId).some)
+      .as(
+        new PersistentConnection[F, CloseParams]:
+          override def send(msg: StreamingMessage.FromClient): F[Unit] =
+            sentRef.update(_ :+ msg) >>
+              (msg match
+                case StreamingMessage.FromClient.ConnectionInit(_) if autoAck =>
+                  handler.onMessage(
+                    connectionId,
+                    StreamingMessage.FromServer.ConnectionAck().asJson.noSpaces
+                  )
+                case _                                                        => Async[F].unit)
+
+          override protected[clue] def closeInternal(
+            closeParameters: Option[CloseParams]
+          ): F[Unit] =
+            closesRef.update(_ :+ closeParameters)
+      )
+
+object TestWebSocketBackend:
+  def apply[F[_]: Async](autoAck: Boolean = true): F[TestWebSocketBackend[F]] =
+    for
+      sent   <- Ref.of[F, Vector[StreamingMessage.FromClient]](Vector.empty)
+      cur    <- Ref.of[F, Option[(PersistentBackendHandler[F, CloseEvent], ConnectionId)]](none)
+      closes <- Ref.of[F, Vector[Option[CloseParams]]](Vector.empty)
+    yield new TestWebSocketBackend(sent, cur, closes, autoAck)

--- a/model/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/src/main/scala/clue/model/StreamingMessage.scala
@@ -116,6 +116,20 @@ object StreamingMessage:
       inline def apply(payload: JsonObject) = new Ping(payload.some)
 
     /**
+     * Server initiated message that keeps the client connection alive. It is either a response to a
+     * client `Ping` or a unidirectional heartbeat. It can arrive at any time.
+     *
+     * @param payload
+     *   optional field can be used to transfer additional details about the pong
+     */
+    final case class Pong(payload: Option[JsonObject] = none)
+        extends FromServer
+        with Payload[Option[JsonObject]] derives Eq
+
+    object Pong:
+      inline def apply(payload: JsonObject) = new Pong(payload.some)
+
+    /**
      * GraphQL execution result from the server. The result is associated with an operation that was
      * previously started by a `Start` message with the associated `id`.
      *

--- a/model/src/main/scala/clue/model/json/package.scala
+++ b/model/src/main/scala/clue/model/json/package.scala
@@ -156,6 +156,22 @@ package object json {
         p <- c.get[Option[JsonObject]]("payload")
       yield FromServer.Ping(p)
 
+  given FromServerPongEncoder: Encoder[FromServer.Pong] =
+    Encoder.instance: a =>
+      Json
+        .obj(
+          "type"    -> Json.fromString("pong"),
+          "payload" -> a.payload.asJson
+        )
+        .dropNullValues
+
+  given FromServerPongDecoder: Decoder[FromServer.Pong] =
+    Decoder.instance: c =>
+      for
+        _ <- checkType(c, "pong")
+        p <- c.get[Option[JsonObject]]("payload")
+      yield FromServer.Pong(p)
+
   given Encoder[GraphQLError.PathElement] =
     (a: GraphQLError.PathElement) => a.fold(_.asJson, _.asJson)
 
@@ -299,6 +315,7 @@ package object json {
     Encoder.instance:
       case m @ FromServer.ConnectionAck(_) => m.asJson
       case m @ FromServer.Ping(_)          => m.asJson
+      case m @ FromServer.Pong(_)          => m.asJson
       case m @ FromServer.Next(_, _)       => m.asJson
       case m @ FromServer.Error(_, _)      => m.asJson
       case m @ FromServer.Complete(_)      => m.asJson
@@ -309,6 +326,7 @@ package object json {
         .flatMap:
           case "connection_ack" => c.as[FromServer.ConnectionAck]
           case "ping"           => c.as[FromServer.Ping]
+          case "pong"           => c.as[FromServer.Pong]
           case "next"           => c.as[FromServer.Next]
           case "error"          => c.as[FromServer.Error]
           case "complete"       => c.as[FromServer.Complete]

--- a/model/src/test/scala/clue/model/arb/ArbFromServer.scala
+++ b/model/src/test/scala/clue/model/arb/ArbFromServer.scala
@@ -76,6 +76,11 @@ trait ArbFromServer:
       for p <- arbitrary[Option[JsonObject]](using arbOptJsonObject)
       yield Ping(p)
 
+  given Arbitrary[Pong] =
+    Arbitrary:
+      for p <- arbitrary[Option[JsonObject]](using arbOptJsonObject)
+      yield Pong(p)
+
   given Arbitrary[Next] =
     Arbitrary:
       for
@@ -99,6 +104,7 @@ trait ArbFromServer:
       Gen.oneOf[FromServer](
         arbitrary[ConnectionAck],
         arbitrary[Ping],
+        arbitrary[Pong],
         arbitrary[Next],
         arbitrary[Error],
         arbitrary[Complete]

--- a/model/src/test/scala/clue/model/json/FromServerPongDecoderSuite.scala
+++ b/model/src/test/scala/clue/model/json/FromServerPongDecoderSuite.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model.json
+
+import cats.syntax.all.*
+import clue.model.StreamingMessage.FromServer
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.parser.decode
+import io.circe.syntax.*
+
+final class FromServerPongDecoderSuite extends munit.FunSuite:
+
+  test("A pong without a payload decodes as FromServer.Pong"):
+    assertEquals(decode[FromServer]("""{"type":"pong"}"""), Right(FromServer.Pong()))
+
+  test("A pong with a payload decodes as FromServer.Pong"):
+    val payload = JsonObject("latency" -> Json.fromInt(42))
+    assertEquals(
+      decode[FromServer]("""{"type":"pong","payload":{"latency":42}}"""),
+      Right(FromServer.Pong(payload.some))
+    )
+
+  test("A pong with a null payload decodes as FromServer.Pong"):
+    assertEquals(decode[FromServer]("""{"type":"pong","payload":null}"""), Right(FromServer.Pong()))
+
+  test("A pong without a payload encodes without a payload field"):
+    assertEquals((FromServer.Pong(): FromServer).asJson,
+                 Json.obj("type" -> Json.fromString("pong"))
+    )


### PR DESCRIPTION
The graphql-transport-ws protocol permits Pong messages in both
directions. A server can send an unsolicited Pong as a heartbeat. The
FromServer decoder had no case for the pong type, so the decode failed
and onMessage raised the error. In the http4s backend, that error stopped
the receive stream and closed the connection, and all active
subscriptions were lost.

Add FromServer.Pong with an optional payload, its codecs, and a pong case
in the FromServer decoder. In onMessage, log the Pong at trace level and
send no reply.
