### PR TITLE
Make a one-shot request over a WebSocket cancelable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
-ThisBuild / tlBaseVersion               := "0.57"
+ThisBuild / tlBaseVersion               := "0.58"
 ThisBuild / tlJdkRelease                := Some(17)
 ThisBuild / githubWorkflowJavaVersions  := Seq("25", "17").map(JavaSpec.temurin(_))
 ThisBuild / scalaVersion                := "3.8.4"

--- a/core/src/main/scala/clue/websocket/ApolloClient.scala
+++ b/core/src/main/scala/clue/websocket/ApolloClient.scala
@@ -28,8 +28,7 @@ import java.util.UUID
 class ApolloClient[F[_], P, S](
   connectionParams:     P,
   reconnectionStrategy: ReconnectionStrategy,
-  state:                Ref[F, State[F]],
-  connectionStatus:     SignallingRef[F, PersistentClientStatus]
+  state:                SignallingRef[F, State[F]]
 )(using
   F:                    Async[F],
   backend:              WebSocketBackend[F, P],
@@ -48,17 +47,16 @@ class ApolloClient[F[_], P, S](
         newState -> ((oldState, newState, action))
       }
       .flatMap { case (oldState, newState, action) =>
-        s"State Modified [$oldState] ==> [$newState]".traceF >>
-          connectionStatus.set(newState.status) >>
-          action
+        s"State Modified [$oldState] ==> [$newState]".traceF >> action
       }
 
   // <ApolloClient>
   override def status: F[PersistentClientStatus] =
-    connectionStatus.get
+    state.get.map(_.status)
 
+  // `changes` because a state transition does not always change the status.
   override def statusStream: fs2.Stream[F, PersistentClientStatus] =
-    connectionStatus.discrete
+    state.discrete.map(_.status).changes
 
   override def connect(): F[JsonObject] = connect(JsonObject.empty.pure[F])
 
@@ -67,7 +65,7 @@ class ApolloClient[F[_], P, S](
 
     Latch[F, JsonObject].flatMap { newLatch =>
       stateModify {
-        case Disconnected(connectionId)        =>
+        case Disconnected(connectionId, _)     =>
           Connecting(connectionId, none, payload.map(_.asJsonObject), Map.empty, newLatch) ->
             (doConnect(connectionId) >> newLatch.resolve.map(_.getOrElse(JsonObject.empty)))
         case s @ Connecting(_, _, _, _, latch) =>
@@ -92,14 +90,16 @@ class ApolloClient[F[_], P, S](
 
     // We *could* wait for onClose to be invoked before completing, but is there a point to that?
     stateModify {
-      case Connecting(connectionId, connection, _, _, latch)     =>
+      case Connecting(connectionId, connection, _, subscriptions, latch) =>
         // We need a wait for the connection to establish and then disconnect it, without blocking the client.
+        // The subscriptions go away with the state, so their streams must end here.
         Disconnected(connectionId.next) ->
           (latch.error(interruptedError) >>
+            haltSubscriptions(subscriptions) >>
             connection
               .map(_.closeInternal(closeParameters))
               .getOrElse(F.unit)) // >> TODO wait in background to complete and close
-      case Connected(connectionId, connection, _, subscriptions) =>
+      case Connected(connectionId, connection, _, subscriptions)         =>
         Disconnected(connectionId.next) ->
           (
             (gracefulTerminate(connection, subscriptions),
@@ -107,7 +107,7 @@ class ApolloClient[F[_], P, S](
             ).parTupled >>
               connection.closeInternal(closeParameters)
           )
-      case s                                                     => s -> error
+      case s                                                             => s -> error
     }.uncancelable
   }
 
@@ -130,14 +130,9 @@ class ApolloClient[F[_], P, S](
     modParams:     Unit => Unit,  // This is ignored here.
     descriptor:    Option[String] // This is ignored here.
   ): F[GraphQLResponse[D]] =
-    F.async(cb =>
-      startSubscription[D](document, operationName, variables, extensions)
-        .flatMap(subscription =>
-          subscription.stream.attempt.head.compile.onlyOrError.attempt
-            .map(onlyOrError => cb(onlyOrError.flatten))
-        )
-        .as(none) // Don't return a cancellation cleanup. Subscription is cleaned up whenm stream is finalized.
-    )
+    // A one-shot request is a subscription that ends after its first response.
+    subscriptionResource[D](document, operationName, variables, extensions)
+      .use(_.head.compile.lastOrError)
   // </FetchClient>
   // </StreamingClient>
   // </ApolloClient>
@@ -186,18 +181,14 @@ class ApolloClient[F[_], P, S](
             ).logAndRaiseF
       case Right(StreamingMessage.FromServer.Complete(subscriptionId))             =>
         state.get.flatMap:
-          case Connected(stateConnectionId, _, _, subscriptions)
-              if connectionId === stateConnectionId =>
-            subscriptions.get(subscriptionId) match {
-              case None               => F.unit
-              case Some(subscription) => subscription.halt
-            }
+          case Connected(stateConnectionId, _, _, _) if connectionId === stateConnectionId     =>
+            completeSubscription(subscriptionId)
           // Next 3 cases are expected. Server will send complete packages for subscriptions shut down when reestablishing/reinitializing.
           case Connecting(stateConnectionId, _, _, _, _) if connectionId =!= stateConnectionId =>
             F.unit
           case Connected(stateConnectionId, _, _, _) if connectionId =!= stateConnectionId     =>
             F.unit
-          case s @ Disconnected(_)                                                             =>
+          case s @ Disconnected(_, _)                                                          =>
             s"Complete RECEIVED for subscription [$subscriptionId] on Disconnected state.".debugF >>
               s"  \\-- State Is: [$s]".traceF
           case s @ _                                                                           =>
@@ -228,18 +219,19 @@ class ApolloClient[F[_], P, S](
       (reconnectionStrategy(0, event.asRight) match {
         case None       =>
           stateModify:
-            case s @ Disconnected(_) =>
+            case s @ Disconnected(_, _) =>
               s -> s"onClose() called while disconnected.".debugF
             case Connecting(stateConnectionId, _, _, subscriptions, latch)
                 if connectionId === stateConnectionId =>
               // The subscriptions go away with the state, so the subscribers must be told.
               // Otherwise each subscriber stream waits forever on its queue.
-              Disconnected(connectionId.next) ->
+              Disconnected(connectionId.next, error.some) ->
                 (latch.error(error) >> crashSubscriptions(subscriptions, error))
             case Connected(stateConnectionId, _, _, subscriptions)
                 if connectionId === stateConnectionId =>
-              Disconnected(connectionId.next) -> crashSubscriptions(subscriptions, error)
-            case s @ _               =>
+              Disconnected(connectionId.next, error.some) ->
+                crashSubscriptions(subscriptions, error)
+            case s @ _                  =>
               s -> debug
         case Some(wait) =>
           Latch[F, JsonObject].flatMap: newLatch =>
@@ -250,7 +242,7 @@ class ApolloClient[F[_], P, S](
                 doConnect(nextConnectionId, attempt = 1)
 
             stateModify:
-              case s @ Disconnected(stateConnectionId) if connectionId === stateConnectionId =>
+              case s @ Disconnected(stateConnectionId, _) if connectionId === stateConnectionId =>
                 s -> s"Unexpected onClose() called while disconnected. Not applying reconnectStrategy.".warnF
               case Connecting(stateConnectionId, _, initPayload, subscriptions, connectLatch)
                   if connectionId === stateConnectionId =>
@@ -265,7 +257,7 @@ class ApolloClient[F[_], P, S](
                   subscriptions,
                   newLatch
                 ) -> waitAndConnect(connectionId.next)
-              case s @ _                                                                     =>
+              case s @ _                                                                        =>
                 s -> debug
       })
   }
@@ -288,7 +280,7 @@ class ApolloClient[F[_], P, S](
 
     reconnectionStrategy(attempt, t.asLeft) match
       case None       =>
-        Disconnected(nextConnectionId) ->
+        Disconnected(nextConnectionId, t.some) ->
           (errorSubscriptions >> disconnectBackend >> t.logAndRaiseF)
       case Some(wait) =>
         Connecting(nextConnectionId, none, payload, subscriptions, newLatch) ->
@@ -350,8 +342,8 @@ class ApolloClient[F[_], P, S](
                         case Right(_) =>
                           Connected(connectionId, connection, payload, subscriptions) ->
                             startSubscriptions(connection, subscriptions)
-                    case Disconnected(connectionId) if result.isLeft                           =>
-                      Disconnected(connectionId) -> (s"Disconnected while initializing.".debugF >>
+                    case s @ Disconnected(_, _) if result.isLeft                               =>
+                      s -> (s"Disconnected while initializing.".debugF >>
                         RemoteInitializationException(result.swap.toOption.get).raiseF)
                     case s                                                                     =>
                       s -> (s"Unexpected state when initializing.".errorF >> s"State Is: [$s]".traceF >>
@@ -381,7 +373,7 @@ class ApolloClient[F[_], P, S](
         connection.send(StreamingMessage.FromClient.Subscribe(id, emitter.request))
       .void
 
-  // Stop = Send stop message to server.
+  // Stop = Send stop message to server. Does not halt the streams nor drop the subscriptions.
   private def stopSubscriptions(
     connection:    WebSocketConnection[F],
     subscriptions: Map[String, Emitter[F]]
@@ -403,21 +395,64 @@ class ApolloClient[F[_], P, S](
   ): F[Unit] =
     subscriptions.toList.traverse { case (_, emitter) => emitter.crash(t) }.void
 
-  private def haltSubscription(subscriptionId: String): F[Unit] =
-    s"Halting subscription [$subscriptionId]".debugF >>
-      state.get.flatMap {
-        case Connected(_, _, _, subscriptions) =>
-          for {
-            _ <- s"Current subscriptions: [${subscriptions.keySet}]".traceF
-            _ <- subscriptions.get(subscriptionId) match {
-                   case None               =>
-                     (new InvalidSubscriptionOperationException("stop", subscriptionId)).raiseF
-                   case Some(subscription) => subscription.halt
-                 }
-          } yield ()
-        case s @ _                             =>
-          InvalidSubscriptionOperationException("stop", subscriptionId).logAndRaiseF
-      }
+  // Drop = Remove the subscription from the state, so a reconnection does not restart it, and tell
+  // the server to stop sending. Never waits for a connection, since it runs uncancelably.
+  private def dropSubscription(
+    subscriptionId: String,
+    reason:         String,
+    halt:           Boolean,
+    notify:         Boolean = true
+  ): F[Unit] = {
+    def dropped(connection: Option[WebSocketConnection[F]], emitter: Emitter[F]): F[Unit] = {
+      val tellServer: F[Unit] =
+        connection.traverse_(_.send(StreamingMessage.FromClient.Complete(subscriptionId)))
+
+      // The halt runs even when the message fails. The subscription is gone from the state, so
+      // nothing else can end the stream and a reader would wait forever.
+      s"Dropping subscription [$subscriptionId] ($reason).".traceF >>
+        tellServer.whenA(notify).guarantee(emitter.halt.whenA(halt))
+    }
+
+    def drop(
+      current:       State[F],
+      subscriptions: Map[String, Emitter[F]],
+      connection:    Option[WebSocketConnection[F]]
+    )(rebuild: Map[String, Emitter[F]] => State[F]): (State[F], F[Unit]) =
+      subscriptions.get(subscriptionId) match
+        case Some(emitter) =>
+          rebuild(subscriptions - subscriptionId) -> dropped(connection, emitter)
+        case None          =>
+          current -> s"Subscription [$subscriptionId] already dropped ($reason).".traceF
+
+    stateModify {
+      case s @ Connected(cid, connection, i, subscriptions)         =>
+        drop(s, subscriptions, connection.some)(Connected(cid, connection, i, _))
+      case s @ Connecting(cid, connection, i, subscriptions, latch) =>
+        drop(s, subscriptions, none)(Connecting(cid, connection, i, _, latch))
+      // Every transition to Disconnected halts or crashes the subscriptions it drops, so the
+      // stream already ended here.
+      case s @ _                                                    =>
+        s -> s"Subscription [$subscriptionId] not dropped ($reason). Client is disconnected.".traceF
+    }
+  }
+
+  // Release = The stream ended on its own, so it needs no halt.
+  private def releaseSubscription(subscriptionId: String): F[Unit] =
+    dropSubscription(subscriptionId, "release", halt = false)
+
+  // Stop = The caller ended the subscription.
+  private def stopSubscription(subscriptionId: String): F[Unit] =
+    dropSubscription(subscriptionId, "stop", halt = true)
+
+  // Complete = The server ended the subscription. It needs no message back, and a reconnection
+  // must not restart it.
+  private def completeSubscription(subscriptionId: String): F[Unit] =
+    dropSubscription(subscriptionId, "server complete", halt = true, notify = false)
+
+  // Discard = The subscribe message never reached the server, so nobody holds or reads the
+  // subscription. Without this, a reconnection would restart a subscription nobody can stop.
+  private def discardSubscription(subscriptionId: String): F[Unit] =
+    dropSubscription(subscriptionId, "failed subscribe", halt = false, notify = false)
 
   private def createSubscription[D](
     subscriptionStream: Stream[F, D],
@@ -425,11 +460,7 @@ class ApolloClient[F[_], P, S](
   ): GraphQLSubscription[F, D] = new GraphQLSubscription[F, D] {
     override val stream: fs2.Stream[F, D] = subscriptionStream
 
-    override def stop(): F[Unit] =
-      for {
-        _ <- haltSubscription(subscriptionId)
-        _ <- sendStop(subscriptionId)
-      } yield ()
+    override def stop(): F[Unit] = stopSubscription(subscriptionId)
   }
 
   private type DataQueueType[D] = Option[Either[Throwable, GraphQLResponse[D]]]
@@ -452,8 +483,7 @@ class ApolloClient[F[_], P, S](
     def emitGraphQLErrors(errors: GraphQLErrors): F[Unit] =
       s"Emitting error: $errors".traceF >> queue.offer(GraphQLResponse.errors(errors).asRight.some)
 
-    def crash(t: Throwable): F[Unit] =
-      queue.offer(t.asLeft.some)
+    def crash(t: Throwable): F[Unit] = queue.offer(t.asLeft.some)
 
     val halt: F[Unit] = queue.offer(none)
   }
@@ -471,65 +501,40 @@ class ApolloClient[F[_], P, S](
 
   // TODO Handle interruptions in subscription and query.
 
-  private def subscriptionResource[D: Decoder, R](
+  // Wait until the client leaves the Connecting state.
+  private def awaitConnection: F[Unit] =
+    state.waitUntil(_.status =!= PersistentClientStatus.Connecting)
+
+  private def subscriptionResource[D: Decoder](
     subscription:  GraphQLQuery,
     operationName: Option[String],
     variables:     Option[JsonObject],
     extensions:    Option[JsonObject]
   ): Resource[F, fs2.Stream[F, GraphQLResponse[D]]] =
     Resource
-      .make(startSubscription[D](subscription, operationName, variables, extensions))(
-        _.stop()
-          .handleErrorWith(_.logF("Error stopping subscription"))
-      )
+      .makeFull[F, GraphQLSubscription[F, GraphQLResponse[D]]] { poll =>
+        // Only the wait for a connection is cancelable. Once the subscription is registered, its
+        // release must run, so the rest of the acquisition stays uncancelable and never waits.
+        def go: F[GraphQLSubscription[F, GraphQLResponse[D]]] =
+          startSubscription[D](subscription, operationName, variables, extensions)
+            .flatMap(_.fold(poll(awaitConnection) >> go)(_.pure[F]))
+
+        go
+      }(_.stop().handleErrorWith(_.logF("Error stopping subscription")))
       .map(_.stream)
 
+  // Never waits. Returns `none` if the client is still connecting, so the caller must retry.
   private def startSubscription[D: Decoder](
     subscription:  GraphQLQuery,
     operationName: Option[String],
     variables:     Option[JsonObject],
     extensions:    Option[JsonObject]
-  ): F[GraphQLSubscription[F, GraphQLResponse[D]]] =
+  ): F[Option[GraphQLSubscription[F, GraphQLResponse[D]]]] =
     state.get.flatMap {
-      case Connected(_, _, _, _)         =>
+      case Connected(_, _, _, _)     =>
         val request = GraphQLRequest(subscription, operationName, variables, extensions)
 
         buildQueue[D](request).flatMap { case (id, emitter) =>
-          def acquire: F[Unit] =
-            s"Acquiring queue for subscription [$id]".traceF >>
-              stateModify {
-                case Connected(cid, c, i, subscriptions) =>
-                  Connected(cid, c, i, subscriptions + (id -> emitter)) -> F.unit
-                case s @ Connecting(_, _, _, _, latch)   =>
-                  s -> (latch.resolve >> acquire)
-                case s @ _                               =>
-                  s ->
-                    InvalidSubscriptionOperationException("acquire queue", id).logAndRaiseF
-              }
-
-          def release: F[Unit] =
-            s"Releasing queue for subscription[$id]".traceF >>
-              stateModify {
-                case Connected(cid, c, i, subscriptions) =>
-                  Connected(cid, c, i, subscriptions - id) -> F.unit
-                case s @ Connecting(_, _, _, _, latch)   =>
-                  s -> (latch.resolve >> release)
-                case s @ Disconnected(_)                 =>
-                  // It's OK to call release when Disconnected.
-                  // It may happen if client is disconnected and we are halting streams.
-                  s -> F.unit
-              }
-
-          def sendStart: F[Unit] = state.get.flatMap {
-            // The connection may have changed since we created the subscription, so we re-get it.
-            case Connected(_, currentConnection, _, _) =>
-              currentConnection.send(StreamingMessage.FromClient.Subscribe(id, request))
-            case Connecting(_, _, _, _, latch)         =>
-              latch.resolve >> sendStart
-            case s @ _                                 =>
-              InvalidSubscriptionOperationException("send start", id).logAndRaiseF
-          }
-
           val stream =
             Stream
               .fromQueueUnterminated(emitter.queue)
@@ -540,26 +545,34 @@ class ApolloClient[F[_], P, S](
                 s"Stream for subscription [$id] finalized with ExitCase [$c]".traceF >>
                   (c match { // If canceled, we don't want to clean up. Other fibers may be evaluating the stream. Clients can explicitly call `stop()`.
                     case Resource.ExitCase.Canceled => F.unit
-                    case _                          => release
+                    // A failed complete message says nothing about the responses already read.
+                    case _                          =>
+                      releaseSubscription(id)
+                        .handleErrorWith(_.logF(s"Error releasing subscription [$id]"))
                   })
               )
 
-          (acquire >> sendStart).as(createSubscription(stream, id))
+          // Register the subscription and send the subscribe message in one state transition, so
+          // both use the same connection. If the send fails, the registration must go away again.
+          s"Acquiring queue for subscription [$id]".traceF >>
+            stateModify[Option[GraphQLSubscription[F, GraphQLResponse[D]]]] {
+              case Connected(cid, connection, i, subscriptions) =>
+                Connected(cid, connection, i, subscriptions + (id -> emitter)) ->
+                  connection
+                    .send(StreamingMessage.FromClient.Subscribe(id, request))
+                    .onError(_ => discardSubscription(id))
+                    .as(createSubscription(stream, id).some)
+              case s @ Connecting(_, _, _, _, _)                =>
+                s -> none.pure[F]
+              case s @ _                                        =>
+                s -> InvalidSubscriptionOperationException("acquire queue", id).logAndRaiseF_
+            }
         }
-      case Connecting(_, _, _, _, latch) =>
-        latch.resolve >>
-          startSubscription(subscription, operationName, variables, extensions)
-      case _                             =>
-        ConnectionNotInitializedException.logAndRaiseF_
-    }
-
-  private def sendStop(subscriptionId: String): F[Unit] =
-    state.get.flatMap {
-      // The connection may have changed since we created the subscription, so we re-get it.
-      case Connected(_, currentConnection, _, _) =>
-        currentConnection.send(StreamingMessage.FromClient.Complete(subscriptionId))
-      case s @ _                                 =>
-        InvalidSubscriptionOperationException("send stop", subscriptionId).logAndRaiseF
+      case Connecting(_, _, _, _, _) =>
+        none.pure[F]
+      // The client gave up on a connection, so the caller gets the failure that caused it.
+      case Disconnected(_, cause)    =>
+        cause.getOrElse(ConnectionNotInitializedException).logAndRaiseF_
     }
 
   // </GraphQLStreamingClient Helpers>
@@ -581,10 +594,8 @@ object ApolloClient {
     val logPrefix = s"clue.ApolloClient[${if (name.isEmpty) connectionParams else name}]"
 
     for {
-      state            <- Ref[F].of[State[F]](State.Disconnected(ConnectionId.Zero))
-      connectionStatus <-
-        SignallingRef[F, PersistentClientStatus](PersistentClientStatus.Disconnected)
-    } yield new ApolloClient(connectionParams, reconnectionStrategy, state, connectionStatus)(using
+      state <- SignallingRef[F].of[State[F]](State.Disconnected(ConnectionId.Zero))
+    } yield new ApolloClient(connectionParams, reconnectionStrategy, state)(using
       F,
       backend,
       logger.withModifiedString(s => s"$logPrefix $s"),

--- a/core/src/main/scala/clue/websocket/State.scala
+++ b/core/src/main/scala/clue/websocket/State.scala
@@ -9,15 +9,13 @@ import io.circe.*
 // Client internal state for the FSM.
 // We keep a connectionId throughout all states to ensure that callback events (onClose, onMessage)
 // correpond to the current connection iteration. This is important in case of reconnections.
-protected sealed abstract class State[F[_]](val status: PersistentClientStatus) {
-  val connectionId: ConnectionId
-}
+protected enum State[F[_]](val status: PersistentClientStatus) {
+  def connectionId: ConnectionId
 
-protected object State {
-  final case class Disconnected[F[_]](connectionId: ConnectionId)
+  case Disconnected[F[_]](connectionId: ConnectionId, cause: Option[Throwable] = None)
       extends State[F](PersistentClientStatus.Disconnected)
 
-  final case class Connecting[F[_]](
+  case Connecting[F[_]](
     connectionId:  ConnectionId,
     connection:    Option[WebSocketConnection[F]],
     initPayload:   F[JsonObject],
@@ -25,7 +23,7 @@ protected object State {
     latch:         Latch[F, JsonObject]
   ) extends State[F](PersistentClientStatus.Connecting)
 
-  final case class Connected[F[_]](
+  case Connected[F[_]](
     connectionId:  ConnectionId,
     connection:    WebSocketConnection[F],
     initPayload:   F[JsonObject],

--- a/core/src/test/scala/clue/websocket/ApolloClientCloseSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientCloseSuite.scala
@@ -4,38 +4,19 @@
 package clue.websocket
 
 import cats.effect.*
-import cats.effect.std.SecureRandom
 import cats.syntax.all.*
 import clue.DisconnectedException
+import clue.PersistentClientStatus
 import clue.model.GraphQLQuery
 import clue.model.GraphQLResponse
 import clue.model.StreamingMessage
 import io.circe.Json
-import munit.CatsEffectSuite
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.testing.TestingLogger
-
-import scala.concurrent.duration.*
 
 /**
- * Tests for the close path without a reconnection. Every subscription must terminate. It must not
- * wait forever.
+ * Tests for the paths that end a connection. Every subscription must terminate. It must not wait
+ * forever.
  */
-final class ApolloClientCloseSuite extends CatsEffectSuite:
-
-  private given Logger[IO] = TestingLogger.impl[IO]()
-
-  private val Timeout: FiniteDuration = 5.seconds
-
-  private def clientOn(
-    backend:  TestWebSocketBackend[IO],
-    strategy: ReconnectionStrategy = ReconnectionStrategy.never
-  ): IO[ApolloClient[IO, String, Unit]] =
-    for
-      given SecureRandom[IO]            <- SecureRandom.javaSecuritySecureRandom[IO]
-      given WebSocketBackend[IO, String] = backend
-      client                            <- ApolloClient.of[IO, String, Unit]("ws://test", "test", strategy)
-    yield client
+final class ApolloClientCloseSuite extends ApolloClientSuite:
 
   private def subscription(
     client: ApolloClient[IO, String, Unit]
@@ -46,7 +27,6 @@ final class ApolloClientCloseSuite extends CatsEffectSuite:
     for
       backend <- TestWebSocketBackend[IO]()
       client  <- clientOn(backend)
-      _       <- client.connect()
       outcome <- subscription(client).use: stream =>
                    for
                      fiber  <- stream.compile.toList.attempt.start
@@ -59,7 +39,6 @@ final class ApolloClientCloseSuite extends CatsEffectSuite:
     for
       backend  <- TestWebSocketBackend[IO]()
       client   <- clientOn(backend)
-      _        <- client.connect()
       outcomes <- subscription(client).use: first =>
                     subscription(client).use: second =>
                       for
@@ -73,18 +52,41 @@ final class ApolloClientCloseSuite extends CatsEffectSuite:
       assertEquals(outcomes._1, DisconnectedException("1006: gone").asLeft)
       assertEquals(outcomes._2, DisconnectedException("1006: gone").asLeft)
 
+  // The client status now comes from the client state, which changes more often than the status.
+  test("A reconnection reports each client status once"):
+    for
+      backend  <- TestWebSocketBackend[IO]()
+      client   <- clientOn(backend, retryOnce)
+      statuses <- Ref.of[IO, List[PersistentClientStatus]](Nil)
+      watcher  <- client.statusStream.evalTap(s => statuses.update(_ :+ s)).compile.drain.start
+      // The watcher reads the current status first.
+      _        <- IO.sleep(Settle)
+      // The reconnection holds in the Connecting state until the test acknowledges it.
+      _        <- backend.autoAck(false)
+      // The reconnection runs inside the close handler, which waits for the acknowledgement.
+      _        <- backend.closeFromServer(CloseParams(1000, "retry").asRight).start
+      _        <- backend.awaitConnectionInits(2).timeout(Timeout)
+      _        <- awaitStatus(client, PersistentClientStatus.Connecting).timeout(Timeout)
+      _        <- backend.emit(StreamingMessage.FromServer.ConnectionAck())
+      _        <- awaitStatus(client, PersistentClientStatus.Connected).timeout(Timeout)
+      _        <- IO.sleep(Settle)
+      _        <- watcher.cancel
+      seen     <- statuses.get
+    yield assertEquals(
+      seen,
+      List(
+        PersistentClientStatus.Connected,
+        PersistentClientStatus.Connecting,
+        PersistentClientStatus.Connected
+      )
+    )
+
   test("A close while connecting terminates the subscription"):
     // The strategy reconnects once, on the close with reason "retry". The second close
     // then finds the client in the Connecting state and gives up.
-    val strategy: ReconnectionStrategy = (_, reason) =>
-      reason match
-        case Right(Right(CloseParams(_, Some("retry")))) => Duration.Zero.some
-        case _                                           => none
-
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- clientOn(backend, strategy)
-      _       <- client.connect()
+      client  <- clientOn(backend, retryOnce)
       outcome <- subscription(client).use: stream =>
                    for
                      fiber <- stream.compile.toList.attempt.start
@@ -92,16 +94,37 @@ final class ApolloClientCloseSuite extends CatsEffectSuite:
                      _     <- backend.autoAck(false)
                      _     <- backend.closeFromServer(CloseParams(1000, "retry").asRight).start
                      // The second connection_init proves that the client reconnects.
-                     _     <- backend
-                                .awaitSent(
-                                  _.count(
-                                    _.isInstanceOf[
-                                      StreamingMessage.FromClient.ConnectionInit
-                                    ]
-                                  ) === 2
-                                )
-                                .timeout(Timeout)
+                     _     <- backend.awaitConnectionInits(2).timeout(Timeout)
                      _     <- backend.closeFromServer(CloseParams(4000, "gone").asRight)
                      r     <- fiber.joinWithNever.timeout(Timeout)
                    yield r
     yield assertEquals(outcome, DisconnectedException("4000: gone").asLeft)
+
+  test("A disconnection while the client reconnects terminates the subscription"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- clientOn(backend, retryOnce)
+      reader  <- subscription(client).use: stream =>
+                   for
+                     fiber <- stream.compile.toList.attempt.start
+                     _     <- backend.awaitSubscribeId()
+                     // The reconnection must not complete, so that the client stays Connecting.
+                     _     <- backend.autoAck(false)
+                     _     <- backend.closeFromServer(CloseParams(1000, "retry").asRight).start
+                     _     <- backend.awaitConnectionInits(2).timeout(Timeout)
+                     _     <- client.disconnect()
+                   yield fiber
+      done    <- reader.join.as(true).timeoutTo(Timeout, IO.pure(false))
+    yield assert(done, "The subscription stream did not end.")
+
+  test("A subscription that waits for a connection fails with the cause of the close"):
+    for
+      backend <- TestWebSocketBackend[IO](autoAck = false)
+      client  <- clientOn(backend, connect = false)
+      _       <- client.connect().start
+      _       <- backend.awaitConnectionInits(1).timeout(Timeout)
+      // The client is Connecting, so the subscription waits for the connection.
+      fiber   <- subscription(client).use_.attempt.start
+      _       <- backend.closeFromServer(CloseParams(1006, "gone").asRight)
+      outcome <- fiber.joinWithNever.timeout(Timeout)
+    yield assertEquals(outcome, DisconnectedException("1006: gone").asLeft)

--- a/core/src/test/scala/clue/websocket/ApolloClientDecodeFailureSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientDecodeFailureSuite.scala
@@ -3,77 +3,44 @@
 
 package clue.websocket
 
-import cats.data.Ior
 import cats.effect.*
-import cats.effect.std.SecureRandom
 import cats.syntax.all.*
 import clue.model.GraphQLQuery
-import clue.model.GraphQLResponse
-import clue.model.StreamingMessage
 import io.circe.DecodingFailure
 import io.circe.Json
-import munit.CatsEffectSuite
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.testing.TestingLogger
-
-import scala.concurrent.duration.*
 
 /**
  * Tests for a `next` payload that does not match the `Data` decoder of its subscription. The
  * failure must stay inside that one subscription.
  */
-final class ApolloClientDecodeFailureSuite extends CatsEffectSuite:
-
-  private given Logger[IO] = TestingLogger.impl[IO]()
-
-  private val Timeout: FiniteDuration = 5.seconds
-
-  private def connectedClient(
-    backend: TestWebSocketBackend[IO]
-  ): IO[ApolloClient[IO, String, Unit]] =
-    for
-      given SecureRandom[IO]            <- SecureRandom.javaSecuritySecureRandom[IO]
-      given WebSocketBackend[IO, String] = backend
-      client                            <- ApolloClient.of[IO, String, Unit]("ws://test")
-      _                                 <- client.connect()
-    yield client
-
-  /** The subscription id that the client generated for the given query text. */
-  private def idOf(backend: TestWebSocketBackend[IO], query: String): IO[String] =
-    backend.sent.map(
-      _.collectFirst {
-        case StreamingMessage.FromClient.Subscribe(id, request) if request.query.value === query =>
-          id
-      }.get
-    )
-
-  private def next(id: String, data: Json): StreamingMessage.FromServer =
-    StreamingMessage.FromServer.Next(id, GraphQLResponse(Ior.right(data)))
+final class ApolloClientDecodeFailureSuite extends ApolloClientSuite:
 
   test("A bad payload does not raise out of the message handler"):
     val query = "subscription { a }"
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- connectedClient(backend)
+      client  <- clientOn(backend)
       outcome <- client
                    .subscribeInternal[Int](GraphQLQuery(query))
                    .use: _ =>
-                     idOf(backend, query).flatMap: id =>
-                       backend.emit(next(id, Json.fromString("not an int"))).attempt
+                     backend
+                       .awaitSubscribeId(query.some)
+                       .flatMap: id =>
+                         backend.emitNext(id, Json.fromString("not an int")).attempt
     yield assertEquals(outcome, ().asRight)
 
   test("A bad payload raises on its own subscription stream"):
     val query = "subscription { a }"
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- connectedClient(backend)
+      client  <- clientOn(backend)
       outcome <- client
                    .subscribeInternal[Int](GraphQLQuery(query))
                    .use: stream =>
                      for
-                       id    <- idOf(backend, query)
+                       id    <- backend.awaitSubscribeId(query.some)
                        fiber <- stream.head.compile.lastOrError.attempt.start
-                       _     <- backend.emit(next(id, Json.fromString("not an int")))
+                       _     <- backend.emitNext(id, Json.fromString("not an int"))
                        r     <- fiber.joinWithNever.timeout(Timeout)
                      yield r
     yield assert(outcome.swap.exists(_.isInstanceOf[DecodingFailure]), clue = outcome)
@@ -83,7 +50,7 @@ final class ApolloClientDecodeFailureSuite extends CatsEffectSuite:
     val queryB = "subscription { b }"
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- connectedClient(backend)
+      client  <- clientOn(backend)
       outcome <- client
                    .subscribeInternal[Int](GraphQLQuery(queryA))
                    .use: streamA =>
@@ -91,12 +58,12 @@ final class ApolloClientDecodeFailureSuite extends CatsEffectSuite:
                        .subscribeInternal[Int](GraphQLQuery(queryB))
                        .use: streamB =>
                          for
-                           idA    <- idOf(backend, queryA)
-                           idB    <- idOf(backend, queryB)
+                           idA    <- backend.awaitSubscribeId(queryA.some)
+                           idB    <- backend.awaitSubscribeId(queryB.some)
                            fiberA <- streamA.head.compile.lastOrError.attempt.start
                            fiberB <- streamB.head.compile.lastOrError.attempt.start
-                           _      <- backend.emit(next(idA, Json.fromString("not an int")))
-                           _      <- backend.emit(next(idB, Json.fromInt(2)))
+                           _      <- backend.emitNext(idA, Json.fromString("not an int"))
+                           _      <- backend.emitNext(idB, Json.fromInt(2))
                            a      <- fiberA.joinWithNever.timeout(Timeout)
                            b      <- fiberB.joinWithNever.timeout(Timeout)
                          yield (a, b)

--- a/core/src/test/scala/clue/websocket/ApolloClientPongSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientPongSuite.scala
@@ -3,37 +3,18 @@
 
 package clue.websocket
 
-import cats.data.Ior
 import cats.effect.*
-import cats.effect.std.SecureRandom
 import cats.syntax.all.*
 import clue.PersistentClientStatus
 import clue.model.GraphQLQuery
-import clue.model.GraphQLResponse
-import clue.model.StreamingMessage
 import io.circe.Json
-import munit.CatsEffectSuite
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.testing.TestingLogger
 
-final class ApolloClientPongSuite extends CatsEffectSuite:
-
-  private given Logger[IO] = TestingLogger.impl[IO]()
-
-  private def connectedClient(
-    backend: TestWebSocketBackend[IO]
-  ): IO[ApolloClient[IO, String, Unit]] =
-    for
-      given SecureRandom[IO]            <- SecureRandom.javaSecuritySecureRandom[IO]
-      given WebSocketBackend[IO, String] = backend
-      client                            <- ApolloClient.of[IO, String, Unit]("ws://test")
-      _                                 <- client.connect()
-    yield client
+final class ApolloClientPongSuite extends ApolloClientSuite:
 
   test("A pong from the server leaves the client connected"):
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- connectedClient(backend)
+      client  <- clientOn(backend)
       _       <- backend.emitRaw("""{"type":"pong"}""")
       status  <- client.status
     yield assertEquals(status, PersistentClientStatus.Connected)
@@ -41,7 +22,7 @@ final class ApolloClientPongSuite extends CatsEffectSuite:
   test("A pong with a payload leaves the client connected"):
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- connectedClient(backend)
+      client  <- clientOn(backend)
       _       <- backend.emitRaw("""{"type":"pong","payload":{"ok":true}}""")
       status  <- client.status
     yield assertEquals(status, PersistentClientStatus.Connected)
@@ -49,7 +30,7 @@ final class ApolloClientPongSuite extends CatsEffectSuite:
   test("A pong from the server draws no reply"):
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- connectedClient(backend)
+      client  <- clientOn(backend)
       before  <- backend.sent
       _       <- backend.emitRaw("""{"type":"pong"}""")
       after   <- backend.sent
@@ -58,22 +39,15 @@ final class ApolloClientPongSuite extends CatsEffectSuite:
   test("A pong from the server does not disturb an active subscription"):
     for
       backend <- TestWebSocketBackend[IO]()
-      client  <- connectedClient(backend)
+      client  <- clientOn(backend)
       result  <- client
                    .subscribeInternal[Json](GraphQLQuery("subscription { x }"))
                    .use: stream =>
                      for
-                       id    <- backend.sent.map(
-                                  _.collectFirst { case StreamingMessage.FromClient.Subscribe(i, _) =>
-                                    i
-                                  }.get
-                                )
+                       id    <- backend.awaitSubscribeId()
                        fiber <- stream.head.compile.lastOrError.start
                        _     <- backend.emitRaw("""{"type":"pong"}""")
-                       _     <- backend.emit(
-                                  StreamingMessage.FromServer
-                                    .Next(id, GraphQLResponse(Ior.right(Json.fromInt(1))))
-                                )
+                       _     <- backend.emitNext(id, Json.fromInt(1))
                        r     <- fiber.joinWithNever
                      yield r
     yield assertEquals(result.data, Json.fromInt(1).some)

--- a/core/src/test/scala/clue/websocket/ApolloClientRequestSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientRequestSuite.scala
@@ -1,0 +1,163 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.websocket
+
+import cats.effect.*
+import cats.syntax.all.*
+import clue.PersistentClientStatus
+import clue.model.GraphQLQuery
+import clue.model.GraphQLResponse
+import clue.model.StreamingMessage
+import io.circe.Json
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration.*
+
+/**
+ * Tests for a one-shot request over a WebSocket. The caller must be able to cancel the request, and
+ * the client must clean up afterwards.
+ */
+final class ApolloClientRequestSuite extends ApolloClientSuite:
+
+  private val Query  = "query { x }"
+  private val Answer = Json.fromInt(7)
+
+  /** Starts a request and waits until the client sent the subscribe message for it. */
+  private def startedRequest(
+    backend: TestWebSocketBackend[IO],
+    client:  ApolloClient[IO, String, Unit]
+  ): IO[(FiberIO[GraphQLResponse[Json]], String)] =
+    for
+      fiber <- client.requestInternal[Json](GraphQLQuery(Query)).start
+      id    <- backend.awaitSubscribeId()
+    yield (fiber, id)
+
+  /** Starts a request and answers it from the server. */
+  private def answeredRequest(
+    backend: TestWebSocketBackend[IO],
+    client:  ApolloClient[IO, String, Unit]
+  ): IO[(GraphQLResponse[Json], String)] =
+    for
+      (fiber, id) <- startedRequest(backend, client)
+      _           <- backend.emitNext(id, Answer)
+      response    <- fiber.joinWithNever.timeout(Timeout)
+    yield (response, id)
+
+  test("A request on a silent server honors a timeout"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- clientOn(backend)
+      outcome <- client
+                   .requestInternal[Json](GraphQLQuery(Query))
+                   .timeout(200.millis)
+                   .attempt
+    yield assert(outcome.swap.exists(_.isInstanceOf[TimeoutException]), clue = outcome)
+
+  test("A request started while the client connects honors a timeout"):
+    for
+      backend <- TestWebSocketBackend[IO](autoAck = false)
+      client  <- clientOn(backend, connect = false)
+      _       <- client.connect().start
+      _       <- backend.awaitConnectionInits(1).timeout(Timeout)
+      outcome <- client
+                   .requestInternal[Json](GraphQLQuery(Query))
+                   .timeout(200.millis)
+                   .attempt
+    yield assert(outcome.swap.exists(_.isInstanceOf[TimeoutException]), clue = outcome)
+
+  test("A canceled request sends a complete message for its id"):
+    for
+      backend   <- TestWebSocketBackend[IO]()
+      client    <- clientOn(backend)
+      (f, id)   <- startedRequest(backend, client)
+      _         <- f.cancel
+      completes <- backend.completes
+    yield assertEquals(completes, List(id))
+
+  test("A canceled request leaves no subscription for a reconnection to restart"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- clientOn(backend, retryOnce)
+      (f, _)  <- startedRequest(backend, client)
+      _       <- f.cancel
+      _       <- backend.closeFromServer(CloseParams(1000, "retry").asRight)
+      // The second connection_init proves that the client reconnected.
+      _       <- backend.awaitConnectionInits(2).timeout(Timeout)
+      after   <- backend.subscribes
+    yield assertEquals(after.length, 1)
+
+  /** Drives the client into a reconnection that never completes, with the request still pending. */
+  private def reconnecting(
+    backend: TestWebSocketBackend[IO],
+    client:  ApolloClient[IO, String, Unit]
+  ): IO[FiberIO[GraphQLResponse[Json]]] =
+    for
+      (f, _) <- startedRequest(backend, client)
+      _      <- backend.autoAck(false)
+      // The client reconnects inside `onClose` and waits there for an ack that never arrives, so
+      // the close runs in its own fiber.
+      _      <- backend.closeFromServer(CloseParams(1000, "retry").asRight).start
+      // The second connection_init proves that the client reconnects.
+      _      <- backend.awaitConnectionInits(2).timeout(Timeout)
+    yield f
+
+  test("A request canceled while the client reconnects returns"):
+    for
+      backend  <- TestWebSocketBackend[IO]()
+      client   <- clientOn(backend, retryOnce)
+      f        <- reconnecting(backend, client)
+      canceler <- f.cancel.start
+      done     <- canceler.join.as(true).timeoutTo(Timeout, IO.pure(false))
+    yield assert(done, "The cancelation did not return.")
+
+  test("A request canceled while the client reconnects leaves no subscription to restart"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- clientOn(backend, retryOnce)
+      f       <- reconnecting(backend, client)
+      _       <- f.cancel.timeout(Timeout)
+      _       <- backend.emit(StreamingMessage.FromServer.ConnectionAck())
+      _       <- awaitStatus(client, PersistentClientStatus.Connected).timeout(Timeout)
+      _       <- IO.sleep(Settle)
+      after   <- backend.subscribes
+    yield assertEquals(after.length, 1)
+
+  test("A request that the server answers logs no error"):
+    for
+      backend          <- TestWebSocketBackend[IO]()
+      (client, logger) <- clientWithLogger(backend)
+      _                <- answeredRequest(backend, client)
+      logged           <- errors(logger)
+    yield assertEquals(logged, Vector.empty)
+
+  // The protocol permits a complete message for an operation that the server already completed, so
+  // the client always sends one.
+  test("A request that the server answers sends a complete message"):
+    for
+      backend   <- TestWebSocketBackend[IO]()
+      client    <- clientOn(backend)
+      (_, id)   <- answeredRequest(backend, client)
+      completes <- backend.completes
+    yield assertEquals(completes, List(id))
+
+  // The caller already holds the response, so a dead socket must not turn it into a failure.
+  test("A request whose complete message fails still returns the response"):
+    for
+      backend          <- TestWebSocketBackend[IO]()
+      (client, logger) <- clientWithLogger(backend)
+      (f, id)          <- startedRequest(backend, client)
+      _                <- backend.failSends(true)
+      _                <- backend.emitNext(id, Answer)
+      result           <- f.joinWithNever.timeout(Timeout)
+      logged           <- errors(logger)
+    yield
+      assertEquals(result.data, Answer.some)
+      assert(logged.exists(_.contains("Error releasing subscription")), clue = logged)
+
+  test("A request returns the first response from the server"):
+    for
+      backend     <- TestWebSocketBackend[IO]()
+      client      <- clientOn(backend)
+      (result, _) <- answeredRequest(backend, client)
+    yield assertEquals(result.data, Answer.some)

--- a/core/src/test/scala/clue/websocket/ApolloClientSubscriptionSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientSubscriptionSuite.scala
@@ -1,0 +1,159 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.websocket
+
+import cats.effect.*
+import cats.syntax.all.*
+import clue.PersistentClientStatus
+import clue.model.GraphQLQuery
+import clue.model.StreamingMessage
+import io.circe.Json
+
+/** Tests for the end of a subscription, whichever side ends it. */
+final class ApolloClientSubscriptionSuite extends ApolloClientSuite:
+
+  private val Subscription = "subscription { x }"
+
+  test("A subscription that the server completes logs no error"):
+    for
+      backend          <- TestWebSocketBackend[IO]()
+      (client, logger) <- clientWithLogger(backend)
+      _                <- client
+                            .subscribeInternal[Json](GraphQLQuery(Subscription))
+                            .use: stream =>
+                              for
+                                fiber <- stream.compile.toList.start
+                                id    <- backend.awaitSubscribeId()
+                                _     <- backend.emitNext(id, Json.fromInt(1))
+                                _     <- backend.emit(StreamingMessage.FromServer.Complete(id))
+                                _     <- fiber.joinWithNever.timeout(Timeout)
+                              yield ()
+      logged           <- errors(logger)
+    yield assertEquals(logged, Vector.empty)
+
+  test("A subscription that the server completes draws no complete message back"):
+    for
+      backend   <- TestWebSocketBackend[IO]()
+      client    <- clientOn(backend)
+      _         <- client
+                     .subscribeInternal[Json](GraphQLQuery(Subscription))
+                     .use: stream =>
+                       for
+                         fiber <- stream.compile.toList.start
+                         id    <- backend.awaitSubscribeId()
+                         _     <- backend.emit(StreamingMessage.FromServer.Complete(id))
+                         _     <- fiber.joinWithNever.timeout(Timeout)
+                       yield ()
+      completes <- backend.completes
+    yield assertEquals(completes, Nil)
+
+  // Nobody reads the stream, so only the complete message can drop the subscription.
+  test("A subscription that the server completes is not restarted on a reconnection"):
+    for
+      backend    <- TestWebSocketBackend[IO]()
+      client     <- clientOn(backend, retryOnce)
+      _          <- client
+                      .subscribeInternal[Json](GraphQLQuery(Subscription))
+                      .use: _ =>
+                        for
+                          id <- backend.awaitSubscribeId()
+                          _  <- backend.emit(StreamingMessage.FromServer.Complete(id))
+                          _  <- backend.closeFromServer(CloseParams(1006, "retry").asRight)
+                          _  <- backend.awaitConnectionInits(2).timeout(Timeout)
+                          _  <- IO.sleep(Settle)
+                        yield ()
+      subscribes <- backend.subscribes
+      completes  <- backend.completes
+    yield
+      assertEquals(subscribes.length, 1)
+      assertEquals(completes, Nil)
+
+  test("A subscription that the caller stops after one element sends a complete message"):
+    for
+      backend   <- TestWebSocketBackend[IO]()
+      client    <- clientOn(backend)
+      id        <- client
+                     .subscribeInternal[Json](GraphQLQuery(Subscription))
+                     .use: stream =>
+                       for
+                         fiber <- stream.take(1).compile.toList.start
+                         id    <- backend.awaitSubscribeId()
+                         _     <- backend.emitNext(id, Json.fromInt(1))
+                         _     <- fiber.joinWithNever.timeout(Timeout)
+                       yield id
+      completes <- backend.completes
+    yield assertEquals(completes, List(id))
+
+  test("A subscription that the caller releases first sends a complete message"):
+    for
+      backend   <- TestWebSocketBackend[IO]()
+      client    <- clientOn(backend)
+      id        <- client
+                     .subscribeInternal[Json](GraphQLQuery(Subscription))
+                     .use(_ => backend.awaitSubscribeId())
+      completes <- backend.completes
+    yield assertEquals(completes, List(id))
+
+  test("A subscription that starts and ends repeats no client status"):
+    for
+      backend  <- TestWebSocketBackend[IO]()
+      client   <- clientOn(backend)
+      statuses <- Ref.of[IO, List[PersistentClientStatus]](Nil)
+      watcher  <- client.statusStream.evalTap(s => statuses.update(_ :+ s)).compile.drain.start
+      _        <- client
+                    .subscribeInternal[Json](GraphQLQuery(Subscription))
+                    .use(_ => backend.awaitSubscribeId().timeout(Timeout))
+      _        <- IO.sleep(Settle)
+      _        <- watcher.cancel
+      seen     <- statuses.get
+    yield assertEquals(seen, List(PersistentClientStatus.Connected))
+
+  // The stop drops the subscription from the state, so no other event can end its stream.
+  test("A subscription whose complete message fails still ends its stream"):
+    for
+      backend <- TestWebSocketBackend[IO]()
+      client  <- clientOn(backend)
+      reader  <- client
+                   .subscribeInternal[Json](GraphQLQuery(Subscription))
+                   .use: stream =>
+                     for
+                       fiber <- stream.compile.toList.start
+                       _     <- backend.awaitSubscribeId()
+                       _     <- backend.failSends(true)
+                     yield fiber
+      // The resource release stops the subscription, and the send of the complete message fails.
+      done    <- reader.join.as(true).timeoutTo(Timeout, IO.pure(false))
+    yield assert(done, "The subscription stream did not end.")
+
+  // The acquisition fails, so the resource release never runs and cannot do the cleanup.
+  test("A subscription whose subscribe message fails is not restarted on a reconnection"):
+    for
+      backend    <- TestWebSocketBackend[IO]()
+      client     <- clientOn(backend, retryOnce)
+      _          <- backend.failSends(true)
+      result     <- client.subscribeInternal[Json](GraphQLQuery(Subscription)).use_.attempt
+      _          <- backend.failSends(false)
+      _          <- backend.closeFromServer(CloseParams(1006, "retry").asRight)
+      _          <- backend.awaitConnectionInits(2).timeout(Timeout)
+      _          <- IO.sleep(Settle)
+      subscribes <- backend.subscribes
+    yield
+      assert(result.isLeft, "The subscription did not fail.")
+      assertEquals(subscribes, Nil)
+
+  test("A subscription released after a disconnection logs no error"):
+    for
+      backend          <- TestWebSocketBackend[IO]()
+      (client, logger) <- clientWithLogger(backend)
+      _                <- client
+                            .subscribeInternal[Json](GraphQLQuery(Subscription))
+                            .use: stream =>
+                              for
+                                fiber <- stream.compile.toList.attempt.start
+                                _     <- backend.awaitSubscribeId()
+                                _     <- backend.closeFromServer(CloseParams(1006, "gone").asRight)
+                                _     <- fiber.joinWithNever.timeout(Timeout)
+                              yield ()
+      logged           <- errors(logger)
+    yield assertEquals(logged, Vector.empty)

--- a/core/src/test/scala/clue/websocket/ApolloClientSuite.scala
+++ b/core/src/test/scala/clue/websocket/ApolloClientSuite.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.websocket
+
+import cats.effect.*
+import cats.effect.std.SecureRandom
+import cats.syntax.all.*
+import clue.PersistentClientStatus
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.testing.TestingLogger
+
+import scala.concurrent.duration.*
+
+/** Common fixtures for the tests of the WebSocket client. */
+trait ApolloClientSuite extends CatsEffectSuite:
+
+  protected given Logger[IO] = TestingLogger.impl[IO]()
+
+  protected val Timeout: FiniteDuration = 5.seconds
+
+  /** The wait before a test asserts that the client sent no further message. */
+  protected val Settle: FiniteDuration = 100.millis
+
+  override def munitIOTimeout: Duration = 10.seconds
+
+  protected def clientOn(
+    backend:  TestWebSocketBackend[IO],
+    strategy: ReconnectionStrategy = ReconnectionStrategy.never,
+    connect:  Boolean = true
+  )(using Logger[IO]): IO[ApolloClient[IO, String, Unit]] =
+    for
+      given SecureRandom[IO]            <- SecureRandom.javaSecuritySecureRandom[IO]
+      given WebSocketBackend[IO, String] = backend
+      client                            <- ApolloClient.of[IO, String, Unit]("ws://test", "test", strategy)
+      _                                 <- client.connect().whenA(connect)
+    yield client
+
+  /** Builds a client with a logger that the test can inspect. */
+  protected def clientWithLogger(
+    backend:  TestWebSocketBackend[IO],
+    strategy: ReconnectionStrategy = ReconnectionStrategy.never
+  ): IO[(ApolloClient[IO, String, Unit], TestingLogger[IO])] =
+    val logger = TestingLogger.impl[IO]()
+    clientOn(backend, strategy)(using logger).tupleRight(logger)
+
+  /** Reconnects on a close with the reason "retry", and gives up on any other. */
+  protected val retryOnce: ReconnectionStrategy = (_, reason) =>
+    reason match
+      case Right(Right(CloseParams(_, Some("retry")))) => Duration.Zero.some
+      case _                                           => none
+
+  protected def awaitStatus(
+    client: ApolloClient[IO, String, Unit],
+    status: PersistentClientStatus
+  ): IO[Unit] =
+    client.statusStream.find(_ == status).compile.drain
+
+  /** The messages that the logger recorded at the error level. */
+  protected def errors(logger: TestingLogger[IO]): IO[Vector[String]] =
+    logger.logged.map(_.collect { case TestingLogger.ERROR(m, _) => m })

--- a/core/src/test/scala/clue/websocket/TestWebSocketBackend.scala
+++ b/core/src/test/scala/clue/websocket/TestWebSocketBackend.scala
@@ -3,13 +3,17 @@
 
 package clue.websocket
 
+import cats.data.Ior
 import cats.effect.*
 import cats.syntax.all.*
 import clue.ConnectionId
 import clue.PersistentBackendHandler
 import clue.PersistentConnection
+import clue.model.GraphQLResponse
 import clue.model.StreamingMessage
 import clue.model.json.given
+import fs2.concurrent.SignallingRef
+import io.circe.Json
 import io.circe.syntax.*
 
 /**
@@ -17,14 +21,18 @@ import io.circe.syntax.*
  * messages that the client sends. It feeds server messages and close events to the client.
  */
 final class TestWebSocketBackend[F[_]: Async] private (
-  sentRef:    Ref[F, Vector[StreamingMessage.FromClient]],
-  currentRef: Ref[F, Option[(PersistentBackendHandler[F, CloseEvent], ConnectionId)]],
-  closesRef:  Ref[F, Vector[Option[CloseParams]]],
-  autoAckRef: Ref[F, Boolean]
+  sentRef:      SignallingRef[F, Vector[StreamingMessage.FromClient]],
+  currentRef:   Ref[F, Option[(PersistentBackendHandler[F, CloseEvent], ConnectionId)]],
+  closesRef:    Ref[F, Vector[Option[CloseParams]]],
+  autoAckRef:   Ref[F, Boolean],
+  failSendsRef: Ref[F, Boolean]
 ) extends WebSocketBackend[F, String]:
 
   /** Turns the automatic `connection_ack` answer on or off. */
   def autoAck(enabled: Boolean): F[Unit] = autoAckRef.set(enabled)
+
+  /** Makes every further `send` raise, like a socket that died without a close event. */
+  def failSends(enabled: Boolean): F[Unit] = failSendsRef.set(enabled)
 
   /** The messages that the client sent, in order. */
   val sent: F[List[StreamingMessage.FromClient]] = sentRef.get.map(_.toList)
@@ -32,13 +40,39 @@ final class TestWebSocketBackend[F[_]: Async] private (
   /** The close parameters of every `closeInternal` call, in order. */
   val closes: F[List[Option[CloseParams]]] = closesRef.get.map(_.toList)
 
+  /** The subscribe messages that the client sent, in order. */
+  val subscribes: F[List[StreamingMessage.FromClient.Subscribe]] =
+    sent.map(_.collect { case s: StreamingMessage.FromClient.Subscribe => s })
+
+  /** The subscription ids of the complete messages that the client sent, in order. */
+  val completes: F[List[String]] =
+    sent.map(_.collect { case StreamingMessage.FromClient.Complete(id) => id })
+
+  /** Waits until the recorded client messages produce a result, and returns it. */
+  private def awaitSentF[A](f: List[StreamingMessage.FromClient] => Option[A]): F[A] =
+    sentRef.discrete.map(msgs => f(msgs.toList)).unNone.head.compile.lastOrError
+
+  /** Waits for the first subscribe message, for `query` if given, and returns its id. */
+  def awaitSubscribeId(query: Option[String] = none): F[String] =
+    awaitSentF(_.collectFirst {
+      case s: StreamingMessage.FromClient.Subscribe if query.forall(_ === s.payload.query.value) =>
+        s.id
+    })
+
   /** Waits until the recorded client messages match the condition. */
-  def awaitSent(condition: List[StreamingMessage.FromClient] => Boolean): F[Unit] =
-    sent.flatMap: msgs =>
-      if condition(msgs) then Async[F].unit else Async[F].cede >> awaitSent(condition)
+  private def awaitSent(condition: List[StreamingMessage.FromClient] => Boolean): F[Unit] =
+    awaitSentF(msgs => Option.when(condition(msgs))(()))
+
+  /** Waits until the client sent at least `count` connection_init messages. */
+  def awaitConnectionInits(count: Int): F[Unit] =
+    awaitSent(_.count(_.isInstanceOf[StreamingMessage.FromClient.ConnectionInit]) >= count)
 
   /** Sends a message from the server to the client. */
   def emit(msg: StreamingMessage.FromServer): F[Unit] = emitRaw(msg.asJson.noSpaces)
+
+  /** Sends a data message from the server for the subscription id. */
+  def emitNext(id: String, data: Json): F[Unit] =
+    emit(StreamingMessage.FromServer.Next(id, GraphQLResponse(Ior.right(data))))
 
   /** Sends raw text from the server to the client. */
   def emitRaw(msg: String): F[Unit] =
@@ -58,17 +92,20 @@ final class TestWebSocketBackend[F[_]: Async] private (
       .as(
         new PersistentConnection[F, CloseParams]:
           override def send(msg: StreamingMessage.FromClient): F[Unit] =
-            sentRef.update(_ :+ msg) >>
-              (msg match
-                case StreamingMessage.FromClient.ConnectionInit(_) =>
-                  autoAckRef.get.flatMap: enabled =>
-                    if enabled then
-                      handler.onMessage(
-                        connectionId,
-                        StreamingMessage.FromServer.ConnectionAck().asJson.noSpaces
-                      )
-                    else Async[F].unit
-                case _                                             => Async[F].unit)
+            failSendsRef.get.ifM(
+              Async[F].raiseError(new RuntimeException("send failed")),
+              sentRef.update(_ :+ msg) >>
+                (msg match
+                  case StreamingMessage.FromClient.ConnectionInit(_) =>
+                    autoAckRef.get.flatMap: enabled =>
+                      if enabled then
+                        handler.onMessage(
+                          connectionId,
+                          StreamingMessage.FromServer.ConnectionAck().asJson.noSpaces
+                        )
+                      else Async[F].unit
+                  case _                                             => Async[F].unit)
+            )
 
           override protected[clue] def closeInternal(
             closeParameters: Option[CloseParams]
@@ -79,8 +116,9 @@ final class TestWebSocketBackend[F[_]: Async] private (
 object TestWebSocketBackend:
   def apply[F[_]: Async](autoAck: Boolean = true): F[TestWebSocketBackend[F]] =
     for
-      sent   <- Ref.of[F, Vector[StreamingMessage.FromClient]](Vector.empty)
+      sent   <- SignallingRef.of[F, Vector[StreamingMessage.FromClient]](Vector.empty)
       cur    <- Ref.of[F, Option[(PersistentBackendHandler[F, CloseEvent], ConnectionId)]](none)
       closes <- Ref.of[F, Vector[Option[CloseParams]]](Vector.empty)
       ack    <- Ref.of[F, Boolean](autoAck)
-    yield new TestWebSocketBackend(sent, cur, closes, ack)
+      fail   <- Ref.of[F, Boolean](false)
+    yield new TestWebSocketBackend(sent, cur, closes, ack, fail)


### PR DESCRIPTION
requestInternal used F.async and returned none as the finalizer. In cats-effect 3 the registration runs uncancelably, so the caller could neither cancel the request nor apply a timeout. On a dead connection the fiber stayed blocked forever.

Drive the request with a Resource over the subscription instead, and read the first element of its stream. The wait is now cancelable. The finalizer halts the emitter, sends the Complete message, and drops the subscription from the state, so a later reconnection does not restart it.

startSubscription now returns the subscription id with the subscription, and the release step moves to releaseSubscription.