### PR TITLE
Support application/graphql-response+json over HTTP

### DIFF
--- a/core/src/main/scala/clue/GraphQLOverHttp.scala
+++ b/core/src/main/scala/clue/GraphQLOverHttp.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+/**
+ * Media types and response rules of the GraphQL-over-HTTP specification.
+ *
+ * See https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md
+ */
+object GraphQLOverHttp:
+
+  /** The media type for GraphQL responses. */
+  val GraphQLResponseMediaType: String = "application/graphql-response+json"
+
+  /**
+   * Extract the media type from the value of a `Content-Type` header. The result has no parameters
+   * and is in lower case.
+   */
+  def mediaType(contentType: Option[String]): Option[String] =
+    contentType.map(_.takeWhile(_ != ';').trim.toLowerCase)
+
+  /**
+   * Decide if the client must read the body of an HTTP response as a GraphQL response.
+   *
+   * With the media type `application/graphql-response+json`, the body is a GraphQL response for
+   * every status code. With any other media type, an intermediary such as a proxy can be the source
+   * of the response, so the client trusts the body only on a 2xx status.
+   */
+  def processBody(status: Int, contentType: Option[String]): Boolean =
+    mediaType(contentType).contains(GraphQLResponseMediaType) ||
+      (status >= 200 && status < 300)

--- a/http4s/src/main/scala/clue/http4s/Http4sHttpBackend.scala
+++ b/http4s/src/main/scala/clue/http4s/Http4sHttpBackend.scala
@@ -4,29 +4,58 @@
 package clue.http4s
 
 import cats.effect.*
+import cats.syntax.all.*
 import clue.*
 import clue.model.GraphQLRequest
 import clue.model.json.given
 import io.circe.Encoder
 import io.circe.syntax.*
