### PR TITLE
Remove now-unnecessary grackle workaround

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
-ThisBuild / tlBaseVersion     := "0.58"
+ThisBuild / tlBaseVersion     := "0.59"
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 // The CI matrix covers Scala 3 only, which builds `sbt-clue` for sbt 2.x. Run the scripted tests

--- a/gen/input/src/main/scala/test/StarWarsUnusedVariable.scala
+++ b/gen/input/src/main/scala/test/StarWarsUnusedVariable.scala
@@ -10,11 +10,10 @@ package test
 
 import clue.GraphQLOperation
 
-// Unused-variable detection is disabled because grackle's `collectValueRefs` overwrites instead of
-// accumulating variable references, falsely flagging variables that appear alongside others (e.g.
-// several `$var` fields in one input object). So even this genuinely-unused `$unused` must NOT
-// produce a diagnostic.
+// The operation declares `$unused` but never references it. Per the GraphQL spec (All Variables
+// Used) this is a validation error, so the validation pass must report a diagnostic. Unused
+// detection is only skipped for documents that splice subqueries (see `validateParsed`).
 trait StarWarsUnusedVariable extends GraphQLOperation[StarWars] {
-  override val document = gql"query ($$unused: ID!) { hero(episode: NEWHOPE) { id } }"
+  override val document = gql"query ($$unused: ID!) { hero(episode: NEWHOPE) { id } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLGen.scala
@@ -168,7 +168,7 @@ class GraphQLGen(val config: GraphQLGenConfig)
                     withSchema(schemaType.value, obj.pos) { schema =>
                       // Validate the document against the schema first, reporting all problems as
                       // diagnostics (errors at the document, warnings at the definition).
-                      val validation: Result[Unit] = validateDocument(schema, document.render)
+                      val validation: Result[Unit] = validateDocument(schema, document)
                       val diagnostics: Patch       =
                         lintResult(
                           validation,
@@ -280,7 +280,7 @@ class GraphQLGen(val config: GraphQLGenConfig)
                       // Validate the subquery against its root type first, reporting all problems
                       // as diagnostics (errors at the subquery, warnings at the definition).
                       val validation: Result[Unit]             =
-                        validateSubquery(schema, rootTypeName, variableDefs, subquery.render)
+                        validateSubquery(schema, rootTypeName, variableDefs, subquery)
                       val diagnostics: Patch                   =
                         lintResult(
                           validation,

--- a/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
+++ b/gen/rules/src/main/scala/clue/gen/GraphQLValidation.scala
@@ -131,7 +131,7 @@ trait GraphQLValidation extends QueryGen {
         else
           withSchema(schemaType.value, defnPos) { schema =>
             lintResult(
-              validateDocument(schema, document.render),
+              validateDocument(schema, document),
               gqlValuePos("document", stats).getOrElse(defnPos),
               defnPos
             )
@@ -169,7 +169,7 @@ trait GraphQLValidation extends QueryGen {
                                          subquery.render,
                                          infer = generating
                     ),
-                    subquery.render
+                    subquery
                   ),
                   gqlValuePos("subquery", stats).getOrElse(defnPos),
                   defnPos

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -191,13 +191,19 @@ trait QueryGen extends Generator {
    *   - the root type is supplied explicitly, so this also works for subqueries (selection sets on
    *     an arbitrary type), which `compile` can't root directly.
    *
+   * `reportUnused` enables grackle's unused variable/fragment detection. It must be off for a
+   * document that splices subqueries: the enclosing document legitimately declares variables that
+   * only a spliced subquery uses, and a splice is rendered as `__typename` here (see
+   * [[InterpolatedGql.render]]), so grackle would falsely report them.
+   *
    * All errors and warnings are accumulated into the [[Result]] (nothing is thrown).
    */
   private def validateParsed(
-    schema:     Schema,
-    rootTypeOf: UntypedOperation => Result[NamedType],
-    operations: List[UntypedOperation],
-    fragments:  List[UntypedFragment]
+    schema:       Schema,
+    rootTypeOf:   UntypedOperation => Result[NamedType],
+    operations:   List[UntypedOperation],
+    fragments:    List[UntypedFragment],
+    reportUnused: Boolean
   ): Result[Unit] = {
     val compiler = new QueryCompiler(GQLParser, schema, List.empty)
     val phases   =
@@ -210,15 +216,8 @@ trait QueryGen extends Generator {
     val fragMap  = fragments.map(f => f.name -> f).toMap
 
     for {
-      // `reportUnused = false`: grackle's unused detection is unreliable — its `collectValueRefs`
-      // overwrites instead of accumulating variable refs (`loop(values, Set(nme))`), so when one
-      // value holds several variables (e.g. an input object with multiple `$var` fields) all but the
-      // last are falsely reported as unused. Note that re-enabling it would also need an exemption
-      // for subqueries: a subquery legitimately declares variables that only a subquery it splices
-      // uses, and a splice is rendered as `__typename` here (see [[InterpolatedGql.render]]).
-      // TODO Re-enable unused detection when grackle releases the bug fix for `collectValueRefs`.
       _ <- Result.fromProblems(
-             compiler.validateVariablesAndFragments(operations, fragments, reportUnused = false)
+             compiler.validateVariablesAndFragments(operations, fragments, reportUnused)
            )
       _ <- Result.fromProblems(compiler.validateFieldMergeability(operations, fragments))
       _ <- operations.traverse_ { op =>
@@ -251,9 +250,15 @@ trait QueryGen extends Generator {
    * Validate the operation `document` against the `schema`, accumulating all problems. This is the
    * validation entry point for hand-written operations, where the code generator is not used.
    */
-  protected def validateDocument(schema: Schema, document: String): Result[Unit] =
-    GQLParser.parseText(document).flatMap { case (operations, fragments) =>
-      validateParsed(schema, _.rootTpe(schema), operations, fragments)
+  protected def validateDocument(schema: Schema, document: InterpolatedGql): Result[Unit] =
+    GQLParser.parseText(document.render).flatMap { case (operations, fragments) =>
+      validateParsed(
+        schema,
+        _.rootTpe(schema),
+        operations,
+        fragments,
+        reportUnused = document.subqueries.isEmpty
+      )
     }
 
   /**
@@ -434,7 +439,7 @@ trait QueryGen extends Generator {
     schema:       Schema,
     rootTypeName: String,
     variableDefs: String,
-    subquery:     String
+    subquery:     InterpolatedGql
   ): Result[Unit] =
     Result
       .fromOption(
@@ -442,9 +447,15 @@ trait QueryGen extends Generator {
         s"Undefined root type [$rootTypeName] for subquery"
       )
       .flatMap { rootType =>
-        GQLParser.parseText(s"query $variableDefs $subquery").flatMap {
+        GQLParser.parseText(s"query $variableDefs ${subquery.render}").flatMap {
           case (operations, fragments) =>
-            validateParsed(schema, _ => Result.success(rootType), operations, fragments)
+            validateParsed(
+              schema,
+              _ => Result.success(rootType),
+              operations,
+              fragments,
+              reportUnused = subquery.subqueries.isEmpty
+            )
         }
       }
 
@@ -456,7 +467,7 @@ trait QueryGen extends Generator {
     schema:        Schema,
     rootTypeNames: List[String],
     variableDefs:  String,
-    subquery:      String
+    subquery:      InterpolatedGql
   ): Result[Unit] =
     rootTypeNames.parTraverse_(validateSubquery(schema, _, variableDefs, subquery))
 


### PR DESCRIPTION
Grackle has fixed the accumulation of `collectValueRefs`. We can therefore remove the workaround we had for unused vars.

However, we must still refrain from checking unused vars for documents that have subqueries since grackle doesn't see the final spliced document but rather placeholders for where the subqueries get spliced.