### PR TITLE
Cross-build sbt-clue to sbt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
         if: matrix.java == 'temurin@25' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
+      - name: Test the sbt plugin against sbt 1.x
+        if: matrix.project == 'rootJVM'
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' '++ 2.12.20' sbtPlugin/test
+
       - name: Aggregate coverage reports
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' coverageReport coverageAggregate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The build aggregates these modules (see `build.sbt`):
 - **`otel4s`** (JVM+JS, pure) — `clue-otel4s`. Wraps any client with OpenTelemetry tracing via otel4s; emits a `SpanKind.Client` span per request/subscription and propagates W3C trace context. Depends on `core`.
 - **`http4s-jdk-demo`** — runnable demo (`NoPublish`) using the JDK http client behind http4s.
 - **`gen/*`** — the code generator (see below).
-- **`sbt-plugin`** — `sbt-clue`, the sbt plugin that runs the generator (`CluePlugin`), pinned to Scala 2.12.
+- **`sbt-plugin`** — `sbt-clue`, the sbt plugin that runs the generator (`CluePlugin`). It is cross-built for sbt 1.x (Scala 2.12) and sbt 2.x (Scala 3).
 
 ## Core architecture
 
@@ -68,7 +68,11 @@ Per `clue-plugin-integration.md`: add `sbt-clue` to `project/plugins.sbt`, `.ena
 
 ## Version pinning (gotcha)
 
-Different modules deliberately use different Scala versions: most are Scala 3 (`3.8.4`), `gen/rules` is **Scala 2.13.18** (Scalafix rules run on 2.13), and `sbt-plugin` is **Scala 2.12.20** (sbt plugins). Don't assume a single version across the build.
+Different modules deliberately use different Scala versions: most are Scala 3 (`3.8.4`), `gen/rules` is **Scala 2.13.18** (Scalafix rules run on 2.13), and `sbt-plugin` cross-builds **Scala 2.12.20** (for sbt 1.13.0) and **Scala 3.8.4** (for sbt 2.0.7). Don't assume a single version across the build.
+
+`(pluginCrossBuild / sbtVersion)` maps the Scala binary version of `sbt-plugin` to the sbt version. The default is Scala 2.12 / sbt 1, so a plain `publishLocal` publishes the Scala 3 libraries plus the sbt 1 plugin. Use `sbt '++ 3.8.4' sbtPlugin/test` for the sbt 2 side.
+
+The two sbt versions differ in API. `sbt-plugin/src/main/scala/clue/sbt/CluePlugin.scala` is shared, and the per-version shims are in `sbt-plugin/src/main/scala-2.12/` and `sbt-plugin/src/main/scala-3/`. The `sbt2-compat` plugin supplies `Def.uncached`, which every side-effecting task needs, because sbt 2 caches task results by default.
 
 ## Conventions
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,14 @@ ThisBuild / crossScalaVersions          := Seq("3.8.4")
 ThisBuild / githubWorkflowScalaVersions := Seq("3.8.4")
 Global / onChangedBuildSource           := ReloadOnSourceChanges
 
+// The CI matrix covers Scala 3 only, which builds `sbt-clue` for sbt 2.x. Run the scripted tests
+// of the sbt 1.x cross-build (Scala 2.12) in a separate step.
+ThisBuild / githubWorkflowBuild += WorkflowStep.Sbt(
+  List("++ 2.12.20", "sbtPlugin/test"),
+  name = Some("Test the sbt plugin against sbt 1.x"),
+  cond = Some("matrix.project == 'rootJVM'")
+)
+
 // sbt-typelevel-ci hardcodes Java 11 (both the job's `javas` matrix and the baked-in
 // `matrix.java == 'temurin@11'` cond on its Setup Java step) for its auto-added
 // "validate-steward" job, but the scala-steward binary that coursier/setup-action
@@ -214,23 +222,45 @@ lazy val sbtPlugin =
     .in(file("sbt-plugin"))
     .enablePlugins(SbtPlugin, BuildInfoPlugin)
     .settings(
-      moduleName         := "sbt-clue",
-      crossScalaVersions := List("2.12.20"),
-      scalacOptions      := Nil,
-      addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"      % V.scalafixVersion),
-      addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.2"),
-      addSbtPlugin("org.portable-scala" % "sbt-crossproject"  % "1.4.0"),
-      buildInfoPackage   := "clue.sbt",
-      buildInfoKeys      := Seq[BuildInfoKey](
+      moduleName                           := "sbt-clue",
+      scalaVersion                         := "2.12.20",
+      crossScalaVersions                   := List("2.12.20", "3.8.4"),
+      scalacOptions                        := Nil,
+      (pluginCrossBuild / sbtVersion)      := {
+        scalaBinaryVersion.value match {
+          case "2.12" => "1.13.0"
+          case _      => "2.0.7"
+        }
+      },
+      addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"     % V.scalafixVersion),
+      addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.4.0"),
+      addSbtPlugin("com.github.sbt"     % "sbt2-compat"      % "0.2.0"),
+      // Reads `Clue.schemaDirs` out of the scalafix configuration file. Both sbt 1.x and sbt 2.x
+      // already ship this jar, so depend on it as `Provided` and do not bundle a second copy.
+      libraryDependencies += "com.typesafe" % "config" % "1.4.5" % Provided,
+      // sbt-platform-deps supplies is only needed for sbt 1
+      libraryDependencies ++= {
+        if (scalaBinaryVersion.value == "2.12")
+          Seq(
+            Defaults.sbtPluginExtra(
+              "org.portable-scala" % "sbt-platform-deps" % "1.0.2",
+              (pluginCrossBuild / sbtBinaryVersion).value,
+              (pluginCrossBuild / scalaBinaryVersion).value
+            )
+          )
+        else Nil
+      },
+      buildInfoPackage                     := "clue.sbt",
+      buildInfoKeys                        := Seq[BuildInfoKey](
         version,
         organization,
         "rulesModule" -> (genRules / moduleName).value,
         "coreModule"  -> (core.jvm / moduleName).value
       ),
       buildInfoOptions += BuildInfoOption.PackagePrivate,
-      Test / test        :=
+      Test / test                          :=
         scripted.toTask("").value,
-      scripted           := scripted
+      scripted                             := scripted
         .dependsOn(
           genRules / publishLocal,
           model.jvm / publishLocal,
@@ -242,5 +272,8 @@ lazy val sbtPlugin =
         "-Dplugin.version=" + version.value,
         "-Dscala.version=" + (core.jvm / scalaVersion).value
       ),
-      scriptedBufferLog  := false
+      scriptedBufferLog                    := false,
+      tlVersionIntroduced                  := Map(
+        "3" -> "0.58.1"
+      )
     )

--- a/clue-plugin-integration.md
+++ b/clue-plugin-integration.md
@@ -1,5 +1,7 @@
 # How to setup the Clue Plugin
 
+`sbt-clue` is cross-built for sbt 1.x and sbt 2.x.
+
 1. **Plugin Configuration**:
    - Add the Clue plugin to the project in `project/plugins.sbt`:
      ```scala
