### PR TITLE
Keep the GraphQL document unchanged in GET mode

### DIFF
--- a/scalajs/src/main/scala/clue/js/FetchJsBackend.scala
+++ b/scalajs/src/main/scala/clue/js/FetchJsBackend.scala
@@ -16,8 +16,7 @@ import org.scalajs.dom.Headers
 import org.scalajs.dom.HttpMethod
 import org.scalajs.dom.RequestInit
 import org.scalajs.dom.Response
-
-import scala.scalajs.js.URIUtils
+import org.scalajs.dom.URLSearchParams
 
 sealed trait FetchMethod extends Product with Serializable
 object FetchMethod {
@@ -111,11 +110,8 @@ object FetchJsBackend {
   /**
    * Build the URL for a GraphQL GET request.
    *
-   * Each query-string component is individually encoded with `encodeURIComponent`. Encoding the
-   * whole URL with `encodeURI` (as was previously done) is unsafe: `encodeURI` leaves
-   * URL-structural characters such as `&`, `=` and `#` untouched, so a value (e.g. inside the
-   * serialized `variables` JSON) containing those characters could inject extra query parameters or
-   * truncate the request at a `#` fragment.
+   * `URLSearchParams` encodes each parameter. A value that contains `&`, `=` or `#` therefore
+   * cannot add a parameter or truncate the URL at a fragment.
    */
   private[js] def buildGetUri(
     baseUri:       String,
@@ -123,9 +119,12 @@ object FetchJsBackend {
     variables:     Option[String],
     operationName: Option[String]
   ): String = {
-    val q    = URIUtils.encodeURIComponent(query.trim.replaceAll(" +", " "))
-    val vars = variables.foldMap(v => s"&variables=${URIUtils.encodeURIComponent(v)}")
-    val op   = operationName.foldMap(o => s"&operationName=${URIUtils.encodeURIComponent(o)}")
-    s"$baseUri?query=$q$vars$op"
+    val params = new URLSearchParams()
+
+    params.append("query", query.trim)
+    variables.foreach(v => params.append("variables", v))
+    operationName.foreach(o => params.append("operationName", o))
+
+    s"$baseUri?${params.toString()}"
   }
 }

--- a/scalajs/src/test/scala/clue/js/FetchJsBackendSuite.scala
+++ b/scalajs/src/test/scala/clue/js/FetchJsBackendSuite.scala
@@ -4,29 +4,35 @@
 package clue.js
 
 import cats.syntax.all.*
-
-import scala.scalajs.js.URIUtils
+import org.scalajs.dom.URLSearchParams
 
 class FetchJsBackendSuite extends munit.FunSuite {
 
-  // Parse the `?query=...&variables=...&operationName=...` query string back into a key -> value map,
-  // decoding each value, so we can assert that no component leaked URL-structural characters.
+  // Parse the `?query=...&variables=...&operationName=...` query string back into a key -> value map.
+  // `URLSearchParams` is the standard that `buildGetUri` writes, so a value that contains `&`, `=`,
+  // `#` or a space is decoded here in the same way that a server decodes it.
   private def parseParams(uri: String): Map[String, String] = {
-    val queryString = uri.substring(uri.indexOf('?') + 1)
-    queryString
-      .split('&')
-      .toList
-      .map { kv =>
-        val idx = kv.indexOf('=')
-        URIUtils.decodeURIComponent(kv.substring(0, idx)) ->
-          URIUtils.decodeURIComponent(kv.substring(idx + 1))
-      }
-      .toMap
+    val entries = Map.newBuilder[String, String]
+    new URLSearchParams(uri.substring(uri.indexOf('?') + 1))
+      .forEach((value, name) => entries += name -> value)
+    entries.result()
   }
 
-  test("buildGetUri collapses whitespace and trims the query") {
+  test("buildGetUri keeps repeated spaces inside a string literal") {
+    val query = """query { x(s: "two  spaces") }"""
+    val uri   = FetchJsBackend.buildGetUri("https://example.com/gql", query, none, none)
+    assertEquals(parseParams(uri)("query"), query)
+  }
+
+  test("buildGetUri keeps the indentation of a multi-line document") {
+    val query = "query Foo {\n    id\n    name\n}"
+    val uri   = FetchJsBackend.buildGetUri("https://example.com/gql", query, none, none)
+    assertEquals(parseParams(uri)("query"), query)
+  }
+
+  test("buildGetUri trims whitespace around the document") {
     val uri =
-      FetchJsBackend.buildGetUri("https://example.com/gql", "  query   Foo {  id }  ", none, none)
+      FetchJsBackend.buildGetUri("https://example.com/gql", "  query Foo { id }\n", none, none)
     assertEquals(parseParams(uri)("query"), "query Foo { id }")
   }
 


### PR DESCRIPTION
`buildGetUri` collapsed repeated spaces in the document with `replaceAll(" +", " ")`. This changed the text of string literals in the document, so the server received a different operation.

GraphQL-over-HTTP defines the `query` parameter as the string representation of the source text of the document. `encodeURIComponent` already makes the text safe for a URL, so the collapse gives no benefit.

The `trim` call stays. Whitespace around the document is an ignored token in GraphQL, and the shorter URL is an advantage. Uses `URLSearchParams` to build the query parameters in the URL