+import org.http4s.MediaType
+import org.http4s.QValue
 import org.http4s.Request
 import org.http4s.circe.*
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.headers.Accept
+import org.http4s.headers.`Content-Type`
+import org.http4s.syntax.literals.qValue
 
 final class Http4sHttpBackend[F[_]: Concurrent](val client: Client[F])
     extends FetchBackend[F, Request[F]] {
 
   object dsl extends Http4sClientDsl[F]
 
+  private val GraphQLResponseMediaType =
+    new MediaType("application", "graphql-response+json", compressible = true)
+
+  private val AcceptHeader = Accept(
+    GraphQLResponseMediaType.withQValue(QValue.One),
+    MediaType.application.json.withQValue(qValue"0.9")
+  )
+
+  // The specification requires the GraphQL media type in the `Accept` header. A header that the
+  // caller set stays unchanged.
+  private def withAccept(request: Request[F]): Request[F] =
+    if (request.headers.contains[Accept]) request
+    else request.putHeaders(AcceptHeader)
+
   override def request[V: Encoder](
     request:     GraphQLRequest[V],
     baseRequest: Request[F]
   ): F[String] =
-    client.expect[String](
-      baseRequest.withEntity(request.asJson)
-      // POST(request.asJson, uri, headers).withContentType(`Content-Type`(MediaType.application.json))
-    )
+    client
+      .run(withAccept(baseRequest.withEntity(request.asJson)))
+      .use { response =>
+        val contentType: Option[String] =
+          response.headers.get[`Content-Type`].map(_.mediaType.show)
+
+        response.bodyText.compile.string.flatMap { body =>
+          if (GraphQLOverHttp.processBody(response.status.code, contentType))
+            body.pure[F]
+          else
+            HttpStatusException(response.status.code, contentType, body).raiseError[F, String]
+        }
+      }
 }
 
 object Http4sHttpBackend {

--- a/http4s/src/test/scala/clue/http4s/Http4sHttpBackendSuite.scala
+++ b/http4s/src/test/scala/clue/http4s/Http4sHttpBackendSuite.scala
@@ -1,0 +1,108 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.http4s
+
+import cats.effect.*
+import cats.syntax.all.*
+import clue.HttpStatusException
+import clue.model.GraphQLQuery
+import clue.model.GraphQLRequest
+import io.circe.Json
+import munit.CatsEffectSuite
+import org.http4s.*
+import org.http4s.client.Client
+import org.http4s.headers.Accept
+import org.http4s.headers.`Content-Type`
+import org.http4s.syntax.literals.*
+
+class Http4sHttpBackendSuite extends CatsEffectSuite:
+
+  private val SpecAccept = "application/graphql-response+json, application/json;q=0.9"
+
+  private val GraphQLResponseMediaType =
+    new MediaType("application", "graphql-response+json", compressible = true)
+
+  private val JsonContentType    = `Content-Type`(MediaType.application.json)
+  private val GraphQLContentType = `Content-Type`(GraphQLResponseMediaType, Charset.`UTF-8`)
+  private val HtmlContentType    = `Content-Type`(MediaType.text.html)
+
+  private val graphQLRequest: GraphQLRequest[Json] =
+    GraphQLRequest(GraphQLQuery("query { id }"))
+
+  private val baseRequest: Request[IO] =
+    Request[IO](Method.POST, uri"https://example.com/graphql")
+
+  // A client that always answers with the given status, content type and body, and records the
+  // request that it received.
+  private def stubClient(
+    status:      Status,
+    contentType: Option[`Content-Type`],
+    body:        String,
+    sent:        Ref[IO, Option[Request[IO]]]
+  ): Client[IO] =
+    Client[IO] { request =>
+      val response = Response[IO](status = status)
+        .withBodyStream(fs2.Stream.emits(body.getBytes("UTF-8")).covary[IO])
+      Resource
+        .eval(sent.set(request.some))
+        .as(contentType.fold(response)(ct => response.putHeaders(ct)))
+    }
+
+  private def run(
+    status:      Status,
+    contentType: Option[`Content-Type`],
+    body:        String,
+    request:     Request[IO] = baseRequest
+  ): IO[(String, Request[IO])] =
+    for
+      sent   <- Ref.of[IO, Option[Request[IO]]](none)
+      result <- Http4sHttpBackend[IO](stubClient(status, contentType, body, sent))
+                  .request(graphQLRequest, request)
+      seen   <- sent.get
+    yield (result, seen.get)
+
+  private def acceptOf(request: Request[IO]): Option[String] =
+    request.headers.get[Accept].map(Header[Accept].value)
+
+  test("request sends the Accept header of the specification") {
+    run(Status.Ok, JsonContentType.some, """{"data":{}}""")
+      .map((_, sent) => assertEquals(acceptOf(sent), SpecAccept.some))
+  }
+
+  test("request keeps an Accept header that the caller set") {
+    run(
+      Status.Ok,
+      JsonContentType.some,
+      """{"data":{}}""",
+      baseRequest.putHeaders(Accept(MediaType.application.json.withQValue(QValue.One)))
+    ).map((_, sent) => assertEquals(acceptOf(sent), "application/json".some))
+  }
+
+  test("request returns the body of a 400 response with the GraphQL media type") {
+    val body = """{"errors":[{"message":"Bad field"}]}"""
+    run(Status.BadRequest, GraphQLContentType.some, body)
+      .map((result, _) => assertEquals(result, body))
+  }
+
+  test("request returns the body of a 200 response with the legacy JSON media type") {
+    val body = """{"data":{"id":1}}"""
+    run(Status.Ok, JsonContentType.some, body).map((result, _) => assertEquals(result, body))
+  }
+
+  test("request raises HttpStatusException for a 400 response with the legacy JSON media type") {
+    val body = """{"errors":[{"message":"Bad field"}]}"""
+    run(Status.BadRequest, JsonContentType.some, body).attempt.map:
+      case Left(HttpStatusException(status, contentType, seenBody)) =>
+        assertEquals(status, 400)
+        assertEquals(contentType, "application/json".some)
+        assertEquals(seenBody, body)
+      case other                                                    =>
+        fail(s"Expected HttpStatusException, got [$other]")
+  }
+
+  test("request raises HttpStatusException for a 502 response with an HTML body") {
+    run(Status.BadGateway, HtmlContentType.some, "<html>Bad Gateway</html>").attempt.map:
+      case Left(e: HttpStatusException) => assertEquals(e.status, 502)
+      case other                        => fail(s"Expected HttpStatusException, got [$other]")
+  }

--- a/model/src/main/scala/clue/GraphQLException.scala
+++ b/model/src/main/scala/clue/GraphQLException.scala
@@ -43,3 +43,19 @@ case class UnexpectedServerMessageException[M, S](msg: M, state: S)
 
 case class ResponseException[D](errors: GraphQLErrors, data: Option[D])
     extends GraphQLException(errors.map(_.message).toList.mkString(", "))
+
+/**
+ * The server answered with an HTTP status and a media type that do not allow the client to read the
+ * body as a GraphQL response.
+ *
+ * @param status
+ *   the HTTP status code of the response
+ * @param contentType
+ *   the value of the `Content-Type` header, if the response has one
+ * @param body
+ *   the body of the response
+ */
+case class HttpStatusException(status: Int, contentType: Option[String], body: String)
+    extends GraphQLException(
+      s"Unexpected HTTP status [$status] with content type [${contentType.getOrElse("<none>")}]"
+    )

--- a/scalajs/src/main/scala/clue/js/FetchJsBackend.scala
+++ b/scalajs/src/main/scala/clue/js/FetchJsBackend.scala
@@ -3,7 +3,6 @@
 
 package clue.js
 
-import cats.Applicative
 import cats.effect.*
 import cats.syntax.all.*
 import clue.*
@@ -16,11 +15,9 @@ import org.scalajs.dom.Fetch
 import org.scalajs.dom.Headers
 import org.scalajs.dom.HttpMethod
 import org.scalajs.dom.RequestInit
-import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.*
+import org.scalajs.dom.Response
 
 import scala.scalajs.js.URIUtils
-import scala.util.Failure
-import scala.util.Success
 
 sealed trait FetchMethod extends Product with Serializable
 object FetchMethod {
@@ -34,56 +31,82 @@ final class FetchJsBackend[F[_]: Async](fetchMethod: FetchMethod)
     request:     GraphQLRequest[V],
     baseRequest: FetchJsRequest
   ): F[String] =
-    Async[F].async { cb =>
+    Sync[F].defer {
       val controller = new AbortController()
-      val _signal    = controller.signal
-      val _headers   = new Headers(baseRequest.headers)
-      val fetch      = fetchMethod match {
-        case FetchMethod.POST =>
-          _headers.set("Content-Type", "application/json")
-          Fetch
-            .fetch(
-              baseRequest.uri.toString,
-              new RequestInit {
-                method = HttpMethod.POST
-                body = request.asJson.noSpaces
-                headers = _headers
-                signal = _signal
-              }
-            )
-        case FetchMethod.GET  =>
-          Fetch
-            .fetch(
-              FetchJsBackend.buildGetUri(
-                baseRequest.uri.toString,
-                request.query.value,
-                request.variables.map(_.asJson.noSpaces),
-                request.operationName
-              ),
-              new RequestInit {
-                method = HttpMethod.GET
-                headers = _headers
-                signal = _signal
-              }
-            )
-      }
+      val abort      = Sync[F].delay(controller.abort())
 
-      Applicative[F]
-        .pure(
-          fetch.toFuture
-            .flatMap(_.text().toFuture)
-            .onComplete {
-              case Success(r) => cb(Right(r))
-              case Failure(t) => cb(Left(t))
+      val fetch: F[Response] =
+        Async[F].fromPromiseCancelable(
+          Sync[F].delay {
+            val _signal  = controller.signal
+            val _headers = new Headers(baseRequest.headers)
+            // The specification requires the GraphQL media type in the `Accept` header. A header
+            // that the caller set stays unchanged.
+            if (!_headers.has(FetchJsBackend.AcceptHeaderName))
+              _headers.set(FetchJsBackend.AcceptHeaderName, FetchJsBackend.AcceptHeaderValue)
+            val promise  = fetchMethod match {
+              case FetchMethod.POST =>
+                _headers.set("Content-Type", "application/json")
+                Fetch
+                  .fetch(
+                    baseRequest.uri.toString,
+                    new RequestInit {
+                      method = HttpMethod.POST
+                      body = request.asJson.noSpaces
+                      headers = _headers
+                      signal = _signal
+                    }
+                  )
+              case FetchMethod.GET  =>
+                Fetch
+                  .fetch(
+                    FetchJsBackend.buildGetUri(
+                      baseRequest.uri.toString,
+                      request.query.value,
+                      request.variables.map(_.asJson.noSpaces),
+                      request.operationName
+                    ),
+                    new RequestInit {
+                      method = HttpMethod.GET
+                      headers = _headers
+                      signal = _signal
+                    }
+                  )
             }
+            (promise, abort)
+          }
         )
-        .as(Sync[F].delay(controller.abort()).some)
+
+      fetch.flatMap { response =>
+        Async[F]
+          .fromPromiseCancelable(Sync[F].delay((response.text(), abort)))
+          .flatMap { body =>
+            val contentType = Option(response.headers.get("Content-Type"))
+            if (GraphQLOverHttp.processBody(response.status, contentType))
+              body.pure[F]
+            else
+              HttpStatusException(response.status, contentType, body).raiseError[F, String]
+          }
+      }
     }
 }
 
 object FetchJsBackend {
   def apply[F[_]: Async](method: FetchMethod = FetchMethod.POST): FetchJsBackend[F] =
     new FetchJsBackend[F](method)
+
+  /** The name of the `Accept` header. */
+  private val AcceptHeaderName: String = "Accept"
+
+  /** The legacy media type for GraphQL responses. */
+  private val JsonMediaType: String = "application/json"
+
+  /**
+   * The value of the `Accept` header that the specification recommends. It asks for the GraphQL
+   * media type and accepts the legacy JSON media type for older servers.
+   */
+  private val AcceptHeaderValue: String =
+    s"${GraphQLOverHttp.GraphQLResponseMediaType}, $JsonMediaType;q=0.9"
 
   /**
    * Build the URL for a GraphQL GET request.

--- a/scalajs/src/test/scala/clue/js/FetchJsBackendRequestSuite.scala
+++ b/scalajs/src/test/scala/clue/js/FetchJsBackendRequestSuite.scala
@@ -1,0 +1,109 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.js
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import clue.HttpStatusException
+import clue.model.GraphQLQuery
+import clue.model.GraphQLRequest
+import io.circe.Json
+import org.scalajs.dom
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.scalajs.js
+
+class FetchJsBackendRequestSuite extends munit.FunSuite {
+
+  private given ExecutionContext = munitExecutionContext
+
+  private val SpecAccept = "application/graphql-response+json, application/json;q=0.9"
+
+  private val graphQLRequest: GraphQLRequest[Json] =
+    GraphQLRequest(GraphQLQuery("query { id }"))
+
+  private val originalFetch: js.Dynamic = js.Dynamic.global.fetch
+
+  private var lastInit: js.Dynamic = null
+
+  override def afterEach(context: AfterEach): Unit = {
+    js.Dynamic.global.fetch = originalFetch
+    lastInit = null
+  }
+
+  // Replace the global `fetch` with a stub. The stub records the request and answers with the given
+  // status, content type and body.
+  private def stubFetch(status: Int, contentType: Option[String], body: String): Unit = {
+    val stub: js.Function2[js.Any, js.Dynamic, js.Promise[dom.Response]] =
+      (_, init) => {
+        lastInit = init
+        val headers      = js.Dictionary.empty[String]
+        contentType.foreach(ct => headers("Content-Type") = ct)
+        val responseInit = js.Dynamic
+          .literal(status = status, headers = headers.asInstanceOf[js.Any])
+          .asInstanceOf[dom.ResponseInit]
+        js.Promise.resolve[dom.Response](new dom.Response(body, responseInit))
+      }
+    js.Dynamic.global.fetch = stub.asInstanceOf[js.Dynamic]
+  }
+
+  private def send(
+    method:  FetchMethod = FetchMethod.POST,
+    headers: dom.Headers = new dom.Headers()
+  ): Future[Either[Throwable, String]] =
+    FetchJsBackend[IO](method)
+      .request(graphQLRequest, FetchJsRequest("https://example.com/graphql", headers))
+      .attempt
+      .unsafeToFuture()
+
+  private def sentHeader(name: String): Option[String] =
+    Option(lastInit.headers.asInstanceOf[dom.Headers].get(name))
+
+  test("request sends the Accept header of the specification") {
+    stubFetch(200, "application/json".some, """{"data":{}}""")
+    send().map(_ => assertEquals(sentHeader("Accept"), SpecAccept.some))
+  }
+
+  test("request keeps an Accept header that the caller set") {
+    stubFetch(200, "application/json".some, """{"data":{}}""")
+    val headers = new dom.Headers()
+    headers.set("Accept", "application/json")
+    send(headers = headers).map(_ => assertEquals(sentHeader("Accept"), "application/json".some))
+  }
+
+  test("request returns the body of a 400 response with the GraphQL media type") {
+    val body = """{"errors":[{"message":"Bad field"}]}"""
+    stubFetch(400, "application/graphql-response+json; charset=utf-8".some, body)
+    send().map(assertEquals(_, body.asRight))
+  }
+
+  test("request returns the body of a 200 response with the legacy JSON media type") {
+    val body = """{"data":{"id":1}}"""
+    stubFetch(200, "application/json".some, body)
+    send().map(assertEquals(_, body.asRight))
+  }
+
+  test("request raises HttpStatusException for a 400 response with the legacy JSON media type") {
+    val body = """{"errors":[{"message":"Bad field"}]}"""
+    stubFetch(400, "application/json".some, body)
+    send().map {
+      case Left(HttpStatusException(status, contentType, seenBody)) =>
+        assertEquals(status, 400)
+        assertEquals(contentType, "application/json".some)
+        assertEquals(seenBody, body)
+      case other                                                    =>
+        fail(s"Expected HttpStatusException, got [$other]")
+    }
+  }
+
+  test("request raises HttpStatusException for a 502 response with an HTML body") {
+    stubFetch(502, "text/html".some, "<html>Bad Gateway</html>")
+    send().map {
+      case Left(e: HttpStatusException) => assertEquals(e.status, 502)
+      case other                        => fail(s"Expected HttpStatusException, got [$other]")
+    }
+  }
+}


### PR DESCRIPTION
Send `Accept: application/graphql-response+json, application/json;q=0.9` over HTTP connections. Handle the spec implementations if the server returns with `application/graphql-response+json` or `application/json`. 

The backends examine the status and the media type of the response. With application/graphql-response+json, they read the body for every status code. With any other media type, they read the body only on a 2xx status, and raise HttpStatusException otherwise.

"legacy" backends that only send back `application/json` work the same as before

See https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md

Also reworks the Fetch backend to not use `toFuture`, but `fromPromiseCancelable` instead, removing the need for `org.scalajs.macrotaskexecutor.MacrotaskExecutor`