### PR TITLE
Require discriminator on polymorphic queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ object Character {
 ```
 
 The selection **must** include `__typename` at the same level as the fragments; the generated
-decoder switches on it to pick the case class to decode into. Omitting it is a generation error: "Selection on [...] has fragments on subtypes [...] but does not select `__typename`".
+decoder switches on it to pick the case class to decode into. Omitting it is a generation error: "Selection on [...] has fragments on subtypes [...] but does not select `__typename`". It must also
+be selected **unconditionally**: with `@skip`/`@include` on it, or on a fragment that encloses it,
+generation fails with "... its `__typename` is selected with `@skip`/`@include`". A `__typename`
+inside a fragment on the field's own type (plain grouping, e.g. `... on Character { __typename }`)
+counts, as long as neither it nor the fragment is conditional.
 
 A bare `__typename` is consumed by the decoder and is not generated as a field. Aliased (e.g.
 `kind: __typename`), it is both the decoder key and a regular `String` field on the trait and every

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ Experimental GraphQL client for Scala and Scala.js.
 ### 1) Create a client
 
 Either:
-  * A `FetchClient[F[_], S]` (supporting queries and mutations), or
-  * A `StreamingClient[F[_], S]` (supporting queries, mutations and subscriptions).
 
-  `S` is a type denoting the schema. It can be any type, even a phantom type. It's only used to type-match clients and operations.
+- A `FetchClient[F[_], S]` (supporting queries and mutations), or
+- A `StreamingClient[F[_], S]` (supporting queries, mutations and subscriptions).
+
+`S` is a type denoting the schema. It can be any type, even a phantom type. It's only used to type-match clients and operations.
 
 #### Example
 
-``` scala
+```scala
   import clue.*
   import cats.effect.IO
 
@@ -59,7 +60,7 @@ Either:
 
 They must extend `GraphQLOperation[S]`, defining the following members:
 
-``` scala
+```scala
   val document: GraphQLDocument   // built with the `gql` interpolator (see below)
 
   type Variables
@@ -78,7 +79,7 @@ subqueries correctly (see [Subquery variables](#subquery-variables) below). `.st
 
 #### Example
 
-``` scala
+```scala
   import io.circe._
   import io.circe.generic.semiauto._
 
@@ -114,7 +115,7 @@ generator — no code generation involved. Any definition extending `GraphQLOper
 `GraphQLOperation.Typed[S, ...]` (checked via its `document`) or `GraphQLSubquery[S]` /
 `GraphQLSubquery.Typed[S, ...]` (checked via its `subquery`) is validated; fields, arguments,
 variables and deprecations that don't typecheck against schema `S` are reported as scalafix
-diagnostics. Operations that *are* generated (annotated with `@GraphQL`) are validated during
+diagnostics. Operations that _are_ generated (annotated with `@GraphQL`) are validated during
 generation.
 
 A subquery declares the GraphQL root type(s) its selection applies to with a
@@ -133,6 +134,43 @@ A subquery's `subquery` is a `GraphQLDocument` too, so it is built with `gql` fo
 Hand-written subqueries may declare **multiple** types (the selection is validated against each:
 `@GraphQLType("Human", "Droid")`). A subquery processed by the generator (`@GraphQL`) must declare
 **exactly one** type. `@GraphQLType` is only valid on a subquery, not on a `GraphQLOperation`.
+
+#### Interfaces and unions
+
+When a selection on an interface or union field has inline fragments (or fragment spreads) on its
+subtypes, the generator emits a `sealed trait` for the field, one case class per fragment type
+carrying the shared fields plus the fragment's own, and, if the schema has concrete types none of
+the fragments cover, a case class `Other` with just the shared fields. For example, the StarWars
+selection
+
+```graphql
+character { __typename id name ... on Human { homePlanet } }
+```
+
+(`character`'s type is an interface implemented by `Human` and `Droid`) generates roughly:
+
+```scala
+sealed trait Character { val id: String; val name: Option[String] }
+object Character {
+  case class Human(id: String, name: Option[String], homePlanet: Option[String]) extends Character
+  case class Other(id: String, name: Option[String]) extends Character // Droid, uncovered
+}
+```
+
+The selection **must** include `__typename` at the same level as the fragments; the generated
+decoder switches on it to pick the case class to decode into. Omitting it is a generation error: "Selection on [...] has fragments on subtypes [...] but does not select `__typename`".
+
+A bare `__typename` is consumed by the decoder and is not generated as a field. Aliased (e.g.
+`kind: __typename`), it is both the decoder key and a regular `String` field on the trait and every
+case class — the way to keep the raw type name around, e.g. for the types folded into `Other`.
+
+Fragments whose type condition is the field's own type or one of its supertypes are plain grouping
+(e.g. for `@include`), not subtypes, and are flattened rather than turned into cases.
+
+A subquery is spliced as the whole selection set of a field (`field $Subquery`); splicing one inside
+a fragment (`... on Human $HumanFields`) is rejected. A subquery may itself be rooted at an
+interface/union (`@GraphQLType("Character")`) and use fragments in its own selection, in which case
+its `Data` is the sealed trait.
 
 ##### Subquery variables
 
@@ -165,7 +203,7 @@ without declaring it reads as "requires nothing" to callers. That omission is an
 subquery is validated (it needs `@GraphQLType` and a configured schema), so keep validation enabled
 on projects that publish subqueries.
 
-To splice a subquery into an operation *and* have the operation's variables checked against it, build
+To splice a subquery into an operation _and_ have the operation's variables checked against it, build
 the `document` with the `gql` interpolator (from `clue`) instead of `s`:
 
 ```scala
@@ -225,7 +263,7 @@ this is reported as a warning rather than silently skipped.
 
 #### Example
 
-``` scala
+```scala
 fetchClient.request(CharacterQuery)(CharacterQuery.Variables("0001"))
   .forEach(println).unsafeRunSync()
 
@@ -240,17 +278,18 @@ A `SpanKind.Client` span is emitted per HTTP request or subscription.
 W3C trace context is automatically propagated to the server:
 
 - **HTTP requests**: the current span's `traceparent` (and `tracestate`) is injected into outgoing
-request headers, thus client spans can propagate to the server
+  request headers, thus client spans can propagate to the server
 - **WebSocket requests**: `traceparent` is included in the `extensions` field, so the server can
-create child reading `extensions.traceparent`.
+  create child reading `extensions.traceparent`.
 
 Some span attributes recorded automatically:
-* `clue.version`
-* `http.request.method`
-* `graphql.operation.type`
-* `graphql.operation.name`
-* `graphql.document`
-* `clue.response.hasData`
+
+- `clue.version`
+- `http.request.method`
+- `graphql.operation.type`
+- `graphql.operation.name`
+- `graphql.document`
+- `clue.response.hasData`
 
 And on errors `clue.response.hasErrors`, `clue.response.errorCount`, `clue.response.errors`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
-ThisBuild / tlBaseVersion     := "0.58"
+ThisBuild / tlBaseVersion     := "0.59"
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 // The CI matrix covers Scala 3 only, which builds `sbt-clue` for sbt 2.x. Run the scripted tests

--- a/gen/input/src/main/resources/graphql/schemas/StarWars.graphql
+++ b/gen/input/src/main/resources/graphql/schemas/StarWars.graphql
@@ -19,13 +19,18 @@ interface Character {
   appearsIn: [Episode!]
 }
 
-type Human implements Character {
+interface Pilot {
+  vehicle: String
+}
+
+type Human implements Character & Pilot {
   id: String!
   name: String
   friends: [Character!]
   more_friends: [Character!]
   appearsIn: [Episode!]
   homePlanet: String
+  vehicle: String
 }
 
 type Droid implements Character {

--- a/gen/input/src/main/scala/test/LucumaQuery.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery.scala
@@ -23,6 +23,7 @@ trait LucumaQuery extends GraphQLOperation[LucumaODB] {
               id
               name
               tracking {
+                __typename
                 ... on Sidereal {
                   epoch
                 }

--- a/gen/input/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery2.scala
@@ -23,6 +23,7 @@ trait LucumaQuery2 extends GraphQLOperation[LucumaODB] {
               id
               name
               tracking {
+                __typename
                 ... on Sidereal {
                   epoch
                 }

--- a/gen/input/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/input/src/main/scala/test/LucumaQuery3.scala
@@ -19,6 +19,7 @@ trait LucumaQuery3 extends GraphQLOperation[LucumaODB] {
           nodes {
             id
             observationTarget {
+              __typename
               ... on Target {
                 target_id: id
                 target_name: name

--- a/gen/input/src/main/scala/test/StarWarsAliasedTypename.scala
+++ b/gen/input/src/main/scala/test/StarWarsAliasedTypename.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+
+// Checks that an ALIASED `__typename` (`kind: __typename`) is used as the decoder
+// discriminator key, AND is also generated as a regular field (`kind: String`) on the trait
+// and every instance.
+@GraphQL // assert: GraphQLGen
+trait StarWarsAliasedTypename extends GraphQLOperation[StarWars] {
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            kind: __typename
+            name
+            ... on Human {
+              homePlanet
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+        }
+      """
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsAliasedTypenameOther.scala
+++ b/gen/input/src/main/scala/test/StarWarsAliasedTypenameOther.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+
+// Combines an ALIASED `__typename` discriminator with a fallback `Other` instance (`Droid` is
+// left uncovered): `kind` must still be generated as a regular field on `Other` too.
+@GraphQL
+trait StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            kind: __typename
+            name
+            ... on Human {
+              homePlanet
+            }
+          }
+        }
+      """
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsHumanSubquery.scala
+++ b/gen/input/src/main/scala/test/StarWarsHumanSubquery.scala
@@ -12,26 +12,17 @@ import clue.GraphQLSubquery
 import clue.annotation.GraphQL
 import clue.annotation.GraphQLType
 
-@GraphQL // assert: GraphQLGen
-@GraphQLType("Character")
-abstract class StarWarsNestedSubquery extends GraphQLSubquery[StarWars] {
+@GraphQL
+@GraphQLType("Human")
+abstract class StarWarsHumanSubquery extends GraphQLSubquery[StarWars] {
 
   override val subquery = gql"""
         {
-          __typename
-          id
-          name
-          ... on Human {
-            homePlanet
-          }
-          contacts:friends $StarWarsSubquery
-          ... on Droid {
-            primaryFunction
-          }
+          homePlanet
         }
       """
 }
 
 @clue.annotation.GraphQLStub
-object StarWarsNestedSubquery
+object StarWarsHumanSubquery
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsInterfaceSubtype.scala
+++ b/gen/input/src/main/scala/test/StarWarsInterfaceSubtype.scala
@@ -11,22 +11,18 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-@GraphQL // assert: GraphQLGen
-trait StarWarsQuery extends GraphQLOperation[StarWars] {
+// A fragment on an interface (`Pilot`, implemented only by `Human`): `__typename` in a response is
+// always the concrete object type name (`Human`), never the interface name, so the decoder must
+// map every concrete implementor to the `Pilot` instance, not match on `"Pilot"` itself.
+@GraphQL
+trait StarWarsInterfaceSubtype extends GraphQLOperation[StarWars] {
   override val document = gql"""
-        query ($$charId: ID!) {
-          character(id: $$charId) {
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
             __typename
-            id
             name
-            ... on Human {
-              homePlanet
-            }
-            friends {
-              name
-            }
-            ... on Droid {
-              primaryFunction
+            ... on Pilot {
+              vehicle
             }
           }
         }

--- a/gen/input/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery2.scala
@@ -18,6 +18,7 @@ object Wrapper /* gql: extends Something */ {
   trait StarWarsQuery2 extends GraphQLOperation[StarWars] {
   override val document = gql"""
         fragment fields on Character {
+          __typename
           id
           name
           ... on Human {

--- a/gen/input/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/input/src/main/scala/test/StarWarsQuery3.scala
@@ -16,6 +16,7 @@ trait StarWarsQuery3 extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) {
+            __typename
             id
             name
             ... on Human {

--- a/gen/input/src/main/scala/test/StarWarsSingleSubtype.scala
+++ b/gen/input/src/main/scala/test/StarWarsSingleSubtype.scala
@@ -11,22 +11,18 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-@GraphQL // assert: GraphQLGen
-trait StarWarsQuery extends GraphQLOperation[StarWars] {
+// A single fragment on a subtype (`Human`), leaving `Droid` uncovered: `Character` has exactly
+// two implementors, so this must still generate a fallback `Other` instance (no special-casing
+// for "just one variant").
+@GraphQL
+trait StarWarsSingleSubtype extends GraphQLOperation[StarWars] {
   override val document = gql"""
-        query ($$charId: ID!) {
-          character(id: $$charId) {
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
             __typename
-            id
             name
             ... on Human {
               homePlanet
-            }
-            friends {
-              name
-            }
-            ... on Droid {
-              primaryFunction
             }
           }
         }

--- a/gen/input/src/main/scala/test/StarWarsSubqueryInFragmentInvalid.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubqueryInFragmentInvalid.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+
+// A subquery is only legal as the *whole* selection set of a field (`field $Subquery`, see
+// StarWarsQuery3). Here it's spliced as the body of an inline fragment instead, which `resolveData`
+// doesn't recognize, so this must be rejected.
+@GraphQL
+trait StarWarsSubqueryInFragmentInvalid extends GraphQLOperation[StarWars] {
+  override val document =
+    gql"query ($$ep: Episode!) { hero(episode: $$ep) { __typename name ... on Human $StarWarsHumanSubquery } }" // assert: GraphQLGen
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypename.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypename.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+
+// A base-level `__typename` guarded by `@include`: at runtime with the flag off, the field is
+// absent from the response and the generated decoder can't tell which subtype it got, so this must
+// be rejected.
+@GraphQL
+trait StarWarsSubtypeConditionalTypename extends GraphQLOperation[StarWars] {
+  override val document =
+    gql"query ($$ep: Episode!, $$withType: Boolean!) { hero(episode: $$ep) { __typename @include(if: $$withType) name ... on Human { homePlanet } } }" // assert: GraphQLGen
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypenameFragment.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypenameFragment.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+
+// `__typename` sits inside a same-type fragment (`... on Character`) that itself carries
+// `@include`: the fragment flattens to a plain `__typename` at the base level, but at runtime with
+// the flag off the whole fragment (and therefore `__typename`) is absent from the response, so this
+// must be rejected just like a directly-conditional `__typename`.
+@GraphQL
+trait StarWarsSubtypeConditionalTypenameFragment extends GraphQLOperation[StarWars] {
+  override val document =
+    gql"query ($$ep: Episode!, $$withType: Boolean!) { hero(episode: $$ep) { ... on Character @include(if: $$withType) { __typename } name ... on Human { homePlanet } } }" // assert: GraphQLGen
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsSubtypeNoTypename.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubtypeNoTypename.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+
+// A fragment on a subtype (`Human`) without a base-level `__typename`: the generated decoder
+// couldn't tell a `Human` response from any other `Character`, so this must be rejected.
+@GraphQL
+trait StarWarsSubtypeNoTypename extends GraphQLOperation[StarWars] {
+  override val document =
+    gql"query ($$ep: Episode!) { hero(episode: $$ep) { name ... on Human { homePlanet } } }" // assert: GraphQLGen
+}
+// format: on

--- a/gen/input/src/main/scala/test/StarWarsTypenameInFragment.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypenameInFragment.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+/*
+  rules = [GraphQLGen]
+  Clue.schemaDirs = ["gen/input/src/main/resources/graphql/schemas"]
+ */
+package test
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+
+// `__typename` inside an unconditional same-type fragment is pure grouping and lands flat in the
+// response, so it satisfies the discriminator requirement.
+@GraphQL
+trait StarWarsTypenameInFragment extends GraphQLOperation[StarWars] {
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            ... on Character { __typename }
+            name
+            ... on Human {
+              homePlanet
+            }
+          }
+        }
+      """
+}
+// format: on

--- a/gen/output/src/main/scala/test/LucumaQuery.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery.scala
@@ -25,6 +25,7 @@ object LucumaQuery extends GraphQLOperation[LucumaODB] {
               id
               name
               tracking {
+                __typename
                 ... on Sidereal {
                   epoch
                 }
@@ -70,7 +71,16 @@ object LucumaQuery extends GraphQLOperation[LucumaODB] {
             val nonsidereal: monocle.Prism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Nonsidereal] = monocle.macros.GenPrism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Nonsidereal]
             implicit val eqTracking: cats.Eq[Data.Program.Targets.Nodes.Tracking] = cats.Eq.fromUniversalEquals
             implicit val showTracking: cats.Show[Data.Program.Targets.Nodes.Tracking] = cats.Show.fromToString
-            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = List[io.circe.Decoder[Data.Program.Targets.Nodes.Tracking]](io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Sidereal].asInstanceOf[io.circe.Decoder[Data.Program.Targets.Nodes.Tracking]], io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Nonsidereal].asInstanceOf[io.circe.Decoder[Data.Program.Targets.Nodes.Tracking]]).reduceLeft(_ or _)
+            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = io.circe.Decoder.instance {
+              c => c.downField("__typename").as[String].flatMap {
+                case "Sidereal" =>
+                  io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Sidereal].tryDecode(c)
+                case "Nonsidereal" =>
+                  io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Nonsidereal].tryDecode(c)
+                case other =>
+                  Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Tracking", c.history))
+              }
+            }
           }
           val id: monocle.Lens[Data.Program.Targets.Nodes, TargetId] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.id)
           val name: monocle.Lens[Data.Program.Targets.Nodes, NonEmptyString] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.name)

--- a/gen/output/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery2.scala
@@ -25,6 +25,7 @@ object LucumaQuery2 extends GraphQLOperation[LucumaODB] {
               id
               name
               tracking {
+                __typename
                 ... on Sidereal {
                   epoch
                 }
@@ -47,12 +48,33 @@ object LucumaQuery2 extends GraphQLOperation[LucumaODB] {
       object Targets {
         case class Nodes(val id: TargetId, val name: NonEmptyString, val tracking: Data.Program.Targets.Nodes.Tracking)
         object Nodes {
-          case class Tracking(val epoch: EpochString)
+          sealed trait Tracking
           object Tracking {
-            val epoch: monocle.Iso[Data.Program.Targets.Nodes.Tracking, EpochString] = monocle.Focus[Data.Program.Targets.Nodes.Tracking](_.epoch)
+            case class Sidereal(val epoch: EpochString) extends Tracking()
+            object Sidereal {
+              val epoch: monocle.Iso[Data.Program.Targets.Nodes.Tracking.Sidereal, EpochString] = monocle.Focus[Data.Program.Targets.Nodes.Tracking.Sidereal](_.epoch)
+              implicit val eqSidereal: cats.Eq[Data.Program.Targets.Nodes.Tracking.Sidereal] = cats.Eq.fromUniversalEquals
+              implicit val showSidereal: cats.Show[Data.Program.Targets.Nodes.Tracking.Sidereal] = cats.Show.fromToString
+              implicit val jsonDecoderSidereal: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Sidereal] = io.circe.generic.semiauto.deriveDecoder[Data.Program.Targets.Nodes.Tracking.Sidereal]
+            }
+            case class Other() extends Tracking()
+            object Other {
+              implicit val eqOther: cats.Eq[Data.Program.Targets.Nodes.Tracking.Other] = cats.Eq.fromUniversalEquals
+              implicit val showOther: cats.Show[Data.Program.Targets.Nodes.Tracking.Other] = cats.Show.fromToString
+              implicit val jsonDecoderOther: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Program.Targets.Nodes.Tracking.Other]
+            }
+            val sidereal: monocle.Prism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Sidereal] = monocle.macros.GenPrism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Sidereal]
+            val other: monocle.Prism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Other] = monocle.macros.GenPrism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Other]
             implicit val eqTracking: cats.Eq[Data.Program.Targets.Nodes.Tracking] = cats.Eq.fromUniversalEquals
             implicit val showTracking: cats.Show[Data.Program.Targets.Nodes.Tracking] = cats.Show.fromToString
-            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = io.circe.generic.semiauto.deriveDecoder[Data.Program.Targets.Nodes.Tracking]
+            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = io.circe.Decoder.instance {
+              c => c.downField("__typename").as[String].flatMap {
+                case "Sidereal" =>
+                  io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Sidereal].tryDecode(c)
+                case _ =>
+                  io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Other].tryDecode(c)
+              }
+            }
           }
           val id: monocle.Lens[Data.Program.Targets.Nodes, TargetId] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.id)
           val name: monocle.Lens[Data.Program.Targets.Nodes, NonEmptyString] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.name)

--- a/gen/output/src/main/scala/test/LucumaQuery3.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery3.scala
@@ -21,6 +21,7 @@ object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
           nodes {
             id
             observationTarget {
+              __typename
               ... on Target {
                 target_id: id
                 target_name: name
@@ -67,7 +68,16 @@ object LucumaQuery3 extends GraphQLOperation[LucumaODB] {
           val asterism: monocle.Prism[Data.Observations.Nodes.ObservationTarget, Data.Observations.Nodes.ObservationTarget.Asterism] = monocle.macros.GenPrism[Data.Observations.Nodes.ObservationTarget, Data.Observations.Nodes.ObservationTarget.Asterism]
           implicit val eqObservationTarget: cats.Eq[Data.Observations.Nodes.ObservationTarget] = cats.Eq.fromUniversalEquals
           implicit val showObservationTarget: cats.Show[Data.Observations.Nodes.ObservationTarget] = cats.Show.fromToString
-          implicit val jsonDecoderObservationTarget: io.circe.Decoder[Data.Observations.Nodes.ObservationTarget] = List[io.circe.Decoder[Data.Observations.Nodes.ObservationTarget]](io.circe.Decoder[Data.Observations.Nodes.ObservationTarget.Target].asInstanceOf[io.circe.Decoder[Data.Observations.Nodes.ObservationTarget]], io.circe.Decoder[Data.Observations.Nodes.ObservationTarget.Asterism].asInstanceOf[io.circe.Decoder[Data.Observations.Nodes.ObservationTarget]]).reduceLeft(_ or _)
+          implicit val jsonDecoderObservationTarget: io.circe.Decoder[Data.Observations.Nodes.ObservationTarget] = io.circe.Decoder.instance {
+            c => c.downField("__typename").as[String].flatMap {
+              case "Target" =>
+                io.circe.Decoder[Data.Observations.Nodes.ObservationTarget.Target].tryDecode(c)
+              case "Asterism" =>
+                io.circe.Decoder[Data.Observations.Nodes.ObservationTarget.Asterism].tryDecode(c)
+              case other =>
+                Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for ObservationTarget", c.history))
+            }
+          }
         }
         val id: monocle.Lens[Data.Observations.Nodes, ObservationId] = monocle.macros.GenLens[Data.Observations.Nodes](_.id)
         val observationTarget: monocle.Lens[Data.Observations.Nodes, Option[Data.Observations.Nodes.ObservationTarget]] = monocle.macros.GenLens[Data.Observations.Nodes](_.observationTarget)

--- a/gen/output/src/main/scala/test/StarWarsAliasedTypename.scala
+++ b/gen/output/src/main/scala/test/StarWarsAliasedTypename.scala
@@ -1,0 +1,108 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLOperation
+
+// Checks that an ALIASED `__typename` (`kind: __typename`) is used as the decoder
+// discriminator key, AND is also generated as a regular field (`kind: String`) on the trait
+// and every instance.
+
+object StarWarsAliasedTypename extends GraphQLOperation[StarWars] {
+  import StarWars.Scalars._
+  ignoreUnusedImportScalars()
+  import StarWars.Enums._
+  ignoreUnusedImportEnums()
+  import StarWars.Types._
+  ignoreUnusedImportTypes()
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            kind: __typename
+            name
+            ... on Human {
+              homePlanet
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+        }
+      """
+  case class Variables(val ep: Episode)
+  object Variables {
+    val ep: monocle.Iso[Variables, Episode] = monocle.Focus[Variables](_.ep)
+    implicit val eqVariables: cats.Eq[Variables] = cats.Eq.fromUniversalEquals
+    implicit val showVariables: cats.Show[Variables] = cats.Show.fromToString
+    implicit val jsonEncoderVariables: io.circe.Encoder.AsObject[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJsonObject(clue.data.Input.dropIgnores)
+  }
+  case class Data(val hero: Data.Hero)
+  object Data {
+    sealed trait Hero {
+      val kind: String
+      val name: Option[String]
+    }
+    object Hero {
+      case class Human(override val kind: String, override val name: Option[String] = None, val homePlanet: Option[String] = None) extends Hero()
+      object Human {
+        val kind: monocle.Lens[Data.Hero.Human, String] = monocle.macros.GenLens[Data.Hero.Human](_.kind)
+        val name: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.name)
+        val homePlanet: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.homePlanet)
+        implicit val eqHuman: cats.Eq[Data.Hero.Human] = cats.Eq.fromUniversalEquals
+        implicit val showHuman: cats.Show[Data.Hero.Human] = cats.Show.fromToString
+        implicit val jsonDecoderHuman: io.circe.Decoder[Data.Hero.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Human]
+      }
+      case class Droid(override val kind: String, override val name: Option[String] = None, @deprecated("Use 'functions' instead") val primaryFunction: Option[String] = None) extends Hero()
+      object Droid {
+        val kind: monocle.Lens[Data.Hero.Droid, String] = monocle.macros.GenLens[Data.Hero.Droid](_.kind)
+        val name: monocle.Lens[Data.Hero.Droid, Option[String]] = monocle.macros.GenLens[Data.Hero.Droid](_.name)
+        @deprecated("Use 'functions' instead") val primaryFunction: monocle.Lens[Data.Hero.Droid, Option[String]] = monocle.macros.GenLens[Data.Hero.Droid](_.primaryFunction)
+        implicit val eqDroid: cats.Eq[Data.Hero.Droid] = cats.Eq.fromUniversalEquals
+        implicit val showDroid: cats.Show[Data.Hero.Droid] = cats.Show.fromToString
+        implicit val jsonDecoderDroid: io.circe.Decoder[Data.Hero.Droid] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Droid]
+      }
+      val kind: monocle.Lens[Data.Hero, String] = monocle.Lens[Data.Hero, String](_.kind) {
+        v => _ match {
+          case s: Data.Hero.Human =>
+            s.copy(kind = v)
+          case s: Data.Hero.Droid =>
+            s.copy(kind = v)
+        }
+      }
+      val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
+        v => _ match {
+          case s: Data.Hero.Human =>
+            s.copy(name = v)
+          case s: Data.Hero.Droid =>
+            s.copy(name = v)
+        }
+      }
+      val human: monocle.Prism[Data.Hero, Data.Hero.Human] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Human]
+      val droid: monocle.Prism[Data.Hero, Data.Hero.Droid] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Droid]
+      implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
+      implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
+      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
+        c => c.downField("kind").as[String].flatMap {
+          case "Human" =>
+            io.circe.Decoder[Data.Hero.Human].tryDecode(c)
+          case "Droid" =>
+            io.circe.Decoder[Data.Hero.Droid].tryDecode(c)
+          case other =>
+            Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Hero", c.history))
+        }
+      }
+    }
+    val hero: monocle.Iso[Data, Data.Hero] = monocle.Focus[Data](_.hero)
+    implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
+    implicit val showData: cats.Show[Data] = cats.Show.fromToString
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+  }
+  val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
+  val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(ep: Episode, modParams: P => P = identity) = client.request(StarWarsAliasedTypename).withDescriptor("StarWarsAliasedTypename").withInput(Variables(ep), modParams) }
+}
+// format: on

--- a/gen/output/src/main/scala/test/StarWarsAliasedTypenameOther.scala
+++ b/gen/output/src/main/scala/test/StarWarsAliasedTypenameOther.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLOperation
+
+// Combines an ALIASED `__typename` discriminator with a fallback `Other` instance (`Droid` is
+// left uncovered): `kind` must still be generated as a regular field on `Other` too.
+
+object StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
+  import StarWars.Scalars._
+  ignoreUnusedImportScalars()
+  import StarWars.Enums._
+  ignoreUnusedImportEnums()
+  import StarWars.Types._
+  ignoreUnusedImportTypes()
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            kind: __typename
+            name
+            ... on Human {
+              homePlanet
+            }
+          }
+        }
+      """
+  case class Variables(val ep: Episode)
+  object Variables {
+    val ep: monocle.Iso[Variables, Episode] = monocle.Focus[Variables](_.ep)
+    implicit val eqVariables: cats.Eq[Variables] = cats.Eq.fromUniversalEquals
+    implicit val showVariables: cats.Show[Variables] = cats.Show.fromToString
+    implicit val jsonEncoderVariables: io.circe.Encoder.AsObject[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJsonObject(clue.data.Input.dropIgnores)
+  }
+  case class Data(val hero: Data.Hero)
+  object Data {
+    sealed trait Hero {
+      val kind: String
+      val name: Option[String]
+    }
+    object Hero {
+      case class Human(override val kind: String, override val name: Option[String] = None, val homePlanet: Option[String] = None) extends Hero()
+      object Human {
+        val kind: monocle.Lens[Data.Hero.Human, String] = monocle.macros.GenLens[Data.Hero.Human](_.kind)
+        val name: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.name)
+        val homePlanet: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.homePlanet)
+        implicit val eqHuman: cats.Eq[Data.Hero.Human] = cats.Eq.fromUniversalEquals
+        implicit val showHuman: cats.Show[Data.Hero.Human] = cats.Show.fromToString
+        implicit val jsonDecoderHuman: io.circe.Decoder[Data.Hero.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Human]
+      }
+      case class Other(override val kind: String, override val name: Option[String] = None) extends Hero()
+      object Other {
+        val kind: monocle.Lens[Data.Hero.Other, String] = monocle.macros.GenLens[Data.Hero.Other](_.kind)
+        val name: monocle.Lens[Data.Hero.Other, Option[String]] = monocle.macros.GenLens[Data.Hero.Other](_.name)
+        implicit val eqOther: cats.Eq[Data.Hero.Other] = cats.Eq.fromUniversalEquals
+        implicit val showOther: cats.Show[Data.Hero.Other] = cats.Show.fromToString
+        implicit val jsonDecoderOther: io.circe.Decoder[Data.Hero.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Other]
+      }
+      val kind: monocle.Lens[Data.Hero, String] = monocle.Lens[Data.Hero, String](_.kind) {
+        v => _ match {
+          case s: Data.Hero.Human =>
+            s.copy(kind = v)
+          case s: Data.Hero.Other =>
+            s.copy(kind = v)
+        }
+      }
+      val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
+        v => _ match {
+          case s: Data.Hero.Human =>
+            s.copy(name = v)
+          case s: Data.Hero.Other =>
+            s.copy(name = v)
+        }
+      }
+      val human: monocle.Prism[Data.Hero, Data.Hero.Human] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Human]
+      val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
+      implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
+      implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
+      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
+        c => c.downField("kind").as[String].flatMap {
+          case "Human" =>
+            io.circe.Decoder[Data.Hero.Human].tryDecode(c)
+          case _ =>
+            io.circe.Decoder[Data.Hero.Other].tryDecode(c)
+        }
+      }
+    }
+    val hero: monocle.Iso[Data, Data.Hero] = monocle.Focus[Data](_.hero)
+    implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
+    implicit val showData: cats.Show[Data] = cats.Show.fromToString
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+  }
+  val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
+  val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(ep: Episode, modParams: P => P = identity) = client.request(StarWarsAliasedTypenameOther).withDescriptor("StarWarsAliasedTypenameOther").withInput(Variables(ep), modParams) }
+}
+// format: on

--- a/gen/output/src/main/scala/test/StarWarsHumanSubquery.scala
+++ b/gen/output/src/main/scala/test/StarWarsHumanSubquery.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQLType
+
+
+@GraphQLType("Human") object StarWarsHumanSubquery extends GraphQLSubquery[StarWars] {
+  import StarWars.Scalars._
+  ignoreUnusedImportScalars()
+  import StarWars.Enums._
+  ignoreUnusedImportEnums()
+  import StarWars.Types._
+  ignoreUnusedImportTypes()
+  override val subquery = gql"""
+        {
+          homePlanet
+        }
+      """
+  case class Data(val homePlanet: Option[String] = None)
+  object Data {
+    val homePlanet: monocle.Iso[Data, Option[String]] = monocle.Focus[Data](_.homePlanet)
+    implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
+    implicit val showData: cats.Show[Data] = cats.Show.fromToString
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+  }
+  val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
+}
+
+
+// format: on

--- a/gen/output/src/main/scala/test/StarWarsInterfaceSubtype.scala
+++ b/gen/output/src/main/scala/test/StarWarsInterfaceSubtype.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLOperation
+
+// A fragment on an interface (`Pilot`, implemented only by `Human`): `__typename` in a response is
+// always the concrete object type name (`Human`), never the interface name, so the decoder must
+// map every concrete implementor to the `Pilot` instance, not match on `"Pilot"` itself.
+
+object StarWarsInterfaceSubtype extends GraphQLOperation[StarWars] {
+  import StarWars.Scalars._
+  ignoreUnusedImportScalars()
+  import StarWars.Enums._
+  ignoreUnusedImportEnums()
+  import StarWars.Types._
+  ignoreUnusedImportTypes()
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            __typename
+            name
+            ... on Pilot {
+              vehicle
+            }
+          }
+        }
+      """
+  case class Variables(val ep: Episode)
+  object Variables {
+    val ep: monocle.Iso[Variables, Episode] = monocle.Focus[Variables](_.ep)
+    implicit val eqVariables: cats.Eq[Variables] = cats.Eq.fromUniversalEquals
+    implicit val showVariables: cats.Show[Variables] = cats.Show.fromToString
+    implicit val jsonEncoderVariables: io.circe.Encoder.AsObject[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJsonObject(clue.data.Input.dropIgnores)
+  }
+  case class Data(val hero: Data.Hero)
+  object Data {
+    sealed trait Hero { val name: Option[String] }
+    object Hero {
+      case class Pilot(override val name: Option[String] = None, val vehicle: Option[String] = None) extends Hero()
+      object Pilot {
+        val name: monocle.Lens[Data.Hero.Pilot, Option[String]] = monocle.macros.GenLens[Data.Hero.Pilot](_.name)
+        val vehicle: monocle.Lens[Data.Hero.Pilot, Option[String]] = monocle.macros.GenLens[Data.Hero.Pilot](_.vehicle)
+        implicit val eqPilot: cats.Eq[Data.Hero.Pilot] = cats.Eq.fromUniversalEquals
+        implicit val showPilot: cats.Show[Data.Hero.Pilot] = cats.Show.fromToString
+        implicit val jsonDecoderPilot: io.circe.Decoder[Data.Hero.Pilot] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Pilot]
+      }
+      case class Other(override val name: Option[String] = None) extends Hero()
+      object Other {
+        val name: monocle.Iso[Data.Hero.Other, Option[String]] = monocle.Focus[Data.Hero.Other](_.name)
+        implicit val eqOther: cats.Eq[Data.Hero.Other] = cats.Eq.fromUniversalEquals
+        implicit val showOther: cats.Show[Data.Hero.Other] = cats.Show.fromToString
+        implicit val jsonDecoderOther: io.circe.Decoder[Data.Hero.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Other]
+      }
+      val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
+        v => _ match {
+          case s: Data.Hero.Pilot =>
+            s.copy(name = v)
+          case s: Data.Hero.Other =>
+            s.copy(name = v)
+        }
+      }
+      val pilot: monocle.Prism[Data.Hero, Data.Hero.Pilot] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Pilot]
+      val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
+      implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
+      implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
+      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
+        c => c.downField("__typename").as[String].flatMap {
+          case "Human" =>
+            io.circe.Decoder[Data.Hero.Pilot].tryDecode(c)
+          case _ =>
+            io.circe.Decoder[Data.Hero.Other].tryDecode(c)
+        }
+      }
+    }
+    val hero: monocle.Iso[Data, Data.Hero] = monocle.Focus[Data](_.hero)
+    implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
+    implicit val showData: cats.Show[Data] = cats.Show.fromToString
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+  }
+  val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
+  val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(ep: Episode, modParams: P => P = identity) = client.request(StarWarsInterfaceSubtype).withDescriptor("StarWarsInterfaceSubtype").withInput(Variables(ep), modParams) }
+}
+// format: on

--- a/gen/output/src/main/scala/test/StarWarsNestedSubquery.scala
+++ b/gen/output/src/main/scala/test/StarWarsNestedSubquery.scala
@@ -18,6 +18,7 @@ import clue.annotation.GraphQLType
   ignoreUnusedImportTypes()
   override val subquery = gql"""
         {
+          __typename
           id
           name
           ... on Human {
@@ -29,14 +30,70 @@ import clue.annotation.GraphQLType
           }
         }
       """
-  case class Data(val id: String, val name: Option[String] = None, val contacts: Option[List[StarWarsSubquery.Data]] = None)
+  sealed trait Data {
+    val id: String
+    val name: Option[String]
+    val contacts: Option[List[StarWarsSubquery.Data]]
+  }
   object Data {
-    val id: monocle.Lens[Data, String] = monocle.macros.GenLens[Data](_.id)
-    val name: monocle.Lens[Data, Option[String]] = monocle.macros.GenLens[Data](_.name)
-    val contacts: monocle.Lens[Data, Option[List[StarWarsSubquery.Data]]] = monocle.macros.GenLens[Data](_.contacts)
+    case class Human(override val id: String, override val name: Option[String] = None, val homePlanet: Option[String] = None, override val contacts: Option[List[StarWarsSubquery.Data]] = None) extends Data()
+    object Human {
+      val id: monocle.Lens[Data.Human, String] = monocle.macros.GenLens[Data.Human](_.id)
+      val name: monocle.Lens[Data.Human, Option[String]] = monocle.macros.GenLens[Data.Human](_.name)
+      val homePlanet: monocle.Lens[Data.Human, Option[String]] = monocle.macros.GenLens[Data.Human](_.homePlanet)
+      val contacts: monocle.Lens[Data.Human, Option[List[StarWarsSubquery.Data]]] = monocle.macros.GenLens[Data.Human](_.contacts)
+      implicit val eqHuman: cats.Eq[Data.Human] = cats.Eq.fromUniversalEquals
+      implicit val showHuman: cats.Show[Data.Human] = cats.Show.fromToString
+      implicit val jsonDecoderHuman: io.circe.Decoder[Data.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Human]
+    }
+    case class Droid(override val id: String, override val name: Option[String] = None, override val contacts: Option[List[StarWarsSubquery.Data]] = None, @deprecated("Use 'functions' instead") val primaryFunction: Option[String] = None) extends Data()
+    object Droid {
+      val id: monocle.Lens[Data.Droid, String] = monocle.macros.GenLens[Data.Droid](_.id)
+      val name: monocle.Lens[Data.Droid, Option[String]] = monocle.macros.GenLens[Data.Droid](_.name)
+      val contacts: monocle.Lens[Data.Droid, Option[List[StarWarsSubquery.Data]]] = monocle.macros.GenLens[Data.Droid](_.contacts)
+      @deprecated("Use 'functions' instead") val primaryFunction: monocle.Lens[Data.Droid, Option[String]] = monocle.macros.GenLens[Data.Droid](_.primaryFunction)
+      implicit val eqDroid: cats.Eq[Data.Droid] = cats.Eq.fromUniversalEquals
+      implicit val showDroid: cats.Show[Data.Droid] = cats.Show.fromToString
+      implicit val jsonDecoderDroid: io.circe.Decoder[Data.Droid] = io.circe.generic.semiauto.deriveDecoder[Data.Droid]
+    }
+    val id: monocle.Lens[Data, String] = monocle.Lens[Data, String](_.id) {
+      v => _ match {
+        case s: Data.Human =>
+          s.copy(id = v)
+        case s: Data.Droid =>
+          s.copy(id = v)
+      }
+    }
+    val name: monocle.Lens[Data, Option[String]] = monocle.Lens[Data, Option[String]](_.name) {
+      v => _ match {
+        case s: Data.Human =>
+          s.copy(name = v)
+        case s: Data.Droid =>
+          s.copy(name = v)
+      }
+    }
+    val contacts: monocle.Lens[Data, Option[List[StarWarsSubquery.Data]]] = monocle.Lens[Data, Option[List[StarWarsSubquery.Data]]](_.contacts) {
+      v => _ match {
+        case s: Data.Human =>
+          s.copy(contacts = v)
+        case s: Data.Droid =>
+          s.copy(contacts = v)
+      }
+    }
+    val human: monocle.Prism[Data, Data.Human] = monocle.macros.GenPrism[Data, Data.Human]
+    val droid: monocle.Prism[Data, Data.Droid] = monocle.macros.GenPrism[Data, Data.Droid]
     implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
     implicit val showData: cats.Show[Data] = cats.Show.fromToString
-    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.Decoder.instance {
+      c => c.downField("__typename").as[String].flatMap {
+        case "Human" =>
+          io.circe.Decoder[Data.Human].tryDecode(c)
+        case "Droid" =>
+          io.circe.Decoder[Data.Droid].tryDecode(c)
+        case other =>
+          Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Data", c.history))
+      }
+    }
   }
   val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
 }

--- a/gen/output/src/main/scala/test/StarWarsQuery.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery.scala
@@ -18,6 +18,7 @@ object StarWarsQuery extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) {
+            __typename
             id
             name
             ... on Human {
@@ -102,7 +103,16 @@ object StarWarsQuery extends GraphQLOperation[StarWars] {
       val droid: monocle.Prism[Data.Character, Data.Character.Droid] = monocle.macros.GenPrism[Data.Character, Data.Character.Droid]
       implicit val eqCharacter: cats.Eq[Data.Character] = cats.Eq.fromUniversalEquals
       implicit val showCharacter: cats.Show[Data.Character] = cats.Show.fromToString
-      implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = List[io.circe.Decoder[Data.Character]](io.circe.Decoder[Data.Character.Human].asInstanceOf[io.circe.Decoder[Data.Character]], io.circe.Decoder[Data.Character.Droid].asInstanceOf[io.circe.Decoder[Data.Character]]).reduceLeft(_ or _)
+      implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = io.circe.Decoder.instance {
+        c => c.downField("__typename").as[String].flatMap {
+          case "Human" =>
+            io.circe.Decoder[Data.Character.Human].tryDecode(c)
+          case "Droid" =>
+            io.circe.Decoder[Data.Character.Droid].tryDecode(c)
+          case other =>
+            Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Character", c.history))
+        }
+      }
     }
     val character: monocle.Iso[Data, Option[Data.Character]] = monocle.Focus[Data](_.character)
     implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals

--- a/gen/output/src/main/scala/test/StarWarsQuery2.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery2.scala
@@ -19,6 +19,7 @@ object Wrapper extends Something {
     ignoreUnusedImportTypes()
     override val document = gql"""
           fragment fields on Character {
+            __typename
             id
             name
             ... on Human {
@@ -119,7 +120,16 @@ object Wrapper extends Something {
         implicit val reuseCharacter: japgolly.scalajs.react.Reusability[Data.Character] = {
           japgolly.scalajs.react.Reusability.derive
         }
-        implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = List[io.circe.Decoder[Data.Character]](io.circe.Decoder[Data.Character.Human].asInstanceOf[io.circe.Decoder[Data.Character]], io.circe.Decoder[Data.Character.Droid].asInstanceOf[io.circe.Decoder[Data.Character]]).reduceLeft(_ or _)
+        implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = io.circe.Decoder.instance {
+          c => c.downField("__typename").as[String].flatMap {
+            case "Human" =>
+              io.circe.Decoder[Data.Character.Human].tryDecode(c)
+            case "Droid" =>
+              io.circe.Decoder[Data.Character.Droid].tryDecode(c)
+            case other =>
+              Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Character", c.history))
+          }
+        }
       }
       val character: monocle.Iso[Data, Option[Data.Character]] = monocle.Focus[Data](_.character)
       implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals

--- a/gen/output/src/main/scala/test/StarWarsQuery3.scala
+++ b/gen/output/src/main/scala/test/StarWarsQuery3.scala
@@ -18,6 +18,7 @@ object StarWarsQuery3 extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) {
+            __typename
             id
             name
             ... on Human {
@@ -93,7 +94,16 @@ object StarWarsQuery3 extends GraphQLOperation[StarWars] {
       val droid: monocle.Prism[Data.Character, Data.Character.Droid] = monocle.macros.GenPrism[Data.Character, Data.Character.Droid]
       implicit val eqCharacter: cats.Eq[Data.Character] = cats.Eq.fromUniversalEquals
       implicit val showCharacter: cats.Show[Data.Character] = cats.Show.fromToString
-      implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = List[io.circe.Decoder[Data.Character]](io.circe.Decoder[Data.Character.Human].asInstanceOf[io.circe.Decoder[Data.Character]], io.circe.Decoder[Data.Character.Droid].asInstanceOf[io.circe.Decoder[Data.Character]]).reduceLeft(_ or _)
+      implicit val jsonDecoderCharacter: io.circe.Decoder[Data.Character] = io.circe.Decoder.instance {
+        c => c.downField("__typename").as[String].flatMap {
+          case "Human" =>
+            io.circe.Decoder[Data.Character.Human].tryDecode(c)
+          case "Droid" =>
+            io.circe.Decoder[Data.Character.Droid].tryDecode(c)
+          case other =>
+            Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Character", c.history))
+        }
+      }
     }
     val character: monocle.Iso[Data, Option[Data.Character]] = monocle.Focus[Data](_.character)
     implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals

--- a/gen/output/src/main/scala/test/StarWarsSingleSubtype.scala
+++ b/gen/output/src/main/scala/test/StarWarsSingleSubtype.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLOperation
+
+// A single fragment on a subtype (`Human`), leaving `Droid` uncovered: `Character` has exactly
+// two implementors, so this must still generate a fallback `Other` instance (no special-casing
+// for "just one variant").
+
+object StarWarsSingleSubtype extends GraphQLOperation[StarWars] {
+  import StarWars.Scalars._
+  ignoreUnusedImportScalars()
+  import StarWars.Enums._
+  ignoreUnusedImportEnums()
+  import StarWars.Types._
+  ignoreUnusedImportTypes()
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            __typename
+            name
+            ... on Human {
+              homePlanet
+            }
+          }
+        }
+      """
+  case class Variables(val ep: Episode)
+  object Variables {
+    val ep: monocle.Iso[Variables, Episode] = monocle.Focus[Variables](_.ep)
+    implicit val eqVariables: cats.Eq[Variables] = cats.Eq.fromUniversalEquals
+    implicit val showVariables: cats.Show[Variables] = cats.Show.fromToString
+    implicit val jsonEncoderVariables: io.circe.Encoder.AsObject[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJsonObject(clue.data.Input.dropIgnores)
+  }
+  case class Data(val hero: Data.Hero)
+  object Data {
+    sealed trait Hero { val name: Option[String] }
+    object Hero {
+      case class Human(override val name: Option[String] = None, val homePlanet: Option[String] = None) extends Hero()
+      object Human {
+        val name: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.name)
+        val homePlanet: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.homePlanet)
+        implicit val eqHuman: cats.Eq[Data.Hero.Human] = cats.Eq.fromUniversalEquals
+        implicit val showHuman: cats.Show[Data.Hero.Human] = cats.Show.fromToString
+        implicit val jsonDecoderHuman: io.circe.Decoder[Data.Hero.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Human]
+      }
+      case class Other(override val name: Option[String] = None) extends Hero()
+      object Other {
+        val name: monocle.Iso[Data.Hero.Other, Option[String]] = monocle.Focus[Data.Hero.Other](_.name)
+        implicit val eqOther: cats.Eq[Data.Hero.Other] = cats.Eq.fromUniversalEquals
+        implicit val showOther: cats.Show[Data.Hero.Other] = cats.Show.fromToString
+        implicit val jsonDecoderOther: io.circe.Decoder[Data.Hero.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Other]
+      }
+      val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
+        v => _ match {
+          case s: Data.Hero.Human =>
+            s.copy(name = v)
+          case s: Data.Hero.Other =>
+            s.copy(name = v)
+        }
+      }
+      val human: monocle.Prism[Data.Hero, Data.Hero.Human] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Human]
+      val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
+      implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
+      implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
+      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
+        c => c.downField("__typename").as[String].flatMap {
+          case "Human" =>
+            io.circe.Decoder[Data.Hero.Human].tryDecode(c)
+          case _ =>
+            io.circe.Decoder[Data.Hero.Other].tryDecode(c)
+        }
+      }
+    }
+    val hero: monocle.Iso[Data, Data.Hero] = monocle.Focus[Data](_.hero)
+    implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
+    implicit val showData: cats.Show[Data] = cats.Show.fromToString
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+  }
+  val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
+  val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(ep: Episode, modParams: P => P = identity) = client.request(StarWarsSingleSubtype).withDescriptor("StarWarsSingleSubtype").withInput(Variables(ep), modParams) }
+}
+// format: on

--- a/gen/output/src/main/scala/test/StarWarsTypenameInFragment.scala
+++ b/gen/output/src/main/scala/test/StarWarsTypenameInFragment.scala
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// format: off
+
+package test
+
+import clue.GraphQLOperation
+
+// `__typename` inside an unconditional same-type fragment is pure grouping and lands flat in the
+// response, so it satisfies the discriminator requirement.
+
+object StarWarsTypenameInFragment extends GraphQLOperation[StarWars] {
+  import StarWars.Scalars._
+  ignoreUnusedImportScalars()
+  import StarWars.Enums._
+  ignoreUnusedImportEnums()
+  import StarWars.Types._
+  ignoreUnusedImportTypes()
+  override val document = gql"""
+        query ($$ep: Episode!) {
+          hero(episode: $$ep) {
+            ... on Character { __typename }
+            name
+            ... on Human {
+              homePlanet
+            }
+          }
+        }
+      """
+  case class Variables(val ep: Episode)
+  object Variables {
+    val ep: monocle.Iso[Variables, Episode] = monocle.Focus[Variables](_.ep)
+    implicit val eqVariables: cats.Eq[Variables] = cats.Eq.fromUniversalEquals
+    implicit val showVariables: cats.Show[Variables] = cats.Show.fromToString
+    implicit val jsonEncoderVariables: io.circe.Encoder.AsObject[Variables] = io.circe.generic.semiauto.deriveEncoder[Variables].mapJsonObject(clue.data.Input.dropIgnores)
+  }
+  case class Data(val hero: Data.Hero)
+  object Data {
+    sealed trait Hero { val name: Option[String] }
+    object Hero {
+      case class Human(override val name: Option[String] = None, val homePlanet: Option[String] = None) extends Hero()
+      object Human {
+        val name: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.name)
+        val homePlanet: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.homePlanet)
+        implicit val eqHuman: cats.Eq[Data.Hero.Human] = cats.Eq.fromUniversalEquals
+        implicit val showHuman: cats.Show[Data.Hero.Human] = cats.Show.fromToString
+        implicit val jsonDecoderHuman: io.circe.Decoder[Data.Hero.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Human]
+      }
+      case class Other(override val name: Option[String] = None) extends Hero()
+      object Other {
+        val name: monocle.Iso[Data.Hero.Other, Option[String]] = monocle.Focus[Data.Hero.Other](_.name)
+        implicit val eqOther: cats.Eq[Data.Hero.Other] = cats.Eq.fromUniversalEquals
+        implicit val showOther: cats.Show[Data.Hero.Other] = cats.Show.fromToString
+        implicit val jsonDecoderOther: io.circe.Decoder[Data.Hero.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Other]
+      }
+      val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
+        v => _ match {
+          case s: Data.Hero.Human =>
+            s.copy(name = v)
+          case s: Data.Hero.Other =>
+            s.copy(name = v)
+        }
+      }
+      val human: monocle.Prism[Data.Hero, Data.Hero.Human] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Human]
+      val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
+      implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
+      implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
+      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
+        c => c.downField("__typename").as[String].flatMap {
+          case "Human" =>
+            io.circe.Decoder[Data.Hero.Human].tryDecode(c)
+          case _ =>
+            io.circe.Decoder[Data.Hero.Other].tryDecode(c)
+        }
+      }
+    }
+    val hero: monocle.Iso[Data, Data.Hero] = monocle.Focus[Data](_.hero)
+    implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals
+    implicit val showData: cats.Show[Data] = cats.Show.fromToString
+    implicit val jsonDecoderData: io.circe.Decoder[Data] = io.circe.generic.semiauto.deriveDecoder[Data]
+  }
+  val varEncoder: io.circe.Encoder.AsObject[Variables] = Variables.jsonEncoderVariables
+  val dataDecoder: io.circe.Decoder[Data] = Data.jsonDecoderData
+  def apply[F[_]]: clue.ClientAppliedF[F, StarWars, ClientAppliedFP] = new clue.ClientAppliedF[F, StarWars, ClientAppliedFP] { def applyP[P](client: clue.FetchClientWithPars[F, P, StarWars]) = new ClientAppliedFP(client) }
+  class ClientAppliedFP[F[_], P](val client: clue.FetchClientWithPars[F, P, StarWars]) { def query(ep: Episode, modParams: P => P = identity) = client.request(StarWarsTypenameInFragment).withDescriptor("StarWarsTypenameInFragment").withInput(Variables(ep), modParams) }
+}
+// format: on

--- a/gen/rules/src/main/scala/clue/gen/Generator.scala
+++ b/gen/rules/src/main/scala/clue/gen/Generator.scala
@@ -336,10 +336,30 @@ trait Generator {
       }
   }
 
+  // How a query-side `Sum`'s decoder picks the right subtype, as opposed to trying every
+  // subtype's decoder in turn (which can't tell "wrong subtype" from "field genuinely missing").
+  // `key` is the response key of the base-level `__typename` select (its alias, if aliased).
+  // `__typename` in an actual response is always a *concrete* object type name, so a variant
+  // whose type condition is an interface or union (e.g. `... on Pilot { ... }`) can't be matched
+  // by its own name: `cases` is instead the explicit `(concrete type name, instance name)`
+  // mapping (one entry per concrete type covered by some variant; see `resolveData`), each
+  // becoming one `case "<concrete type name>" => ...` in the generated decoder. `fallback` is the
+  // instance name to fall back to (`Other`, see `Sum.instances`) when the value read at `key`
+  // doesn't match any entry in `cases`, if such a fallback was generated. Named at this level,
+  // rather than nested under `Sum`, because `TypeType.Sum` shadows `Sum` inside `object TypeType`.
+  protected case class SumDiscriminator(
+    key:      String,
+    cases:    List[(String, String)],
+    fallback: Option[String]
+  )
+
   protected case class Sum(
-    params:    List[ClassParam],
-    nested:    List[Class] = List.empty,
-    instances: List[CaseClass]
+    params:        List[ClassParam],
+    nested:        List[Class] = List.empty,
+    instances:     List[CaseClass],
+    // `None` for SchemaGen's oneOf input sums, which have no `__typename` to discriminate on and
+    // keep the original `or`-chaining decoder.
+    discriminator: Option[SumDiscriminator] = None
   )
 
   protected def paramToVal(param: Term.Param): Stat =
@@ -460,7 +480,7 @@ trait Generator {
             scalaJsReactReuse,
             circeEncoder,
             circeDecoder,
-            TypeType.Sum(sum.instances.map(_.name)),
+            TypeType.Sum(sum.instances.map(_.name), sum.discriminator),
             bodyMod = scala.Function.chain(addDefinitions ++ addLenses),
             nestPath = nestPath,
             isOneOfInput = isOneOfInput
@@ -559,9 +579,10 @@ trait Generator {
 
   protected sealed trait TypeType
   protected object TypeType {
-    case object CaseClass                      extends TypeType
-    case class Enum(values: List[EnumValue])   extends TypeType
-    case class Sum(subtypeNames: List[String]) extends TypeType
+    case object CaseClass                    extends TypeType
+    case class Enum(values: List[EnumValue]) extends TypeType
+    case class Sum(subtypeNames: List[String], discriminator: Option[SumDiscriminator])
+        extends TypeType
   }
 
   protected def modifyModuleStatements(
@@ -633,11 +654,11 @@ trait Generator {
     )
 
     val encoderDef = Option.when(circeEncoder)(typeType match {
-      case TypeType.CaseClass                         =>
+      case TypeType.CaseClass                            =>
         q"implicit val ${valName("jsonEncoder")}: io.circe.Encoder.AsObject[$n] = io.circe.generic.semiauto.deriveEncoder[$n].mapJsonObject(clue.data.Input.dropIgnores)"
-      case TypeType.Enum(_)                           =>
+      case TypeType.Enum(_)                              =>
         q"implicit val ${valName("jsonEncoder")}: io.circe.Encoder[$n] = io.circe.Encoder.encodeString.contramap[$n](_.asString)"
-      case TypeType.Sum(subtypeNames) if isOneOfInput =>
+      case TypeType.Sum(subtypeNames, _) if isOneOfInput =>
         val subTypesCases =
           subtypeNames.map(subType =>
             Case(
@@ -649,7 +670,7 @@ trait Generator {
               q"${subType.head.toLower +: subType.tail} -> value.asJson"
             )
           )
-        q"""implicit val ${valName("jsonEncoder")}: io.circe.Encoder.AsObject[$n] = 
+        q"""implicit val ${valName("jsonEncoder")}: io.circe.Encoder.AsObject[$n] =
           io.circe.Encoder.AsObject.instance[$n] {
             instance => io.circe.JsonObject.empty.+: {
               import io.circe.syntax._
@@ -658,29 +679,57 @@ trait Generator {
               }
             }
           }"""
-      case TypeType.Sum(_)                            =>
+      case TypeType.Sum(_, _)                            =>
         q"implicit val ${valName("jsonEncoder")}: io.circe.Encoder.AsObject[$n] = io.circe.generic.semiauto.deriveEncoder[$n]"
     })
 
     val decoderDef = Option.when(circeDecoder)(typeType match {
-      case TypeType.CaseClass         =>
+      case TypeType.CaseClass                        =>
         q"implicit val ${valName("jsonDecoder")}: io.circe.Decoder[$n] = io.circe.generic.semiauto.deriveDecoder[$n]"
-      case TypeType.Enum(_)           =>
+      case TypeType.Enum(_)                          =>
         q"implicit val ${valName("jsonDecoder")}: io.circe.Decoder[$n] = io.circe.Decoder.decodeString.emap(fromString(_))"
-      case TypeType.Sum(subtypeNames) =>
+      case TypeType.Sum(subtypeNames, discriminator) =>
         val baseTerm: Term.Ref =
           nestPath.fold[Term.Ref](Term.Name(name))(t => Term.Select(t, Term.Name(name)))
 
-        def subtypeDecoder(subtypeName: String): Term = {
-          val subType = Type.Select(baseTerm, Type.Name(subtypeName))
-          q"io.circe.Decoder[$subType].asInstanceOf[io.circe.Decoder[$n]]"
-        }
+        def subtypeType(subtypeName: String): Type = Type.Select(baseTerm, Type.Name(subtypeName))
 
-        q"""implicit val ${valName("jsonDecoder")}: io.circe.Decoder[$n] = 
-               List[io.circe.Decoder[$n]](
-                ..${subtypeNames.map(subtypeDecoder)}
-               ).reduceLeft(_ or _)
-        """
+        discriminator match {
+          case None                                         =>
+            // SchemaGen's oneOf input sums: no `__typename` to discriminate on, so keep trying
+            // each subtype's decoder in turn.
+            def subtypeDecoder(subtypeName: String): Term =
+              q"io.circe.Decoder[${subtypeType(subtypeName)}].asInstanceOf[io.circe.Decoder[$n]]"
+
+            q"""implicit val ${valName("jsonDecoder")}: io.circe.Decoder[$n] =
+                   List[io.circe.Decoder[$n]](
+                    ..${subtypeNames.map(subtypeDecoder)}
+                   ).reduceLeft(_ or _)
+            """
+          case Some(SumDiscriminator(key, cases, fallback)) =>
+            // A response for an interface/union field only decodes correctly when read as the
+            // right concrete subtype, so discriminate on `__typename` (or its alias) up front
+            // instead of trying every subtype's decoder in turn (which can't tell "wrong
+            // subtype" from "field genuinely missing"). `__typename` in a response is always a
+            // concrete object type name, so `cases` maps each of those to the instance that
+            // covers it (an interface/union-typed variant covers several concrete names, all
+            // decoding as that same instance).
+            val concreteCases = cases.map { case (typeName, instanceName) =>
+              p"case $typeName => io.circe.Decoder[${subtypeType(instanceName)}].tryDecode(c)"
+            }
+            val fallbackCase  = fallback.fold(
+              p"""case other => Left(io.circe.DecodingFailure("Unexpected __typename [" + other + ${Lit
+                  .String(s"] for $name")}, c.history))"""
+            )(fb => p"case _ => io.circe.Decoder[${subtypeType(fb)}].tryDecode(c)")
+
+            q"""implicit val ${valName("jsonDecoder")}: io.circe.Decoder[$n] =
+                  io.circe.Decoder.instance { c =>
+                    c.downField(${Lit.String(key)}).as[String].flatMap {
+                      ..case ${concreteCases :+ fallbackCase}
+                    }
+                  }
+             """
+        }
     })
 
     modifyModuleStatements(

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -371,44 +371,61 @@ trait QueryGen extends Generator {
    * needs a stable `groupBy` for other reasons.
    *
    * Same-type fragments are unwrapped by recursing into this same function (not into the caller's
-   * own walk), so a bare fragment routed here by the caller can't loop forever.
+   * own walk), so a bare fragment routed here by the caller can't loop forever. `conditional`
+   * accumulates whether any same-type fragment/spread unwrapped along the way (including this
+   * call's own ancestors) carried `@skip`/`@include`; a same-type fragment's own directives are
+   * folded in before recursing into its children, so a `__typename` (or anything else) that
+   * flattens to base-level through such a fragment is marked conditional even though it looks
+   * unconditional once flattened — see `validateTypenameSelections`, which requires the
+   * discriminator to be selected unconditionally.
    */
   private def flattenSelections(
     schema:       Schema,
     fragmentsMap: Map[String, UntypedFragment],
     selections:   List[Query],
-    currentType:  Option[GType]
-  ): List[(Option[String], Query)] = {
+    currentType:  Option[GType],
+    conditional:  Boolean = false
+  ): List[FlatSelection] = {
     def isSameType(tpnme: Option[String]): Boolean =
       tpnme.forall(t => currentType.forall(ct => schema.definition(t).forall(td => ct <:< td)))
 
     selections.flatMap {
-      case Query.Group(inner)                                                =>
-        flattenSelections(schema, fragmentsMap, inner, currentType)
-      case Query.UntypedFragmentSpread(name, _)                              =>
+      case Query.Group(inner)                                                         =>
+        flattenSelections(schema, fragmentsMap, inner, currentType, conditional)
+      case Query.UntypedFragmentSpread(name, directives)                              =>
         fragmentsMap.get(name).toList.flatMap { frag =>
           flattenSelections(
             schema,
             fragmentsMap,
-            List(Query.UntypedInlineFragment(frag.tpnme.some, Nil, frag.child)),
-            currentType
+            List(Query.UntypedInlineFragment(frag.tpnme.some, directives, frag.child)),
+            currentType,
+            conditional
           )
         }
-      case Query.UntypedInlineFragment(tpnme, _, child) if isSameType(tpnme) =>
-        flattenSelections(schema, fragmentsMap, selectionsOf(child), currentType)
-      case Query.UntypedInlineFragment(tpnme, _, child)                      =>
-        List((tpnme, child))
-      case other                                                             =>
-        List((none, other))
+      case Query.UntypedInlineFragment(tpnme, directives, child) if isSameType(tpnme) =>
+        flattenSelections(
+          schema,
+          fragmentsMap,
+          selectionsOf(child),
+          currentType,
+          conditional || hasConditionalDirective(directives)
+        )
+      case Query.UntypedInlineFragment(tpnme, _, child)                               =>
+        List(FlatSelection(tpnme, child, conditional))
+      case other                                                                      =>
+        List(FlatSelection(none, other, conditional))
     }
   }
 
   /**
    * Per-operation check that every selection set with at least one variant fragment (see
-   * [[flattenSelections]]) also selects `__typename` at the base level (possibly aliased), so
-   * `resolveData`'s generated decoder (see `Generator.addModuleDefs`, `TypeType.Sum`) can tell
-   * which subtype a response is. Mirrors [[inferVariableVars]]'s walk through fields/fragments,
-   * tracking the current type as it goes.
+   * [[flattenSelections]]) also selects `__typename` at the base level (possibly aliased)
+   * unconditionally, so `resolveData`'s generated decoder (see `Generator.addModuleDefs`,
+   * `TypeType.Sum`) can tell which subtype a response is. A `__typename` guarded by `@skip`/
+   * `@include` — directly, or via an enclosing same-type fragment/spread carrying the directive
+   * (see `FlatSelection.conditional`) — may be absent from the response even though the field
+   * itself isn't, so it is rejected just like a missing `__typename`. Mirrors
+   * [[inferVariableVars]]'s walk through fields/fragments, tracking the current type as it goes.
    */
   private def validateTypenameSelections(
     schema:    Schema,
@@ -417,19 +434,26 @@ trait QueryGen extends Generator {
     query:     Query
   ): List[Problem] = {
     def check(selections: List[Query], currentType: Option[GType]): List[Problem] = {
-      val flat: List[(Option[String], Query)] =
+      val flat: List[FlatSelection] =
         flattenSelections(schema, fragments, selections, currentType)
 
-      val variantTypeNames: List[String] = flat.collect { case (Some(t), _) => t }.distinct
+      val variantTypeNames: List[String] = flat.collect { case FlatSelection(Some(t), _, _) =>
+        t
+      }.distinct
 
-      val hasTypename: Boolean = flat.exists {
-        case (None, Query.UntypedSelect(TypeSelect, _, _, _, _)) => true
-        case _                                                   => false
+      // Whether each base-level `__typename` select is conditional: directly guarded by
+      // `@skip`/`@include`, or unwrapped from a same-type fragment/spread that was.
+      val typenames: List[Boolean] = flat.collect {
+        case FlatSelection(None,
+                           Query.UntypedSelect(TypeSelect, _, _, directives, _),
+                           conditional
+            ) =>
+          conditional || hasConditionalDirective(directives)
       }
 
       val here: List[Problem] =
-        if (variantTypeNames.isEmpty || hasTypename) List.empty
-        else {
+        if (variantTypeNames.isEmpty) List.empty
+        else if (typenames.isEmpty) {
           val ctName = currentType.flatMap(_.asNamed).fold("?")(_.name)
           List(
             Problem(
@@ -438,19 +462,29 @@ trait QueryGen extends Generator {
                 "them so the response can be decoded to the right subtype."
             )
           )
-        }
+        } else if (typenames.forall(identity)) {
+          val ctName = currentType.flatMap(_.asNamed).fold("?")(_.name)
+          List(
+            Problem(
+              s"Selection on [$ctName] has fragments on subtypes [${variantTypeNames
+                  .mkString(", ")}] but its `__typename` is selected with `@skip`/`@include` " +
+                "(directly or via an enclosing fragment). The discriminator must be selected " +
+                "unconditionally so every response can be decoded to the right subtype."
+            )
+          )
+        } else List.empty
 
       val nested: List[Problem] = flat.flatMap {
-        case (None, Query.UntypedSelect(name, _, _, _, child)) =>
+        case FlatSelection(None, Query.UntypedSelect(name, _, _, _, child), _) =>
           val next =
             MetaTypes
               .get(name)
               .orElse(currentType.flatMap(_.field(name)))
               .flatMap(_.underlyingObject)
           check(selectionsOf(child), next)
-        case (Some(t), child)                                  =>
+        case FlatSelection(Some(t), child, _)                                  =>
           check(selectionsOf(child), schema.definition(t))
-        case _                                                 =>
+        case _                                                                 =>
           List.empty
       }
 
@@ -828,22 +862,26 @@ trait QueryGen extends Generator {
           // (grouping only, e.g. for `@include`) into a flat, ordered list of base-level selects
           // and variant inline fragments (fragments on a proper subtype of `currentType`). See
           // `flattenSelections` for the classification rule.
-          val flatSelections: List[(Option[String], Query)] =
+          val flatSelections: List[FlatSelection] =
             flattenSelections(schema, fragmentsMap, selections, currentType)
 
           val hierarchyAccumulators
             : List[(Option[String], List[(Accumulator[Class, ClassParam, Sum], Int)])] =
             flatSelections.zipWithIndex // We want to preserve order of appeareance
-              .groupBy(_._1._1)         // Group by discriminator (None = base group)
+              .groupBy(_._1.variant)    // Group by discriminator (None = base group)
               .toList
               .sortBy(_._2.head._2)     // Sort by first appeareance of each subtype
               .map { // Resolve groups
                 case (Some(typeName), items) =>
                   (typeName.some,
-                   items.map { case ((_, child), idx) => (go(child, getType(typeName).some), idx) }
+                   items.map { case (FlatSelection(_, child, _), idx) =>
+                     (go(child, getType(typeName).some), idx)
+                   }
                   )
                 case (None, items)           =>
-                  (none, items.map { case ((_, q), idx) => (go(q, currentType), idx) })
+                  (none,
+                   items.map { case (FlatSelection(_, q, _), idx) => (go(q, currentType), idx) }
+                  )
               }
 
           val baseAccumulators    = hierarchyAccumulators.collectFirst { case (None, accumulators) =>
@@ -872,8 +910,9 @@ trait QueryGen extends Generator {
               // `__typename` select whenever there is at least one variant.
               val (discriminatorKey, discriminatorIsAliased): (String, Boolean) =
                 flatSelections
-                  .collectFirst { case (None, UntypedSelect(TypeSelect, alias, _, _, _)) =>
-                    (alias.getOrElse(TypeSelect), alias.isDefined)
+                  .collectFirst {
+                    case FlatSelection(None, UntypedSelect(TypeSelect, alias, _, _, _), _) =>
+                      (alias.getOrElse(TypeSelect), alias.isDefined)
                   }
                   .getOrElse(
                     // Unreachable: validateTypenameSelections rejects variants without a base
@@ -1185,3 +1224,14 @@ trait QueryGen extends Generator {
         .getOrElse(parentBody)
 
 }
+
+// One base-level item of a flattened selection set (see `QueryGen.flattenSelections`). `variant` is
+// the type condition for a fragment on a proper subtype, `None` for a base-level select.
+// `conditional` is true when an enclosing same-type fragment/spread that was unwrapped carried
+// `@skip`/`@include`, so the item may be absent from the response even though it looks unconditional
+// here. Top-level (not nested in the trait) so pattern matches on it need no outer-reference check.
+private[gen] final case class FlatSelection(
+  variant:     Option[String],
+  query:       Query,
+  conditional: Boolean
+)

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -870,10 +870,10 @@ trait QueryGen extends Generator {
               // instance per variant, discriminated on `__typename`. Validation (see
               // `validateParsed`/`validateTypenameSelections`) already guarantees a base-level
               // `__typename` select whenever there is at least one variant.
-              val discriminatorKey: String =
+              val (discriminatorKey, discriminatorIsAliased): (String, Boolean) =
                 flatSelections
                   .collectFirst { case (None, UntypedSelect(TypeSelect, alias, _, _, _)) =>
-                    alias.getOrElse(TypeSelect)
+                    (alias.getOrElse(TypeSelect), alias.isDefined)
                   }
                   .getOrElse(
                     // Unreachable: validateTypenameSelections rejects variants without a base
@@ -881,11 +881,16 @@ trait QueryGen extends Generator {
                     throw new Exception("Missing `__typename` for a validated variant selection")
                   )
 
-              // `__typename` is consumed by the discriminating decoder (see
-              // Generator.addModuleDefs), so it is not generated as a param of the trait or any
-              // instance (nor does it get a lens): strip it out of every params list we emit.
+              // A bare `__typename` carries no information beyond which case class the response
+              // decodes to, so it's noise: it is consumed by the discriminating decoder (see
+              // Generator.addModuleDefs) and stripped out of every params list we emit (dropped
+              // from the trait, every instance, and its lens). An aliased `__typename` (e.g.
+              // `kind: __typename`) is instead an explicit request for the value as a field: it is
+              // kept as the decoder key AND generated as a regular field, which lets users retain
+              // the raw type name (e.g. for logging, or for the subtypes folded into `Other`).
               def stripDiscriminator(params: List[ClassParam]): List[ClassParam] =
-                params.filterNot(_.name == discriminatorKey)
+                if (discriminatorIsAliased) params
+                else params.filterNot(_.name == discriminatorKey)
 
               val ct: NamedType =
                 currentType

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -225,6 +225,15 @@ trait QueryGen extends Generator {
              for {
                rootType <- rootTypeOf(op)
                varDefs  <- compiler.compileVarDefs(op.variables)
+               // A selection with fragments on subtypes must select `__typename` next to them, so
+               // the generated decoder (see Generator.addModuleDefs) can tell subtypes apart.
+               _        <- Result.fromProblems(
+                             validateTypenameSelections(schema, fragMap, rootType, op.query)
+                           )
+               // A spliced subquery (rendered as `{ subqueryN: __typename }`, see
+               // InterpolatedGql.render) is only recognized by `resolveData` as the whole
+               // selection set of a field; anywhere else it silently fails to splice.
+               _        <- Result.fromProblems(validateSubqueryPlacement(fragMap, op.query))
                _        <- phases
                              .foldLeftM(op.query)((acc, phase) =>
                                phase.transformFragments *> phase.transform(acc)
@@ -334,6 +343,163 @@ trait QueryGen extends Generator {
       }
 
     go(query, rootType.some)
+  }
+
+  // The immediate children of a selection set, as a list. grackle's parser collapses a
+  // single-element selection set to a bare node instead of wrapping it in a `Group` (so
+  // `{ a }` parses as a bare `UntypedSelect`, not `Group(List(UntypedSelect(...)))`); this undoes
+  // that collapse uniformly so callers can always treat a selection set as a `List[Query]`.
+  private def selectionsOf(q: Query): List[Query] =
+    q match {
+      case Query.Group(qs) => qs
+      case Query.Empty     => List.empty
+      case other           => List(other)
+    }
+
+  /**
+   * Classify the immediate items of a selection set (whose current GraphQL type is `currentType`)
+   * into base-level selects and variant inline fragments, recursively expanding nested `Group`s and
+   * normalizing named fragment spreads into inline fragments along the way.
+   *
+   * A fragment (inline or, once normalized, a spread) is "same-type" when its type condition is
+   * absent, `currentType` is unknown, or `currentType <:< ` its type condition (grackle's
+   * `Type.<:<`: same type, an interface `currentType` implements, or a union containing it) — such
+   * a fragment is just grouping (e.g. for `@include`), so its children are unwrapped directly into
+   * the result. Anything else is a "variant" fragment (a proper subtype of `currentType`): it is
+   * kept as one flat item per occurrence, tagged with its type condition; merging same-typed
+   * variants together (accumulating their children, in order) is left to the caller, which already
+   * needs a stable `groupBy` for other reasons.
+   *
+   * Same-type fragments are unwrapped by recursing into this same function (not into the caller's
+   * own walk), so a bare fragment routed here by the caller can't loop forever.
+   */
+  private def flattenSelections(
+    schema:       Schema,
+    fragmentsMap: Map[String, UntypedFragment],
+    selections:   List[Query],
+    currentType:  Option[GType]
+  ): List[(Option[String], Query)] = {
+    def isSameType(tpnme: Option[String]): Boolean =
+      tpnme.forall(t => currentType.forall(ct => schema.definition(t).forall(td => ct <:< td)))
+
+    selections.flatMap {
+      case Query.Group(inner)                                                =>
+        flattenSelections(schema, fragmentsMap, inner, currentType)
+      case Query.UntypedFragmentSpread(name, _)                              =>
+        fragmentsMap.get(name).toList.flatMap { frag =>
+          flattenSelections(
+            schema,
+            fragmentsMap,
+            List(Query.UntypedInlineFragment(frag.tpnme.some, Nil, frag.child)),
+            currentType
+          )
+        }
+      case Query.UntypedInlineFragment(tpnme, _, child) if isSameType(tpnme) =>
+        flattenSelections(schema, fragmentsMap, selectionsOf(child), currentType)
+      case Query.UntypedInlineFragment(tpnme, _, child)                      =>
+        List((tpnme, child))
+      case other                                                             =>
+        List((none, other))
+    }
+  }
+
+  /**
+   * Per-operation check that every selection set with at least one variant fragment (see
+   * [[flattenSelections]]) also selects `__typename` at the base level (possibly aliased), so
+   * `resolveData`'s generated decoder (see `Generator.addModuleDefs`, `TypeType.Sum`) can tell
+   * which subtype a response is. Mirrors [[inferVariableVars]]'s walk through fields/fragments,
+   * tracking the current type as it goes.
+   */
+  private def validateTypenameSelections(
+    schema:    Schema,
+    fragments: Map[String, UntypedFragment],
+    rootType:  GType,
+    query:     Query
+  ): List[Problem] = {
+    def check(selections: List[Query], currentType: Option[GType]): List[Problem] = {
+      val flat: List[(Option[String], Query)] =
+        flattenSelections(schema, fragments, selections, currentType)
+
+      val variantTypeNames: List[String] = flat.collect { case (Some(t), _) => t }.distinct
+
+      val hasTypename: Boolean = flat.exists {
+        case (None, Query.UntypedSelect(TypeSelect, _, _, _, _)) => true
+        case _                                                   => false
+      }
+
+      val here: List[Problem] =
+        if (variantTypeNames.isEmpty || hasTypename) List.empty
+        else {
+          val ctName = currentType.flatMap(_.asNamed).fold("?")(_.name)
+          List(
+            Problem(
+              s"Selection on [$ctName] has fragments on subtypes [${variantTypeNames
+                  .mkString(", ")}] but does not select `__typename`. Add `__typename` next to " +
+                "them so the response can be decoded to the right subtype."
+            )
+          )
+        }
+
+      val nested: List[Problem] = flat.flatMap {
+        case (None, Query.UntypedSelect(name, _, _, _, child)) =>
+          val next =
+            MetaTypes
+              .get(name)
+              .orElse(currentType.flatMap(_.field(name)))
+              .flatMap(_.underlyingObject)
+          check(selectionsOf(child), next)
+        case (Some(t), child)                                  =>
+          check(selectionsOf(child), schema.definition(t))
+        case _                                                 =>
+          List.empty
+      }
+
+      here ++ nested
+    }
+
+    check(selectionsOf(query), rootType.some)
+  }
+
+  // A subquery is spliced by rendering it as `{ subqueryN: __typename }` (see
+  // `InterpolatedGql.render`); `resolveData` only recognizes it in that shape when it is the
+  // *whole* selection set of a field (`UntypedSelect(_, _, _, _, UntypedSelect(_, Some(alias), ...))`
+  // with `alias` starting with "subquery"). Anywhere else — inside a fragment (inline or spread),
+  // or alongside sibling selections in a `Group` — it silently fails to splice, so report it.
+  private val subqueryPlacementMessage: String =
+    "A subquery can only be spliced as the whole selection set of a field (`field $Subquery`), " +
+      "not inside a fragment or next to other selections. Splice it on a field of the " +
+      "subquery's type, or move the fragment into the subquery."
+
+  private def validateSubqueryPlacement(
+    fragments: Map[String, UntypedFragment],
+    query:     Query
+  ): List[Problem] = {
+    def isSubqueryMarker(q: Query): Boolean =
+      q match {
+        case Query.UntypedSelect(TypeSelect, Some(alias), _, _, _) => alias.startsWith("subquery")
+        case _                                                     => false
+      }
+
+    // `wholeChild` is true exactly when `q` is the entire (unwrapped) selection set of a field;
+    // that's the only legal position for a subquery marker.
+    def check(q: Query, wholeChild: Boolean): List[Problem] =
+      if (isSubqueryMarker(q))
+        if (wholeChild) List.empty else List(Problem(subqueryPlacementMessage))
+      else
+        q match {
+          case Query.UntypedSelect(_, _, _, _, child)   =>
+            check(child, wholeChild = true)
+          case Query.UntypedInlineFragment(_, _, child) =>
+            check(child, wholeChild = false)
+          case Query.UntypedFragmentSpread(name, _)     =>
+            fragments.get(name).fold(List.empty[Problem])(f => check(f.child, wholeChild = false))
+          case Query.Group(items)                       =>
+            items.flatMap(check(_, wholeChild = false))
+          case _                                        =>
+            List.empty
+        }
+
+    check(query, wholeChild = false)
   }
 
   // Render a grackle type back to GraphQL type syntax (e.g. `Episode!`, `[String!]`, `ID`). grackle
@@ -551,7 +717,7 @@ trait QueryGen extends Generator {
     subqueries: List[Term],
     fragments:  List[UntypedFragment],
     rootType:   Option[GType]
-  ): CaseClass = {
+  ): Class = {
     import Query._
 
     val fragmentsMap: Map[String, UntypedFragment] = fragments.map(f => f.name -> f).toMap
@@ -569,8 +735,13 @@ trait QueryGen extends Generator {
       currentType:    Option[GType]
     ): ClassAccumulator =
       currentAlgebra match {
-        case UntypedSelect(name, alias, _, directives, UntypedSelect(_, Some(subAlias), _, _, _))
-            if subAlias.startsWith("subquery") =>
+        case UntypedSelect(
+              name,
+              alias,
+              _,
+              directives,
+              UntypedSelect(TypeSelect, Some(subAlias), _, _, _)
+            ) if subAlias.startsWith("subquery") =>
           val isConditional: Boolean = hasConditionalDirective(directives)
 
           val param = MetaTypes
@@ -644,51 +815,35 @@ trait QueryGen extends Generator {
                 )
               )
             }
-        case UntypedInlineFragment(typeName, _, child)        =>
-          // Single element in inline fragment
-          go(child, typeName.map(getType).orElse(currentType))
-        case UntypedFragmentSpread(name, _)                   =>
-          val fragment: UntypedFragment = fragmentsMap(name)
-          go(fragment.child, getType(fragment.tpnme).some)
+        case UntypedInlineFragment(_, _, _)                   =>
+          // grackle's parser collapses a selection set with a single inline fragment to a bare
+          // node instead of wrapping it in a `Group`, so route it through the same
+          // flatten-and-classify logic as the `Group` case below (it may itself be a variant).
+          go(Group(List(currentAlgebra)), currentType)
+        case UntypedFragmentSpread(_, _)                      =>
+          // Same reasoning as the bare-inline-fragment case above.
+          go(Group(List(currentAlgebra)), currentType)
         case Group(selections)                                =>
-          // A Group in an inline fragment "... on X" will be represented as Group(List(UntypedInlineFragment(X, ...), UntypedInlineFragment(X, ...))).
-          // We fix that to UntypedInlineFragment(X, Group(List(..., ...)))
-          val fixedSelections = selections.map(_ match {
-            // We flatly assume that if the first element of a group is UntypedInlineFragment(X, ...), then all elements are.
-            case Group(list @ UntypedInlineFragment(typeName, _, _) +: _) =>
-              UntypedInlineFragment(
-                typeName,
-                List.empty,
-                Group(list.collect { case UntypedInlineFragment(_, _, child) =>
-                  child
-                })
-              )
-            case other                                                    => other
-          })
+          // Normalize named-fragment spreads to inline fragments and unwrap same-type fragments
+          // (grouping only, e.g. for `@include`) into a flat, ordered list of base-level selects
+          // and variant inline fragments (fragments on a proper subtype of `currentType`). See
+          // `flattenSelections` for the classification rule.
+          val flatSelections: List[(Option[String], Query)] =
+            flattenSelections(schema, fragmentsMap, selections, currentType)
 
-          // (Also, check what Grackle is returning when there's an interface)
           val hierarchyAccumulators
             : List[(Option[String], List[(Accumulator[Class, ClassParam, Sum], Int)])] =
-            fixedSelections.zipWithIndex // We want to preserve order of appeareance
-              .groupBy {
-                _._1 match {
-                  case UntypedInlineFragment(typeName, _, _) =>
-                    typeName // Selection in inline fragment, group by discriminator
-                  case _ =>
-                    none // Selection in base group, group by none
-                }
-              }
+            flatSelections.zipWithIndex // We want to preserve order of appeareance
+              .groupBy(_._1._1)         // Group by discriminator (None = base group)
               .toList
-              .sortBy(_._2.head._2)      // Sort by first appeareance of each subtype
+              .sortBy(_._2.head._2)     // Sort by first appeareance of each subtype
               .map { // Resolve groups
-                case (Some(typeName), subQueries) =>
-                  (typeName.some, // Unwrap inline fragment selections
-                   subQueries.collect { case (UntypedInlineFragment(_, _, child), idx) =>
-                     (go(child, getType(typeName).some), idx)
-                   }
+                case (Some(typeName), items) =>
+                  (typeName.some,
+                   items.map { case ((_, child), idx) => (go(child, getType(typeName).some), idx) }
                   )
-                case (None, subQueries)           =>
-                  (none, subQueries.map { case (q, idx) => (go(q, currentType), idx) })
+                case (None, items)           =>
+                  (none, items.map { case ((_, q), idx) => (go(q, currentType), idx) })
               }
 
           val baseAccumulators    = hierarchyAccumulators.collectFirst { case (None, accumulators) =>
@@ -708,23 +863,107 @@ trait QueryGen extends Generator {
           val baseAccumulator     = baseAccumulators.map(_._1).combineAll
 
           subTypeAccumulators match {
-            case Nil                  => baseAccumulator // No subtypes.
-            case singleSubType :: Nil =>                 // Treat single subtype as regular group.
-              ClassAccumulator(
-                baseAccumulator.classes ++ singleSubType._2.classes,
-                singleSubType._2.parAccum
-              )
-            case _                    =>
-              val baseParams = baseAccumulator.parAccum
+            case Nil      => baseAccumulator // No variants.
+            case variants =>
+              // Every inline fragment / named-fragment spread on a proper subtype of
+              // `currentType` is a variant (no special single-variant case): build a sum with one
+              // instance per variant, discriminated on `__typename`. Validation (see
+              // `validateParsed`/`validateTypenameSelections`) already guarantees a base-level
+              // `__typename` select whenever there is at least one variant.
+              val discriminatorKey: String =
+                flatSelections
+                  .collectFirst { case (None, UntypedSelect(TypeSelect, alias, _, _, _)) =>
+                    alias.getOrElse(TypeSelect)
+                  }
+                  .getOrElse(
+                    // Unreachable: validateTypenameSelections rejects variants without a base
+                    // `__typename` select before we ever get here.
+                    throw new Exception("Missing `__typename` for a validated variant selection")
+                  )
 
-              val subTypes = subTypeAccumulators.collect { case (typeName, accumulator) =>
-                CaseClass(typeName, accumulator.parAccum, accumulator.classes)
+              // `__typename` is consumed by the discriminating decoder (see
+              // Generator.addModuleDefs), so it is not generated as a param of the trait or any
+              // instance (nor does it get a lens): strip it out of every params list we emit.
+              def stripDiscriminator(params: List[ClassParam]): List[ClassParam] =
+                params.filterNot(_.name == discriminatorKey)
+
+              val ct: NamedType =
+                currentType
+                  .flatMap(_.asNamed)
+                  .getOrElse(
+                    // Unreachable: a variant fragment is only classified relative to a known type.
+                    throw new Exception("Variant fragment without a known current type")
+                  )
+
+              // The concrete (object) type names covered by `t`: itself if it's already concrete,
+              // every implementor if it's an interface, or the (dealiased, recursively resolved)
+              // concrete members if it's a union.
+              def concreteTypeNames(t: NamedType): Set[String] =
+                t.dealias match {
+                  case o: ObjectType    => Set(o.name)
+                  case i: InterfaceType =>
+                    schema.types
+                      .map(_.dealias)
+                      .collect { case o: ObjectType if o <:< i => o.name }
+                      .toSet
+                  case u: UnionType     => u.members.flatMap(m => concreteTypeNames(m)).toSet
+                  case other            => Set(other.name)
+                }
+
+              val coveredConcreteTypes: Set[String] =
+                variants.flatMap { case (typeName, _) =>
+                  concreteTypeNames(getType(typeName))
+                }.toSet
+              val missingConcreteTypes: Set[String] = concreteTypeNames(ct) -- coveredConcreteTypes
+
+              // `__typename` in a response is always a *concrete* object type, so a variant on an
+              // interface/union type condition (e.g. `... on Pilot { ... }`) must be matched by
+              // every concrete type it covers, not by its own (non-concrete) name. Build the
+              // explicit `(concrete type name, instance name)` mapping the decoder needs: one
+              // entry per concrete name, in variant order; if two variants cover the same concrete
+              // type, the earlier one wins.
+              val discriminatorCases: List[(String, String)] = {
+                val seen = scala.collection.mutable.LinkedHashMap.empty[String, String]
+                variants.foreach { case (typeName, _) =>
+                  concreteTypeNames(getType(typeName)).toList.sorted.foreach(concreteName =>
+                    seen.getOrElseUpdate(concreteName, typeName)
+                  )
+                }
+                seen.toList
               }
+
+              if (missingConcreteTypes.nonEmpty && variants.exists(_._1 == "Other"))
+                // Unreachable in practice: no schema in the wild names a concrete type `Other`.
+                throw new Exception(
+                  "Cannot add a fallback `Other` instance: a variant is already named `Other`."
+                )
+
+              val subTypes: List[CaseClass]        = variants.map { case (typeName, accumulator) =>
+                CaseClass(typeName, stripDiscriminator(accumulator.parAccum), accumulator.classes)
+              }
+              // Not every concrete type is covered by a variant: add a fallback instance so the
+              // decoder (and the sealed trait) still account for every possible response.
+              val otherInstance: Option[CaseClass] =
+                Option.when(missingConcreteTypes.nonEmpty)(
+                  CaseClass("Other",
+                            stripDiscriminator(baseAccumulator.withOverrideParams.parAccum)
+                  )
+                )
+
+              val baseParams: List[ClassParam] = stripDiscriminator(baseAccumulator.parAccum)
 
               ClassAccumulator(
                 baseAccumulator.classes,
                 baseParams,
-                Sum(baseParams, baseAccumulator.classes, subTypes).some
+                Sum(
+                  baseParams,
+                  baseAccumulator.classes,
+                  subTypes ++ otherInstance.toList,
+                  SumDiscriminator(discriminatorKey,
+                                   discriminatorCases,
+                                   otherInstance.map(_ => "Other")
+                  ).some
+                ).some
               )
           }
         case Empty                                            => ClassAccumulator()
@@ -736,7 +975,12 @@ trait QueryGen extends Generator {
 
     val algebraTypes = go(algebra, rootType.flatMap(_.underlyingObject))
 
-    CaseClass("Data", algebraTypes.parAccum, algebraTypes.classes)
+    // The root of a query is normally a plain object type (Query/Mutation/Subscription), but a
+    // subquery (`@GraphQLType`) can root directly at an interface/union, in which case its own
+    // "Data" is itself the sum (rather than a field somewhere inside it wrapping one).
+    algebraTypes.sum.fold[Class](CaseClass("Data", algebraTypes.parAccum, algebraTypes.classes))(
+      sum => SumClass("Data", sum)
+    )
   }
 
   protected def addData(

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/app/src/clue/scala/StarWarsQuery.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars-crossproject-pure/app/src/clue/scala/StarWarsQuery.scala
@@ -14,6 +14,7 @@ trait StarWarsQuery extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) {
+            __typename
             id
             name
             ... on Human {

--- a/sbt-plugin/src/sbt-test/clue-plugin/starwars/app/src/clue/scala/StarWarsQuery.scala
+++ b/sbt-plugin/src/sbt-test/clue-plugin/starwars/app/src/clue/scala/StarWarsQuery.scala
@@ -14,6 +14,7 @@ trait StarWarsQuery extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$charId: ID!) {
           character(id: $$charId) {
+            __typename
             id
             name
             ... on Human {


### PR DESCRIPTION
This PR makes `__typename` required whenever we query more than one subtype.

eg:
```
character {
  __typename
  ... on Human { ... }
  ... on Droid { ... }
}
```

Before this, to determine the type of the result, different decoders were tried until one succeeded. This is dangerous in subtypes that have the same shape.

This is a breaking change, but migration is mechanical.