### PR TITLE
Add a Ping message to FromClient

### DIFF
--- a/model/src/main/scala/clue/model/StreamingMessage.scala
+++ b/model/src/main/scala/clue/model/StreamingMessage.scala
@@ -50,7 +50,22 @@ object StreamingMessage:
       inline def apply(payload: JsonObject) = new ConnectionInit(payload.some)
 
     /**
-     * Client initiated message that keeps the client connection alive.
+     * Client initiated message that keeps the client connection alive. The server must reply with a
+     * `FromServer.Pong`. It can be sent at any time after `ConnectionInit`.
+     *
+     * @param payload
+     *   optional field can be used to transfer additional details about the ping
+     */
+    final case class Ping(payload: Option[JsonObject] = none)
+        extends FromClient
+        with Payload[Option[JsonObject]] derives Eq
+
+    object Ping:
+      inline def apply(payload: JsonObject) = new Ping(payload.some)
+
+    /**
+     * Client initiated message that keeps the client connection alive. It is either a response to a
+     * server `Ping` or a unidirectional heartbeat. It can be sent at any time.
      *
      * @param payload
      *   optional field can be used to transfer additional details about the pong

--- a/model/src/main/scala/clue/model/json/package.scala
+++ b/model/src/main/scala/clue/model/json/package.scala
@@ -55,6 +55,22 @@ package object json {
         p <- c.get[Option[JsonObject]]("payload")
       yield FromClient.ConnectionInit(p)
 
+  given Encoder[FromClient.Ping] =
+    Encoder.instance: a =>
+      Json
+        .obj(
+          "type"    -> Json.fromString("ping"),
+          "payload" -> a.payload.asJson
+        )
+        .dropNullValues
+
+  given Decoder[FromClient.Ping] =
+    Decoder.instance: c =>
+      for
+        _ <- checkType(c, "ping")
+        p <- c.get[Option[JsonObject]]("payload")
+      yield FromClient.Ping(p)
+
   given Encoder[FromClient.Pong] =
     Encoder.instance: a =>
       Json
@@ -104,6 +120,7 @@ package object json {
   given Encoder[StreamingMessage.FromClient] =
     Encoder.instance:
       case m @ FromClient.ConnectionInit(_) => m.asJson
+      case m @ FromClient.Ping(_)           => m.asJson
       case m @ FromClient.Pong(_)           => m.asJson
       case m @ FromClient.Subscribe(_, _)   => m.asJson
       case m @ FromClient.Complete(_)       => m.asJson
@@ -113,6 +130,7 @@ package object json {
       c.get[String]("type")
         .flatMap:
           case "connection_init" => Decoder[FromClient.ConnectionInit].widen(c)
+          case "ping"            => Decoder[FromClient.Ping].widen(c)
           case "pong"            => Decoder[FromClient.Pong].widen(c)
           case "subscribe"       => Decoder[FromClient.Subscribe].widen(c)
           case "complete"        => Decoder[FromClient.Complete].widen(c)
@@ -140,7 +158,7 @@ package object json {
         p <- c.get[Option[JsonObject]]("payload")
       yield FromServer.ConnectionAck(p)
 
-  given Encoder[FromServer.Ping] =
+  given FromServerPingEncoder: Encoder[FromServer.Ping] =
     Encoder.instance: a =>
       Json
         .obj(
@@ -149,7 +167,7 @@ package object json {
         )
         .dropNullValues
 
-  given Decoder[FromServer.Ping] =
+  given FromServerPingDecoder: Decoder[FromServer.Ping] =
     Decoder.instance: c =>
       for
         _ <- checkType(c, "ping")

--- a/model/src/test/scala/clue/model/arb/ArbFromClient.scala
+++ b/model/src/test/scala/clue/model/arb/ArbFromClient.scala
@@ -20,6 +20,10 @@ trait ArbFromClient:
     Arbitrary:
       arbitrary[Option[JsonObject]](using arbOptJsonObject).map(ConnectionInit(_))
 
+  given Arbitrary[Ping] =
+    Arbitrary:
+      arbitrary[Option[JsonObject]](using arbOptJsonObject).map(Ping(_))
+
   given Arbitrary[Pong] =
     Arbitrary:
       arbitrary[Option[JsonObject]](using arbOptJsonObject).map(Pong(_))
@@ -39,6 +43,7 @@ trait ArbFromClient:
     Arbitrary:
       Gen.oneOf[FromClient](
         arbitrary[ConnectionInit],
+        arbitrary[Ping],
         arbitrary[Pong],
         arbitrary[Subscribe],
         arbitrary[Complete]

--- a/model/src/test/scala/clue/model/json/FromClientPingCodecSuite.scala
+++ b/model/src/test/scala/clue/model/json/FromClientPingCodecSuite.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.model.json
+
+import cats.syntax.all.*
+import clue.model.StreamingMessage.FromClient
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.parser.decode
+import io.circe.syntax.*
+
+final class FromClientPingCodecSuite extends munit.FunSuite:
+
+  test("A ping without a payload decodes as FromClient.Ping"):
+    assertEquals(decode[FromClient]("""{"type":"ping"}"""), Right(FromClient.Ping()))
+
+  test("A ping with a payload decodes as FromClient.Ping"):
+    val payload = JsonObject("seq" -> Json.fromInt(7))
+    assertEquals(
+      decode[FromClient]("""{"type":"ping","payload":{"seq":7}}"""),
+      Right(FromClient.Ping(payload.some))
+    )
+
+  test("A ping with a null payload decodes as FromClient.Ping"):
+    assertEquals(decode[FromClient]("""{"type":"ping","payload":null}"""), Right(FromClient.Ping()))
+
+  test("A ping without a payload encodes without a payload field"):
+    assertEquals((FromClient.Ping(): FromClient).asJson,
+                 Json.obj("type" -> Json.fromString("ping"))
+    )
+
+  test("A ping with a payload encodes with the payload field"):
+    val payload = JsonObject("seq" -> Json.fromInt(7))
+    assertEquals(
+      (FromClient.Ping(payload.some): FromClient).asJson,
+      Json.obj("type" -> Json.fromString("ping"), "payload" -> payload.asJson)
+    )
+
+  test("A pong does not decode as FromClient.Ping"):
+    assertEquals(decode[FromClient]("""{"type":"pong"}"""), Right(FromClient.Pong()))


### PR DESCRIPTION
The graphql-transport-ws protocol permits Ping and Pong in both
directions. FromServer had both cases, but FromClient had Pong only.

Needed for a change in lucuma-graphql-routes.
