### PR TITLE
Crash subscriptions on a close without a reconnection

### DIFF
--- a/core/src/main/scala/clue/websocket/ApolloClient.scala
+++ b/core/src/main/scala/clue/websocket/ApolloClient.scala
@@ -228,14 +228,18 @@ class ApolloClient[F[_], P, S](
       (reconnectionStrategy(0, event.asRight) match {
         case None       =>
           stateModify:
-            case s @ Disconnected(_)                                                         =>
+            case s @ Disconnected(_) =>
               s -> s"onClose() called while disconnected.".debugF
-            case Connecting(stateConnectionId, _, _, _, latch)
+            case Connecting(stateConnectionId, _, _, subscriptions, latch)
                 if connectionId === stateConnectionId =>
-              Disconnected(connectionId.next) -> latch.error(error)
-            case Connected(stateConnectionId, _, _, _) if connectionId === stateConnectionId =>
-              Disconnected(connectionId.next) -> F.unit
-            case s @ _                                                                       =>
+              // The subscriptions go away with the state, so the subscribers must be told.
+              // Otherwise each subscriber stream waits forever on its queue.
+              Disconnected(connectionId.next) ->
+                (latch.error(error) >> crashSubscriptions(subscriptions, error))
+            case Connected(stateConnectionId, _, _, subscriptions)
+                if connectionId === stateConnectionId =>
+              Disconnected(connectionId.next) -> crashSubscriptions(subscriptions, error)
+            case s @ _               =>
               s -> debug
         case Some(wait) =>
           Latch[F, JsonObject].flatMap: newLatch =>
@@ -280,9 +284,7 @@ class ApolloClient[F[_], P, S](
     val disconnectBackend: F[Unit] =
       oldConnection.map(_.closeInternal(none).start.void).getOrElse(F.unit)
 
-    val errorSubscriptions: F[Unit] = subscriptions.toList.traverse { case (_, emitter) =>
-      emitter.crash(t)
-    }.void
+    val errorSubscriptions: F[Unit] = crashSubscriptions(subscriptions, t)
 
     reconnectionStrategy(attempt, t.asLeft) match
       case None       =>
@@ -393,6 +395,13 @@ class ApolloClient[F[_], P, S](
     subscriptions: Map[String, Emitter[F]]
   ): F[Unit] =
     subscriptions.toList.traverse { case (_, emitter) => emitter.halt }.void
+
+  // Crash = Terminate stream sent to client with an error.
+  private def crashSubscriptions(
+    subscriptions: Map[String, Emitter[F]],
+    t:             Throwable
+  ): F[Unit] =
+    subscriptions.toList.traverse { case (_, emitter) => emitter.crash(t) }.void
 
   private def haltSubscription(subscriptionId: String): F[Unit] =
     s"Halting subscription [$subscriptionId]".debugF >>

--- a/core/src/test/scala/clue/websocket/ApolloClientCloseSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientCloseSuite.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.websocket
+
+import cats.effect.*
+import cats.effect.std.SecureRandom
+import cats.syntax.all.*
+import clue.DisconnectedException
+import clue.model.GraphQLQuery
+import clue.model.GraphQLResponse
+import clue.model.StreamingMessage
+import io.circe.Json
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+
+import scala.concurrent.duration.*
+
+/**
+ * Tests for the close path without a reconnection. Every subscription must terminate. It must not
+ * wait forever.
+ */
+final class ApolloClientCloseSuite extends CatsEffectSuite:
+
+  private given Logger[IO] = TestingLogger.impl[IO]()
+
+  private val Timeout: FiniteDuration = 5.seconds
+
+  private def clientOn(
+    backend:  TestWebSocketBackend[IO],
+    strategy: ReconnectionStrategy = ReconnectionStrategy.never
+  ): IO[ApolloClient[IO, String, Unit]] =
+    for
+      given SecureRandom[IO]            <- SecureRandom.javaSecuritySecureRandom[IO]
+      given WebSocketBackend[IO, String] = backend
+      client                            <- ApolloClient.of[IO, String, Unit]("ws://test", "test", strategy)
+    yield client
+
+  private def subscription(
+    client: ApolloClient[IO, String, Unit]
+  ): Resource[IO, fs2.Stream[IO, GraphQLResponse[Json]]] =
+    client.subscribeInternal[Json](GraphQLQuery("subscription { x }"))
+
+  test("A close without a reconnection strategy terminates the subscription"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- clientOn(backend)
+      _       <- client.connect()
+      outcome <- subscription(client).use: stream =>
+                   for
+                     fiber  <- stream.compile.toList.attempt.start
+                     _      <- backend.closeFromServer(CloseParams(1006, "gone").asRight)
+                     result <- fiber.joinWithNever.timeout(Timeout)
+                   yield result
+    yield assertEquals(outcome, DisconnectedException("1006: gone").asLeft)
+
+  test("A close without a reconnection strategy terminates every subscription"):
+    for
+      backend  <- TestWebSocketBackend[IO]()
+      client   <- clientOn(backend)
+      _        <- client.connect()
+      outcomes <- subscription(client).use: first =>
+                    subscription(client).use: second =>
+                      for
+                        fiberA <- first.compile.toList.attempt.start
+                        fiberB <- second.compile.toList.attempt.start
+                        _      <- backend.closeFromServer(CloseParams(1006, "gone").asRight)
+                        a      <- fiberA.joinWithNever.timeout(Timeout)
+                        b      <- fiberB.joinWithNever.timeout(Timeout)
+                      yield (a, b)
+    yield
+      assertEquals(outcomes._1, DisconnectedException("1006: gone").asLeft)
+      assertEquals(outcomes._2, DisconnectedException("1006: gone").asLeft)
+
+  test("A close while connecting terminates the subscription"):
+    // The strategy reconnects once, on the close with reason "retry". The second close
+    // then finds the client in the Connecting state and gives up.
+    val strategy: ReconnectionStrategy = (_, reason) =>
+      reason match
+        case Right(Right(CloseParams(_, Some("retry")))) => Duration.Zero.some
+        case _                                           => none
+
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- clientOn(backend, strategy)
+      _       <- client.connect()
+      outcome <- subscription(client).use: stream =>
+                   for
+                     fiber <- stream.compile.toList.attempt.start
+                     // The reconnection must not complete, so that the client stays Connecting.
+                     _     <- backend.autoAck(false)
+                     _     <- backend.closeFromServer(CloseParams(1000, "retry").asRight).start
+                     // The second connection_init proves that the client reconnects.
+                     _     <- backend
+                                .awaitSent(
+                                  _.count(
+                                    _.isInstanceOf[
+                                      StreamingMessage.FromClient.ConnectionInit
+                                    ]
+                                  ) === 2
+                                )
+                                .timeout(Timeout)
+                     _     <- backend.closeFromServer(CloseParams(4000, "gone").asRight)
+                     r     <- fiber.joinWithNever.timeout(Timeout)
+                   yield r
+    yield assertEquals(outcome, DisconnectedException("4000: gone").asLeft)

--- a/core/src/test/scala/clue/websocket/TestWebSocketBackend.scala
+++ b/core/src/test/scala/clue/websocket/TestWebSocketBackend.scala
@@ -15,22 +15,27 @@ import io.circe.syntax.*
 /**
  * In-memory WebSocket backend for tests. The test drives the client through it. It records the
  * messages that the client sends. It feeds server messages and close events to the client.
- *
- * @param autoAck
- *   if true, the backend answers a `connection_init` with a `connection_ack`
  */
 final class TestWebSocketBackend[F[_]: Async] private (
   sentRef:    Ref[F, Vector[StreamingMessage.FromClient]],
   currentRef: Ref[F, Option[(PersistentBackendHandler[F, CloseEvent], ConnectionId)]],
   closesRef:  Ref[F, Vector[Option[CloseParams]]],
-  autoAck:    Boolean
+  autoAckRef: Ref[F, Boolean]
 ) extends WebSocketBackend[F, String]:
+
+  /** Turns the automatic `connection_ack` answer on or off. */
+  def autoAck(enabled: Boolean): F[Unit] = autoAckRef.set(enabled)
 
   /** The messages that the client sent, in order. */
   val sent: F[List[StreamingMessage.FromClient]] = sentRef.get.map(_.toList)
 
   /** The close parameters of every `closeInternal` call, in order. */
   val closes: F[List[Option[CloseParams]]] = closesRef.get.map(_.toList)
+
+  /** Waits until the recorded client messages match the condition. */
+  def awaitSent(condition: List[StreamingMessage.FromClient] => Boolean): F[Unit] =
+    sent.flatMap: msgs =>
+      if condition(msgs) then Async[F].unit else Async[F].cede >> awaitSent(condition)
 
   /** Sends a message from the server to the client. */
   def emit(msg: StreamingMessage.FromServer): F[Unit] = emitRaw(msg.asJson.noSpaces)
@@ -55,12 +60,15 @@ final class TestWebSocketBackend[F[_]: Async] private (
           override def send(msg: StreamingMessage.FromClient): F[Unit] =
             sentRef.update(_ :+ msg) >>
               (msg match
-                case StreamingMessage.FromClient.ConnectionInit(_) if autoAck =>
-                  handler.onMessage(
-                    connectionId,
-                    StreamingMessage.FromServer.ConnectionAck().asJson.noSpaces
-                  )
-                case _                                                        => Async[F].unit)
+                case StreamingMessage.FromClient.ConnectionInit(_) =>
+                  autoAckRef.get.flatMap: enabled =>
+                    if enabled then
+                      handler.onMessage(
+                        connectionId,
+                        StreamingMessage.FromServer.ConnectionAck().asJson.noSpaces
+                      )
+                    else Async[F].unit
+                case _                                             => Async[F].unit)
 
           override protected[clue] def closeInternal(
             closeParameters: Option[CloseParams]
@@ -74,4 +82,5 @@ object TestWebSocketBackend:
       sent   <- Ref.of[F, Vector[StreamingMessage.FromClient]](Vector.empty)
       cur    <- Ref.of[F, Option[(PersistentBackendHandler[F, CloseEvent], ConnectionId)]](none)
       closes <- Ref.of[F, Vector[Option[CloseParams]]](Vector.empty)
-    yield new TestWebSocketBackend(sent, cur, closes, autoAck)
+      ack    <- Ref.of[F, Boolean](autoAck)
+    yield new TestWebSocketBackend(sent, cur, closes, ack)


### PR DESCRIPTION
onClose handled the case where the reconnection strategy gives no delay. For the Connected state, it moved to Disconnected and dropped the subscription map without a signal to the emitters. Each subscriber stream
then waited forever on its queue. The Connecting case errored the connect latch, but it also dropped its subscriptions.

Crash every emitter with the DisconnectedException in both branches, as handleRetry already does in its give-up branch. Extract the crash loop into crashSubscriptions and reuse it in handleRetry.