@@ -32,7 +34,9 @@
 
 ## How It Works
 
-1. The Clue plugin generates source code in `target/scala-[version]/src_managed`
+1. The Clue plugin generates source code in the `src_managed` directory of the project. On sbt 1.x
+   this is `<project>/target/scala-[version]/src_managed`. On sbt 2.x it is
+   `target/out/jvm/scala-[version]/[project]/src_managed`.
 2. These generated sources are compiled along with regular code
 3. Generated classes can be imported, like `import [package].SomeQueriesGQL`
 
@@ -58,5 +62,8 @@ as a warning (those are only processed by the generator). Do not add `rules = [G
 
 After setup, you should be able to see generated class files in:
 ```
+# sbt 1.x
 modules/[project]/target/scala-[version]/src_managed/[package]/[Query]GQL.scala
+# sbt 2.x
+target/out/jvm/scala-[version]/[project]/src_managed/[package]/[Query]GQL.scala
 ```

--- a/sbt-plugin/src/main/scala-2.12/clue/sbt/PluginCompat.scala
+++ b/sbt-plugin/src/main/scala-2.12/clue/sbt/PluginCompat.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.sbt
+
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+import sbt._
+
+/**
+ * sbt 1.x half of the compatibility shim. See `src/main/scala-3` for the sbt 2.x half.
+ */
+private[sbt] object PluginCompat {
+
+  /**
+   * A dependency on a module that is cross-published for every platform (JVM, Scala.js, Scala
+   * Native). On sbt 1.x the platform suffix comes from the `%%%` operator of sbt-platform-deps.
+   */
+  def platformModuleID(
+    organization: String,
+    name:         String,
+    revision:     String
+  ): Def.Initialize[ModuleID] =
+    Def.setting(organization %%% name % revision)
+}

--- a/sbt-plugin/src/main/scala-3/clue/sbt/PluginCompat.scala
+++ b/sbt-plugin/src/main/scala-3/clue/sbt/PluginCompat.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue.sbt
+
+import sbt.*
+
+/**
+ * sbt 2.x half of the compatibility shim. See `src/main/scala-2.12` for the sbt 1.x half.
+ */
+private[sbt] object PluginCompat {
+
+  /**
+   * A dependency on a module that is cross-published for every platform (JVM, Scala.js, Scala
+   * Native). On sbt 2.x the `%%` operator is platform-aware, so it replaces `%%%`.
+   */
+  def platformModuleID(
+    organization: String,
+    name:         String,
+    revision:     String
+  ): Def.Initialize[ModuleID] =
+    Def.setting(organization %% name % revision)
+}

--- a/sbt-plugin/src/main/scala/clue/sbt/CluePlugin.scala
+++ b/sbt-plugin/src/main/scala/clue/sbt/CluePlugin.scala
@@ -3,8 +3,8 @@
 
 package clue.sbt
 
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport.*
 import sbt.*
+import sbtcompat.PluginCompat.*
 import sbtcrossproject.CrossPlugin
 import scalafix.sbt.ScalafixPlugin
 
@@ -33,13 +33,13 @@ object CluePlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override def buildSettings: Seq[Setting[_]] = Seq(
+  override def buildSettings: Seq[Setting[?]] = Seq(
     scalafixDependencies += BuildInfo.organization %% BuildInfo.rulesModule % BuildInfo.version,
     Compile / clueSourceGenerators                 := Seq.empty,
     clueClean                                      := {}
   )
 
-  override def projectSettings: Seq[Setting[_]] = Seq(
+  override def projectSettings: Seq[Setting[?]] = Seq(
     Compile / clueSourceDirectory :=
       crossProjectCrossType.?.value
         .flatMap { crossType =>
@@ -47,16 +47,18 @@ object CluePlugin extends AutoPlugin {
         }
         .getOrElse(sourceDirectory.value / "clue"),
     Compile / sourceGenerators ++= (Compile / clueSourceGenerators).value, // workaround for sbt/sbt#7173
-    libraryDependencies += BuildInfo.organization %%% BuildInfo.coreModule % BuildInfo.version,
+    libraryDependencies += PluginCompat
+      .platformModuleID(BuildInfo.organization, BuildInfo.coreModule, BuildInfo.version)
+      .value,
     // another workaround
-    clean                                          := clean.dependsOn(clueClean).value,
+    clean := clean.dependsOn(clueClean).value,
 
     // Validation of hand-written operations/subqueries living in this project's own sources. The
     // generator only scans `clueSourceDirectory`; the validation rule covers the rest.
     // semanticdb is required by the rule.
     semanticdbEnabled     := true,
     semanticdbVersion     := scalafixSemanticdb.revision,
-    clueCheck             := (Compile / scalafix).toTask(" GraphQLValidate --check").value,
+    clueCheck             := Def.uncached((Compile / scalafix).toTask(" GraphQLValidate --check").value),
     clueValidateOnCompile := true
   ) ++
     // Run validation on every compile. We decorate `compile` to run the real compilation first
@@ -70,7 +72,7 @@ object CluePlugin extends AutoPlugin {
     // compile dependency (we've already compiled), breaking the cycle, while the explicitly named
     // rule still runs.
     Seq(Compile, Test).map { config =>
-      config / compile := Def.taskDyn {
+      config / compile := Def.uncached(Def.taskDyn {
         val analysis = (config / compile).value
         if (clueValidateOnCompile.value)
           Def.task {
@@ -78,10 +80,10 @@ object CluePlugin extends AutoPlugin {
             analysis
           }
         else Def.task(analysis)
-      }.value
+      }.value)
     }
 
-  override def derivedProjects(proj: ProjectDefinition[_]): Seq[Project] = Seq(
+  override def derivedProjects(proj: ProjectDefinition[?]): Seq[Project] = Seq(
     Project(
       proj.id + "-clue",
       new File(proj.base.getParent(), proj.base.getName() + "-clue")
@@ -92,8 +94,9 @@ object CluePlugin extends AutoPlugin {
           (LocalProject(proj.id) / Compile / clueSourceDirectory).value,
         scalaVersion                  := (LocalProject(proj.id) / scalaVersion).value,
         Compile / unmanagedSourceDirectories += (Compile / clueSourceDirectory).value / "scala",
-        Compile / dependencyClasspath :=
-          (LocalProject(proj.id) / Compile / dependencyClasspath).value,
+        Compile / dependencyClasspath := Def.uncached(
+          (LocalProject(proj.id) / Compile / dependencyClasspath).value
+        ),
 
         // register generator
         LocalProject(proj.id) / Compile / clueSourceGenerators += Def.taskDyn {
@@ -107,13 +110,12 @@ object CluePlugin extends AutoPlugin {
             val _ = (Compile / scalafix)
               .toTask(s" GraphQLGen --out-from=$outFrom --out-to=$outTo")
               .value
-            (to ** "*.scala").get
+            (to ** "*.scala").get()
           }
         }.taskValue,
 
         // register clean
-        LocalProject(proj.id) / clueClean :=
-          clean.value,
+        LocalProject(proj.id) / clueClean := Def.uncached(clean.value),
 
         // scalafix stuff
         semanticdbEnabled := true,

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/build.sbt
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/build.sbt
@@ -1,10 +1,9 @@
-ThisBuild / scalaVersion := sys.props("scala.version")
-
 lazy val app = crossProject(JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("app"))
   .enablePlugins(CluePlugin)
   .settings(
+    scalaVersion := sys.props("scala.version"),
     libraryDependencies ++= Seq(
       "dev.optics" %% "monocle-macro" % "3.3.0"
     )

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/project/build.properties
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.13.0

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars/build.sbt
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars/build.sbt
@@ -1,9 +1,8 @@
-ThisBuild / scalaVersion := sys.props("scala.version")
-
 lazy val app = project
   .in(file("app"))
   .enablePlugins(CluePlugin)
   .settings(
+    scalaVersion := sys.props("scala.version"),
     libraryDependencies ++= Seq(
       "dev.optics" %% "monocle-macro" % "3.3.0"
     )

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars/project/build.properties
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.13.0

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars/test
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars/test
@@ -1,4 +1,4 @@
 > app/compile
 > app/clean
-$ absent app-clue/target/scala-2.13
+$ absent app-clue/target/scala-2.13 target/**/app-clue/classes
 > app/compile

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/build.sbt
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/build.sbt
@@ -1,5 +1,6 @@
-ThisBuild / scalaVersion := sys.props("scala.version")
-
 lazy val app = project
   .in(file("app"))
   .enablePlugins(CluePlugin)
+  .settings(
+    scalaVersion := sys.props("scala.version")
+  )

--- a/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/project/build.properties
+++ b/sbt-plugin/src/sbt-test/clue-plugin/validate-handwritten/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.12.12


### PR DESCRIPTION
We can't use sbt 2 yet because of sbt-typelevel, but this at least removes one obstacle in the future.
