### PR TITLE
Reinstate flat single fragment queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,15 @@ Hand-written subqueries may declare **multiple** types (the selection is validat
 
 #### Interfaces and unions
 
-When a selection on an interface or union field has inline fragments (or fragment spreads) on its
-subtypes, the generator emits a `sealed trait` for the field, one case class per fragment type
-carrying the shared fields plus the fragment's own, and, if the schema has concrete types none of
-the fragments cover, a case class `Other` with just the shared fields. For example, the StarWars
-selection
+When a selection on an interface or union field has inline fragments (or fragment spreads) on
+**two or more** distinct subtypes (counting distinct type conditions — two fragments on the same
+type still count as one), the generator emits a `sealed trait` for the field, one case class per
+fragment type carrying the shared fields plus the fragment's own, and, if the schema has concrete
+types none of the fragments cover, a case class `Other` with just the shared fields. For example,
+the StarWars selection
 
 ```graphql
-character { __typename id name ... on Human { homePlanet } }
+character { __typename id name ... on Human { homePlanet } ... on Droid { primaryFunction } }
 ```
 
 (`character`'s type is an interface implemented by `Human` and `Droid`) generates roughly:
@@ -153,9 +154,12 @@ character { __typename id name ... on Human { homePlanet } }
 sealed trait Character { val id: String; val name: Option[String] }
 object Character {
   case class Human(id: String, name: Option[String], homePlanet: Option[String]) extends Character
-  case class Other(id: String, name: Option[String]) extends Character // Droid, uncovered
+  case class Droid(id: String, name: Option[String], primaryFunction: Option[String]) extends Character
 }
 ```
+
+(had `Droid` been left uncovered, a case class `Other` with just the shared fields would have been
+added instead.)
 
 The selection **must** include `__typename` at the same level as the fragments; the generated
 decoder switches on it to pick the case class to decode into. Omitting it is a generation error: "Selection on [...] has fragments on subtypes [...] but does not select `__typename`". It must also
@@ -167,6 +171,26 @@ counts, as long as neither it nor the fragment is conditional.
 A bare `__typename` is consumed by the decoder and is not generated as a field. Aliased (e.g.
 `kind: __typename`), it is both the decoder key and a regular `String` field on the trait and every
 case class — the way to keep the raw type name around, e.g. for the types folded into `Other`.
+
+With a fragment on a **single** subtype, none of the above applies: the fragment's fields are
+flattened directly into the parent class instead — no `sealed trait`, no `Other`, and `__typename`
+is not required. For example
+
+```graphql
+character { id name ... on Human { homePlanet } }
+```
+
+generates a single flat class, with no discriminator needed:
+
+```scala
+case class Character(id: String, name: Option[String], homePlanet: Option[String])
+```
+
+This is for "I only care about one subtype" queries: it assumes the response is that subtype, and a
+response of another subtype (`Droid`, here) then fails to decode with a missing-field error — so use
+it only when the surrounding context guarantees the subtype (e.g. a filtered subscription). Since a
+`__typename` selected here isn't a discriminator, it is not stripped by the generator either: bare or
+aliased, it is generated as a plain `String` field like any other selection.
 
 Fragments whose type condition is the field's own type or one of its supertypes are plain grouping
 (e.g. for `@include`), not subtypes, and are flattened rather than turned into cases.

--- a/gen/input/src/main/scala/test/StarWarsAliasedTypenameOther.scala
+++ b/gen/input/src/main/scala/test/StarWarsAliasedTypenameOther.scala
@@ -11,8 +11,10 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-// Combines an ALIASED `__typename` discriminator with a fallback `Other` instance (`Droid` is
-// left uncovered): `kind` must still be generated as a regular field on `Other` too.
+// Combines an ALIASED `__typename` discriminator with a fallback `Other` instance. Two variant
+// types are selected (`Human` and the `Pilot` interface, implemented only by `Human`), so `Droid`
+// stays uncovered and `Other` is still generated; `kind` must be generated as a regular field on
+// every case, `Other` included.
 @GraphQL
 trait StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
   override val document = gql"""
@@ -22,6 +24,9 @@ trait StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
             name
             ... on Human {
               homePlanet
+            }
+            ... on Pilot {
+              vehicle
             }
           }
         }

--- a/gen/input/src/main/scala/test/StarWarsInterfaceSubtype.scala
+++ b/gen/input/src/main/scala/test/StarWarsInterfaceSubtype.scala
@@ -11,10 +11,11 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-// A fragment on an interface (`Pilot`, implemented only by `Human`): `__typename` in a response is
-// always the concrete object type name (`Human`), never the interface name, so the decoder must
-// map every concrete implementor to the `Pilot` instance, not match on `"Pilot"` itself.
-@GraphQL
+// A fragment on an interface (`Pilot`, implemented only by `Human`) plus one on `Droid`, so both
+// implementors of `Character` are covered (no `Other`): `__typename` in a response is always the
+// concrete object type name (`Human`), never the interface name, so the decoder must map every
+// concrete implementor to the `Pilot` instance, not match on `"Pilot"` itself.
+@GraphQL // assert: GraphQLGen
 trait StarWarsInterfaceSubtype extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$ep: Episode!) {
@@ -23,6 +24,9 @@ trait StarWarsInterfaceSubtype extends GraphQLOperation[StarWars] {
             name
             ... on Pilot {
               vehicle
+            }
+            ... on Droid {
+              primaryFunction
             }
           }
         }

--- a/gen/input/src/main/scala/test/StarWarsSingleSubtype.scala
+++ b/gen/input/src/main/scala/test/StarWarsSingleSubtype.scala
@@ -11,15 +11,14 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-// A single fragment on a subtype (`Human`), leaving `Droid` uncovered: `Character` has exactly
-// two implementors, so this must still generate a fallback `Other` instance (no special-casing
-// for "just one variant").
+// A single fragment on a subtype (`Human`): its fields are flattened into the parent class (no
+// `sealed trait`, no `Other`), and `__typename` is not required. A response of another subtype
+// (`Droid`) then fails to decode with a missing-field error.
 @GraphQL
 trait StarWarsSingleSubtype extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$ep: Episode!) {
           hero(episode: $$ep) {
-            __typename
             name
             ... on Human {
               homePlanet

--- a/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypename.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypename.scala
@@ -11,12 +11,12 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-// A base-level `__typename` guarded by `@include`: at runtime with the flag off, the field is
-// absent from the response and the generated decoder can't tell which subtype it got, so this must
-// be rejected.
+// Two subtypes (`Human`, `Droid`) with a base-level `__typename` guarded by `@include`: at runtime
+// with the flag off, the field is absent from the response and the generated decoder can't tell
+// which subtype it got, so this must be rejected.
 @GraphQL
 trait StarWarsSubtypeConditionalTypename extends GraphQLOperation[StarWars] {
   override val document =
-    gql"query ($$ep: Episode!, $$withType: Boolean!) { hero(episode: $$ep) { __typename @include(if: $$withType) name ... on Human { homePlanet } } }" // assert: GraphQLGen
+    gql"query ($$ep: Episode!, $$withType: Boolean!) { hero(episode: $$ep) { __typename @include(if: $$withType) name ... on Human { homePlanet } ... on Droid { primaryFunction } } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypenameFragment.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubtypeConditionalTypenameFragment.scala
@@ -11,13 +11,14 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-// `__typename` sits inside a same-type fragment (`... on Character`) that itself carries
-// `@include`: the fragment flattens to a plain `__typename` at the base level, but at runtime with
-// the flag off the whole fragment (and therefore `__typename`) is absent from the response, so this
-// must be rejected just like a directly-conditional `__typename`.
+// Two subtypes (`Human`, `Droid`); `__typename` sits inside a same-type fragment
+// (`... on Character`) that itself carries `@include`: the fragment flattens to a plain
+// `__typename` at the base level, but at runtime with the flag off the whole fragment (and
+// therefore `__typename`) is absent from the response, so this must be rejected just like a
+// directly-conditional `__typename`.
 @GraphQL
 trait StarWarsSubtypeConditionalTypenameFragment extends GraphQLOperation[StarWars] {
   override val document =
-    gql"query ($$ep: Episode!, $$withType: Boolean!) { hero(episode: $$ep) { ... on Character @include(if: $$withType) { __typename } name ... on Human { homePlanet } } }" // assert: GraphQLGen
+    gql"query ($$ep: Episode!, $$withType: Boolean!) { hero(episode: $$ep) { ... on Character @include(if: $$withType) { __typename } name ... on Human { homePlanet } ... on Droid { primaryFunction } } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsSubtypeNoTypename.scala
+++ b/gen/input/src/main/scala/test/StarWarsSubtypeNoTypename.scala
@@ -11,11 +11,11 @@ package test
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
-// A fragment on a subtype (`Human`) without a base-level `__typename`: the generated decoder
-// couldn't tell a `Human` response from any other `Character`, so this must be rejected.
+// Two subtypes (`Human`, `Droid`) without a base-level `__typename`: the generated decoder
+// couldn't tell which `Character` subtype a response is, so this must be rejected.
 @GraphQL
 trait StarWarsSubtypeNoTypename extends GraphQLOperation[StarWars] {
   override val document =
-    gql"query ($$ep: Episode!) { hero(episode: $$ep) { name ... on Human { homePlanet } } }" // assert: GraphQLGen
+    gql"query ($$ep: Episode!) { hero(episode: $$ep) { name ... on Human { homePlanet } ... on Droid { primaryFunction } } }" // assert: GraphQLGen
 }
 // format: on

--- a/gen/input/src/main/scala/test/StarWarsTypenameInFragment.scala
+++ b/gen/input/src/main/scala/test/StarWarsTypenameInFragment.scala
@@ -12,8 +12,9 @@ import clue.GraphQLOperation
 import clue.annotation.GraphQL
 
 // `__typename` inside an unconditional same-type fragment is pure grouping and lands flat in the
-// response, so it satisfies the discriminator requirement.
-@GraphQL
+// response, so it satisfies the discriminator requirement. Two variant types (`Human` and `Droid`)
+// keep this a sum, so `Other` is not generated.
+@GraphQL // assert: GraphQLGen
 trait StarWarsTypenameInFragment extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$ep: Episode!) {
@@ -22,6 +23,9 @@ trait StarWarsTypenameInFragment extends GraphQLOperation[StarWars] {
             name
             ... on Human {
               homePlanet
+            }
+            ... on Droid {
+              primaryFunction
             }
           }
         }

--- a/gen/output/src/main/scala/test/LucumaQuery2.scala
+++ b/gen/output/src/main/scala/test/LucumaQuery2.scala
@@ -48,33 +48,13 @@ object LucumaQuery2 extends GraphQLOperation[LucumaODB] {
       object Targets {
         case class Nodes(val id: TargetId, val name: NonEmptyString, val tracking: Data.Program.Targets.Nodes.Tracking)
         object Nodes {
-          sealed trait Tracking
+          case class Tracking(val __typename: String, val epoch: EpochString)
           object Tracking {
-            case class Sidereal(val epoch: EpochString) extends Tracking()
-            object Sidereal {
-              val epoch: monocle.Iso[Data.Program.Targets.Nodes.Tracking.Sidereal, EpochString] = monocle.Focus[Data.Program.Targets.Nodes.Tracking.Sidereal](_.epoch)
-              implicit val eqSidereal: cats.Eq[Data.Program.Targets.Nodes.Tracking.Sidereal] = cats.Eq.fromUniversalEquals
-              implicit val showSidereal: cats.Show[Data.Program.Targets.Nodes.Tracking.Sidereal] = cats.Show.fromToString
-              implicit val jsonDecoderSidereal: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Sidereal] = io.circe.generic.semiauto.deriveDecoder[Data.Program.Targets.Nodes.Tracking.Sidereal]
-            }
-            case class Other() extends Tracking()
-            object Other {
-              implicit val eqOther: cats.Eq[Data.Program.Targets.Nodes.Tracking.Other] = cats.Eq.fromUniversalEquals
-              implicit val showOther: cats.Show[Data.Program.Targets.Nodes.Tracking.Other] = cats.Show.fromToString
-              implicit val jsonDecoderOther: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Program.Targets.Nodes.Tracking.Other]
-            }
-            val sidereal: monocle.Prism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Sidereal] = monocle.macros.GenPrism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Sidereal]
-            val other: monocle.Prism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Other] = monocle.macros.GenPrism[Data.Program.Targets.Nodes.Tracking, Data.Program.Targets.Nodes.Tracking.Other]
+            val __typename: monocle.Lens[Data.Program.Targets.Nodes.Tracking, String] = monocle.macros.GenLens[Data.Program.Targets.Nodes.Tracking](_.__typename)
+            val epoch: monocle.Lens[Data.Program.Targets.Nodes.Tracking, EpochString] = monocle.macros.GenLens[Data.Program.Targets.Nodes.Tracking](_.epoch)
             implicit val eqTracking: cats.Eq[Data.Program.Targets.Nodes.Tracking] = cats.Eq.fromUniversalEquals
             implicit val showTracking: cats.Show[Data.Program.Targets.Nodes.Tracking] = cats.Show.fromToString
-            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = io.circe.Decoder.instance {
-              c => c.downField("__typename").as[String].flatMap {
-                case "Sidereal" =>
-                  io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Sidereal].tryDecode(c)
-                case _ =>
-                  io.circe.Decoder[Data.Program.Targets.Nodes.Tracking.Other].tryDecode(c)
-              }
-            }
+            implicit val jsonDecoderTracking: io.circe.Decoder[Data.Program.Targets.Nodes.Tracking] = io.circe.generic.semiauto.deriveDecoder[Data.Program.Targets.Nodes.Tracking]
           }
           val id: monocle.Lens[Data.Program.Targets.Nodes, TargetId] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.id)
           val name: monocle.Lens[Data.Program.Targets.Nodes, NonEmptyString] = monocle.macros.GenLens[Data.Program.Targets.Nodes](_.name)

--- a/gen/output/src/main/scala/test/StarWarsAliasedTypenameOther.scala
+++ b/gen/output/src/main/scala/test/StarWarsAliasedTypenameOther.scala
@@ -7,8 +7,10 @@ package test
 
 import clue.GraphQLOperation
 
-// Combines an ALIASED `__typename` discriminator with a fallback `Other` instance (`Droid` is
-// left uncovered): `kind` must still be generated as a regular field on `Other` too.
+// Combines an ALIASED `__typename` discriminator with a fallback `Other` instance. Two variant
+// types are selected (`Human` and the `Pilot` interface, implemented only by `Human`), so `Droid`
+// stays uncovered and `Other` is still generated; `kind` must be generated as a regular field on
+// every case, `Other` included.
 
 object StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
   import StarWars.Scalars._
@@ -24,6 +26,9 @@ object StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
             name
             ... on Human {
               homePlanet
+            }
+            ... on Pilot {
+              vehicle
             }
           }
         }
@@ -51,6 +56,15 @@ object StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
         implicit val showHuman: cats.Show[Data.Hero.Human] = cats.Show.fromToString
         implicit val jsonDecoderHuman: io.circe.Decoder[Data.Hero.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Human]
       }
+      case class Pilot(override val kind: String, override val name: Option[String] = None, val vehicle: Option[String] = None) extends Hero()
+      object Pilot {
+        val kind: monocle.Lens[Data.Hero.Pilot, String] = monocle.macros.GenLens[Data.Hero.Pilot](_.kind)
+        val name: monocle.Lens[Data.Hero.Pilot, Option[String]] = monocle.macros.GenLens[Data.Hero.Pilot](_.name)
+        val vehicle: monocle.Lens[Data.Hero.Pilot, Option[String]] = monocle.macros.GenLens[Data.Hero.Pilot](_.vehicle)
+        implicit val eqPilot: cats.Eq[Data.Hero.Pilot] = cats.Eq.fromUniversalEquals
+        implicit val showPilot: cats.Show[Data.Hero.Pilot] = cats.Show.fromToString
+        implicit val jsonDecoderPilot: io.circe.Decoder[Data.Hero.Pilot] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Pilot]
+      }
       case class Other(override val kind: String, override val name: Option[String] = None) extends Hero()
       object Other {
         val kind: monocle.Lens[Data.Hero.Other, String] = monocle.macros.GenLens[Data.Hero.Other](_.kind)
@@ -63,6 +77,8 @@ object StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
         v => _ match {
           case s: Data.Hero.Human =>
             s.copy(kind = v)
+          case s: Data.Hero.Pilot =>
+            s.copy(kind = v)
           case s: Data.Hero.Other =>
             s.copy(kind = v)
         }
@@ -71,11 +87,14 @@ object StarWarsAliasedTypenameOther extends GraphQLOperation[StarWars] {
         v => _ match {
           case s: Data.Hero.Human =>
             s.copy(name = v)
+          case s: Data.Hero.Pilot =>
+            s.copy(name = v)
           case s: Data.Hero.Other =>
             s.copy(name = v)
         }
       }
       val human: monocle.Prism[Data.Hero, Data.Hero.Human] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Human]
+      val pilot: monocle.Prism[Data.Hero, Data.Hero.Pilot] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Pilot]
       val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
       implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
       implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString

--- a/gen/output/src/main/scala/test/StarWarsInterfaceSubtype.scala
+++ b/gen/output/src/main/scala/test/StarWarsInterfaceSubtype.scala
@@ -7,9 +7,10 @@ package test
 
 import clue.GraphQLOperation
 
-// A fragment on an interface (`Pilot`, implemented only by `Human`): `__typename` in a response is
-// always the concrete object type name (`Human`), never the interface name, so the decoder must
-// map every concrete implementor to the `Pilot` instance, not match on `"Pilot"` itself.
+// A fragment on an interface (`Pilot`, implemented only by `Human`) plus one on `Droid`, so both
+// implementors of `Character` are covered (no `Other`): `__typename` in a response is always the
+// concrete object type name (`Human`), never the interface name, so the decoder must map every
+// concrete implementor to the `Pilot` instance, not match on `"Pilot"` itself.
 
 object StarWarsInterfaceSubtype extends GraphQLOperation[StarWars] {
   import StarWars.Scalars._
@@ -25,6 +26,9 @@ object StarWarsInterfaceSubtype extends GraphQLOperation[StarWars] {
             name
             ... on Pilot {
               vehicle
+            }
+            ... on Droid {
+              primaryFunction
             }
           }
         }
@@ -48,31 +52,34 @@ object StarWarsInterfaceSubtype extends GraphQLOperation[StarWars] {
         implicit val showPilot: cats.Show[Data.Hero.Pilot] = cats.Show.fromToString
         implicit val jsonDecoderPilot: io.circe.Decoder[Data.Hero.Pilot] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Pilot]
       }
-      case class Other(override val name: Option[String] = None) extends Hero()
-      object Other {
-        val name: monocle.Iso[Data.Hero.Other, Option[String]] = monocle.Focus[Data.Hero.Other](_.name)
-        implicit val eqOther: cats.Eq[Data.Hero.Other] = cats.Eq.fromUniversalEquals
-        implicit val showOther: cats.Show[Data.Hero.Other] = cats.Show.fromToString
-        implicit val jsonDecoderOther: io.circe.Decoder[Data.Hero.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Other]
+      case class Droid(override val name: Option[String] = None, @deprecated("Use 'functions' instead") val primaryFunction: Option[String] = None) extends Hero()
+      object Droid {
+        val name: monocle.Lens[Data.Hero.Droid, Option[String]] = monocle.macros.GenLens[Data.Hero.Droid](_.name)
+        @deprecated("Use 'functions' instead") val primaryFunction: monocle.Lens[Data.Hero.Droid, Option[String]] = monocle.macros.GenLens[Data.Hero.Droid](_.primaryFunction)
+        implicit val eqDroid: cats.Eq[Data.Hero.Droid] = cats.Eq.fromUniversalEquals
+        implicit val showDroid: cats.Show[Data.Hero.Droid] = cats.Show.fromToString
+        implicit val jsonDecoderDroid: io.circe.Decoder[Data.Hero.Droid] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Droid]
       }
       val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
         v => _ match {
           case s: Data.Hero.Pilot =>
             s.copy(name = v)
-          case s: Data.Hero.Other =>
+          case s: Data.Hero.Droid =>
             s.copy(name = v)
         }
       }
       val pilot: monocle.Prism[Data.Hero, Data.Hero.Pilot] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Pilot]
-      val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
+      val droid: monocle.Prism[Data.Hero, Data.Hero.Droid] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Droid]
       implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
       implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
       implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
         c => c.downField("__typename").as[String].flatMap {
           case "Human" =>
             io.circe.Decoder[Data.Hero.Pilot].tryDecode(c)
-          case _ =>
-            io.circe.Decoder[Data.Hero.Other].tryDecode(c)
+          case "Droid" =>
+            io.circe.Decoder[Data.Hero.Droid].tryDecode(c)
+          case other =>
+            Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Hero", c.history))
         }
       }
     }

--- a/gen/output/src/main/scala/test/StarWarsSingleSubtype.scala
+++ b/gen/output/src/main/scala/test/StarWarsSingleSubtype.scala
@@ -7,9 +7,9 @@ package test
 
 import clue.GraphQLOperation
 
-// A single fragment on a subtype (`Human`), leaving `Droid` uncovered: `Character` has exactly
-// two implementors, so this must still generate a fallback `Other` instance (no special-casing
-// for "just one variant").
+// A single fragment on a subtype (`Human`): its fields are flattened into the parent class (no
+// `sealed trait`, no `Other`), and `__typename` is not required. A response of another subtype
+// (`Droid`) then fails to decode with a missing-field error.
 
 object StarWarsSingleSubtype extends GraphQLOperation[StarWars] {
   import StarWars.Scalars._
@@ -21,7 +21,6 @@ object StarWarsSingleSubtype extends GraphQLOperation[StarWars] {
   override val document = gql"""
         query ($$ep: Episode!) {
           hero(episode: $$ep) {
-            __typename
             name
             ... on Human {
               homePlanet
@@ -38,43 +37,13 @@ object StarWarsSingleSubtype extends GraphQLOperation[StarWars] {
   }
   case class Data(val hero: Data.Hero)
   object Data {
-    sealed trait Hero { val name: Option[String] }
+    case class Hero(val name: Option[String] = None, val homePlanet: Option[String] = None)
     object Hero {
-      case class Human(override val name: Option[String] = None, val homePlanet: Option[String] = None) extends Hero()
-      object Human {
-        val name: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.name)
-        val homePlanet: monocle.Lens[Data.Hero.Human, Option[String]] = monocle.macros.GenLens[Data.Hero.Human](_.homePlanet)
-        implicit val eqHuman: cats.Eq[Data.Hero.Human] = cats.Eq.fromUniversalEquals
-        implicit val showHuman: cats.Show[Data.Hero.Human] = cats.Show.fromToString
-        implicit val jsonDecoderHuman: io.circe.Decoder[Data.Hero.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Human]
-      }
-      case class Other(override val name: Option[String] = None) extends Hero()
-      object Other {
-        val name: monocle.Iso[Data.Hero.Other, Option[String]] = monocle.Focus[Data.Hero.Other](_.name)
-        implicit val eqOther: cats.Eq[Data.Hero.Other] = cats.Eq.fromUniversalEquals
-        implicit val showOther: cats.Show[Data.Hero.Other] = cats.Show.fromToString
-        implicit val jsonDecoderOther: io.circe.Decoder[Data.Hero.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Other]
-      }
-      val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
-        v => _ match {
-          case s: Data.Hero.Human =>
-            s.copy(name = v)
-          case s: Data.Hero.Other =>
-            s.copy(name = v)
-        }
-      }
-      val human: monocle.Prism[Data.Hero, Data.Hero.Human] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Human]
-      val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
+      val name: monocle.Lens[Data.Hero, Option[String]] = monocle.macros.GenLens[Data.Hero](_.name)
+      val homePlanet: monocle.Lens[Data.Hero, Option[String]] = monocle.macros.GenLens[Data.Hero](_.homePlanet)
       implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
       implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
-      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
-        c => c.downField("__typename").as[String].flatMap {
-          case "Human" =>
-            io.circe.Decoder[Data.Hero.Human].tryDecode(c)
-          case _ =>
-            io.circe.Decoder[Data.Hero.Other].tryDecode(c)
-        }
-      }
+      implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.generic.semiauto.deriveDecoder[Data.Hero]
     }
     val hero: monocle.Iso[Data, Data.Hero] = monocle.Focus[Data](_.hero)
     implicit val eqData: cats.Eq[Data] = cats.Eq.fromUniversalEquals

--- a/gen/output/src/main/scala/test/StarWarsTypenameInFragment.scala
+++ b/gen/output/src/main/scala/test/StarWarsTypenameInFragment.scala
@@ -8,7 +8,8 @@ package test
 import clue.GraphQLOperation
 
 // `__typename` inside an unconditional same-type fragment is pure grouping and lands flat in the
-// response, so it satisfies the discriminator requirement.
+// response, so it satisfies the discriminator requirement. Two variant types (`Human` and `Droid`)
+// keep this a sum, so `Other` is not generated.
 
 object StarWarsTypenameInFragment extends GraphQLOperation[StarWars] {
   import StarWars.Scalars._
@@ -24,6 +25,9 @@ object StarWarsTypenameInFragment extends GraphQLOperation[StarWars] {
             name
             ... on Human {
               homePlanet
+            }
+            ... on Droid {
+              primaryFunction
             }
           }
         }
@@ -47,31 +51,34 @@ object StarWarsTypenameInFragment extends GraphQLOperation[StarWars] {
         implicit val showHuman: cats.Show[Data.Hero.Human] = cats.Show.fromToString
         implicit val jsonDecoderHuman: io.circe.Decoder[Data.Hero.Human] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Human]
       }
-      case class Other(override val name: Option[String] = None) extends Hero()
-      object Other {
-        val name: monocle.Iso[Data.Hero.Other, Option[String]] = monocle.Focus[Data.Hero.Other](_.name)
-        implicit val eqOther: cats.Eq[Data.Hero.Other] = cats.Eq.fromUniversalEquals
-        implicit val showOther: cats.Show[Data.Hero.Other] = cats.Show.fromToString
-        implicit val jsonDecoderOther: io.circe.Decoder[Data.Hero.Other] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Other]
+      case class Droid(override val name: Option[String] = None, @deprecated("Use 'functions' instead") val primaryFunction: Option[String] = None) extends Hero()
+      object Droid {
+        val name: monocle.Lens[Data.Hero.Droid, Option[String]] = monocle.macros.GenLens[Data.Hero.Droid](_.name)
+        @deprecated("Use 'functions' instead") val primaryFunction: monocle.Lens[Data.Hero.Droid, Option[String]] = monocle.macros.GenLens[Data.Hero.Droid](_.primaryFunction)
+        implicit val eqDroid: cats.Eq[Data.Hero.Droid] = cats.Eq.fromUniversalEquals
+        implicit val showDroid: cats.Show[Data.Hero.Droid] = cats.Show.fromToString
+        implicit val jsonDecoderDroid: io.circe.Decoder[Data.Hero.Droid] = io.circe.generic.semiauto.deriveDecoder[Data.Hero.Droid]
       }
       val name: monocle.Lens[Data.Hero, Option[String]] = monocle.Lens[Data.Hero, Option[String]](_.name) {
         v => _ match {
           case s: Data.Hero.Human =>
             s.copy(name = v)
-          case s: Data.Hero.Other =>
+          case s: Data.Hero.Droid =>
             s.copy(name = v)
         }
       }
       val human: monocle.Prism[Data.Hero, Data.Hero.Human] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Human]
-      val other: monocle.Prism[Data.Hero, Data.Hero.Other] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Other]
+      val droid: monocle.Prism[Data.Hero, Data.Hero.Droid] = monocle.macros.GenPrism[Data.Hero, Data.Hero.Droid]
       implicit val eqHero: cats.Eq[Data.Hero] = cats.Eq.fromUniversalEquals
       implicit val showHero: cats.Show[Data.Hero] = cats.Show.fromToString
       implicit val jsonDecoderHero: io.circe.Decoder[Data.Hero] = io.circe.Decoder.instance {
         c => c.downField("__typename").as[String].flatMap {
           case "Human" =>
             io.circe.Decoder[Data.Hero.Human].tryDecode(c)
-          case _ =>
-            io.circe.Decoder[Data.Hero.Other].tryDecode(c)
+          case "Droid" =>
+            io.circe.Decoder[Data.Hero.Droid].tryDecode(c)
+          case other =>
+            Left(io.circe.DecodingFailure("Unexpected __typename [" + other + "] for Hero", c.history))
         }
       }
     }

--- a/gen/rules/src/main/scala/clue/gen/QueryGen.scala
+++ b/gen/rules/src/main/scala/clue/gen/QueryGen.scala
@@ -418,14 +418,16 @@ trait QueryGen extends Generator {
   }
 
   /**
-   * Per-operation check that every selection set with at least one variant fragment (see
-   * [[flattenSelections]]) also selects `__typename` at the base level (possibly aliased)
-   * unconditionally, so `resolveData`'s generated decoder (see `Generator.addModuleDefs`,
-   * `TypeType.Sum`) can tell which subtype a response is. A `__typename` guarded by `@skip`/
-   * `@include` — directly, or via an enclosing same-type fragment/spread carrying the directive
-   * (see `FlatSelection.conditional`) — may be absent from the response even though the field
-   * itself isn't, so it is rejected just like a missing `__typename`. Mirrors
-   * [[inferVariableVars]]'s walk through fields/fragments, tracking the current type as it goes.
+   * Per-operation check that every selection set with two or more variant types (see
+   * [[flattenSelections]]; fragments on the same type count as one) also selects `__typename` at
+   * the base level (possibly aliased) unconditionally, so `resolveData`'s generated decoder (see
+   * `Generator.addModuleDefs`, `TypeType.Sum`) can tell which subtype a response is. A single
+   * variant type is instead flattened into the parent by `resolveData` and needs no `__typename`
+   * (see README). A `__typename` guarded by `@skip`/`@include` — directly, or via an enclosing
+   * same-type fragment/spread carrying the directive (see `FlatSelection.conditional`) — may be
+   * absent from the response even though the field itself isn't, so it is rejected just like a
+   * missing `__typename`. Mirrors [[inferVariableVars]]'s walk through fields/fragments, tracking
+   * the current type as it goes.
    */
   private def validateTypenameSelections(
     schema:    Schema,
@@ -452,7 +454,7 @@ trait QueryGen extends Generator {
       }
 
       val here: List[Problem] =
-        if (variantTypeNames.isEmpty) List.empty
+        if (variantTypeNames.sizeIs < 2) List.empty
         else if (typenames.isEmpty) {
           val ctName = currentType.flatMap(_.asNamed).fold("?")(_.name)
           List(
@@ -901,13 +903,21 @@ trait QueryGen extends Generator {
           val baseAccumulator     = baseAccumulators.map(_._1).combineAll
 
           subTypeAccumulators match {
-            case Nil      => baseAccumulator // No variants.
-            case variants =>
+            case Nil                  => baseAccumulator // No variants.
+            case (typeName, _) :: Nil =>
+              // Exactly one subtype: flatten it into the parent (see README). Base and variant
+              // items are re-merged from `hierarchyAccumulators` in order of appearance, without
+              // `override` params, since no trait is generated.
+              val variantItems = hierarchyAccumulators.collectFirst {
+                case (Some(`typeName`), items) => items
+              }.orEmpty
+              (baseAccumulators ++ variantItems).sortBy(_._2).map(_._1).combineAll
+            case variants             =>
               // Every inline fragment / named-fragment spread on a proper subtype of
-              // `currentType` is a variant (no special single-variant case): build a sum with one
-              // instance per variant, discriminated on `__typename`. Validation (see
+              // `currentType` is a variant when there are two or more variant types: build a sum
+              // with one instance per variant, discriminated on `__typename`. Validation (see
               // `validateParsed`/`validateTypenameSelections`) already guarantees a base-level
-              // `__typename` select whenever there is at least one variant.
+              // `__typename` select whenever there are two or more.
               val (discriminatorKey, discriminatorIsAliased): (String, Boolean) =
                 flatSelections
                   .collectFirst {


### PR DESCRIPTION
When querying a single subtype, eg:

```
  character {
    name
    ... on Human {
      homePlanet
    }
  }
```

clue used to generate a flat `case class`. This functionality was lost in the last PR which still forced a single-subtype hierarchy.

This PR restores that functionality.