### PR TITLE
Send a mutation with POST, also in GET mode

### DIFF
--- a/scalajs/src/main/scala/clue/js/FetchJsBackend.scala
+++ b/scalajs/src/main/scala/clue/js/FetchJsBackend.scala
@@ -6,6 +6,7 @@ package clue.js
 import cats.effect.*
 import cats.syntax.all.*
 import clue.*
+import clue.model.GraphQLQuery
 import clue.model.GraphQLRequest
 import clue.model.json.given
 import io.circe.Encoder
@@ -44,7 +45,7 @@ final class FetchJsBackend[F[_]: Async](fetchMethod: FetchMethod)
             // that the caller set stays unchanged.
             if (!_headers.has(FetchJsBackend.AcceptHeaderName))
               _headers.set(FetchJsBackend.AcceptHeaderName, FetchJsBackend.AcceptHeaderValue)
-            val promise  = fetchMethod match {
+            val promise  = FetchJsBackend.methodFor(fetchMethod, request.query) match {
               case FetchMethod.POST =>
                 _headers.set("Content-Type", "application/json")
                 Fetch
@@ -107,6 +108,19 @@ object FetchJsBackend {
    */
   private val AcceptHeaderValue: String =
     s"${GraphQLOverHttp.GraphQLResponseMediaType}, $JsonMediaType;q=0.9"
+
+  /**
+   * The HTTP method for one request.
+   *
+   * GraphQL-over-HTTP forbids GET for a mutation operation, because an intermediary can cache, log
+   * or replay a GET request. A mutation therefore goes out with POST, also when the backend is
+   * configured with `FetchMethod.GET`.
+   */
+  private[js] def methodFor(fetchMethod: FetchMethod, query: GraphQLQuery): FetchMethod =
+    fetchMethod match {
+      case FetchMethod.GET if query.operationType.contains("mutation") => FetchMethod.POST
+      case method                                                      => method
+    }
 
   /**
    * Build the URL for a GraphQL GET request.

--- a/scalajs/src/test/scala/clue/js/FetchJsBackendSuite.scala
+++ b/scalajs/src/test/scala/clue/js/FetchJsBackendSuite.scala
@@ -4,6 +4,7 @@
 package clue.js
 
 import cats.syntax.all.*
+import clue.model.GraphQLQuery
 
 import scala.scalajs.js.URIUtils
 
@@ -50,6 +51,26 @@ class FetchJsBackendSuite extends munit.FunSuite {
 
     assert(!uri.contains("#"), s"Unescaped '#' present in: $uri")
     assertEquals(parseParams(uri)("variables"), variables)
+  }
+
+  test("methodFor sends a mutation with POST, also when GET is configured") {
+    val query = GraphQLQuery("mutation Save($x: Int!) { save(x: $x) { id } }")
+    assertEquals(FetchJsBackend.methodFor(FetchMethod.GET, query), FetchMethod.POST)
+  }
+
+  test("methodFor sends a query with GET when GET is configured") {
+    val query = GraphQLQuery("query Foo { id }")
+    assertEquals(FetchJsBackend.methodFor(FetchMethod.GET, query), FetchMethod.GET)
+  }
+
+  test("methodFor sends an anonymous selection set with GET when GET is configured") {
+    val query = GraphQLQuery("{ id }")
+    assertEquals(FetchJsBackend.methodFor(FetchMethod.GET, query), FetchMethod.GET)
+  }
+
+  test("methodFor keeps POST for a query when POST is configured") {
+    val query = GraphQLQuery("query Foo { id }")
+    assertEquals(FetchJsBackend.methodFor(FetchMethod.POST, query), FetchMethod.POST)
   }
 
   test("buildGetUri encodes the operationName") {


### PR DESCRIPTION
GraphQL-over-HTTP forbids GET for a mutation operation. An intermediary can cache, log or replay such a request.

The new `methodFor` helper reads the operation type from the document. For a mutation it returns POST and overrides the configured GET mode. A query and a subscription keep the configured method.
