### PR TITLE
Implement lexer

### DIFF
--- a/core/src/main/scala/clue/GraphQLDocumentScan.scala
+++ b/core/src/main/scala/clue/GraphQLDocumentScan.scala
@@ -1,0 +1,179 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+/**
+ * Token-level utilities over `Vector[GraphQLLexer.Token]`, for the `gql` macro. Macro-free so it
+ * can be unit-tested.
+ */
+private[clue] object GraphQLDocumentScan {
+  import GraphQLLexer.Token
+
+  /** A GraphQL type reference as written in a var-def. */
+  sealed trait VarType { def nonNull: Boolean; def render: String }
+  object VarType       {
+    final case class Named(name: String, nonNull: Boolean)    extends VarType {
+      def render: String = if (nonNull) s"$name!" else name
+    }
+    final case class ListOf(inner: VarType, nonNull: Boolean) extends VarType {
+      def render: String = s"[${inner.render}]" + (if (nonNull) "!" else "")
+    }
+  }
+  import VarType.*
+
+  private def stripTopNonNull(t: VarType): VarType = t match {
+    case Named(n, _)  => Named(n, nonNull = false)
+    case ListOf(i, _) => ListOf(i, nonNull = false)
+  }
+
+  /**
+   * GraphQL "is variable usage allowed", as `main` implements it today: same type modulo top-level
+   * nullability, and a non-null requirement needs a non-null declaration.
+   */
+  def usableAs(declared: VarType, required: VarType): Boolean =
+    stripTopNonNull(declared) == stripTopNonNull(
+      required
+    ) && (!required.nonNull || declared.nonNull)
+
+  final case class ScanError(message: String, pos: Int)
+
+  private def posOf(tokens: Vector[Token], i: Int): Int = tokens.lift(i).map(_.pos).getOrElse(-1)
+
+  private def isPunct(tokens: Vector[Token], i: Int, v: String): Boolean =
+    tokens.lift(i) match {
+      case Some(Token.Punct(p, _)) => p == v
+      case _                       => false
+    }
+
+  // Type :: NamedType "!"? | ListType "!"?
+  private def parseType(tokens: Vector[Token], i: Int): Either[ScanError, (VarType, Int)] =
+    tokens.lift(i) match {
+      case Some(Token.Name(n, _))    =>
+        val nn = isPunct(tokens, i + 1, "!")
+        Right((Named(n, nn), i + (if (nn) 2 else 1)))
+      case Some(Token.Punct("[", _)) =>
+        parseType(tokens, i + 1).flatMap { case (inner, j) =>
+          if (!isPunct(tokens, j, "]")) Left(ScanError("expected ']'", posOf(tokens, j)))
+          else {
+            val nn = isPunct(tokens, j + 1, "!")
+            Right((ListOf(inner, nn), j + (if (nn) 2 else 1)))
+          }
+        }
+      case _                         => Left(ScanError("expected a type", posOf(tokens, i)))
+    }
+
+  // Skip one Value: a single scalar/enum token, a `$variable`, or a balanced `[...]`/`{...}` (nested
+  // strings are already atomic tokens, so counting only the outermost bracket kind is enough).
+  private def skipValue(tokens: Vector[Token], i: Int): Either[ScanError, Int] =
+    tokens.lift(i) match {
+      case Some(Token.Punct(o @ ("[" | "{" | "("), _)) =>
+        val c                                                = o match { case "[" => "]"; case "{" => "}"; case _ => ")" }
+        def loop(j: Int, depth: Int): Either[ScanError, Int] =
+          tokens.lift(j) match {
+            case Some(Token.Punct(`o`, _)) => loop(j + 1, depth + 1)
+            case Some(Token.Punct(`c`, _)) =>
+              if (depth == 1) Right(j + 1) else loop(j + 1, depth - 1)
+            case Some(_)                   => loop(j + 1, depth)
+            case None                      => Left(ScanError(s"unterminated '$o'", posOf(tokens, i)))
+          }
+        loop(i + 1, 1)
+      case Some(Token.Punct("$", _))                   =>
+        tokens.lift(i + 1) match {
+          case Some(Token.Name(_, _)) => Right(i + 2)
+          case _                      => Left(ScanError("expected variable name", posOf(tokens, i + 1)))
+        }
+      case Some(_)                                     => Right(i + 1)
+      case None                                        => Left(ScanError("expected a value", posOf(tokens, i)))
+    }
+
+  // Skip an optional `= Value` default, then any number of `@ Name (Arguments)?` directives.
+  private def skipDefaultAndDirectives(tokens: Vector[Token], i: Int): Either[ScanError, Int] = {
+    def directives(j: Int): Either[ScanError, Int] =
+      if (!isPunct(tokens, j, "@")) Right(j)
+      else
+        tokens.lift(j + 1) match {
+          case Some(Token.Name(_, _)) =>
+            val afterName = j + 2
+            (if (isPunct(tokens, afterName, "(")) skipValue(tokens, afterName)
+             else Right(afterName))
+              .flatMap(directives)
+          case _                      => Left(ScanError("expected directive name", posOf(tokens, j + 1)))
+        }
+
+    (if (isPunct(tokens, i, "=")) skipValue(tokens, i + 1) else Right(i)).flatMap(directives)
+  }
+
+  /**
+   * Parse a parenthesized var-def list `($a: T = default @dir, $b: [U!]!)` given as tokens (the
+   * whole token stream is the list, parens included). Defaults (any Value, possibly nested
+   * lists/objects/strings) and directives are skipped.
+   */
+  def parseVarDefs(tokens: Vector[Token]): Either[ScanError, Map[String, VarType]] = {
+    def loop(i: Int, acc: Map[String, VarType]): Either[ScanError, Map[String, VarType]] =
+      if (isPunct(tokens, i, ")")) Right(acc)
+      else if (!isPunct(tokens, i, "$")) Left(ScanError("expected '$' or ')'", posOf(tokens, i)))
+      else
+        tokens.lift(i + 1) match {
+          case Some(Token.Name(name, _)) =>
+            if (!isPunct(tokens, i + 2, ":")) Left(ScanError("expected ':'", posOf(tokens, i + 2)))
+            else
+              parseType(tokens, i + 3).flatMap { case (tpe, j) =>
+                skipDefaultAndDirectives(tokens, j).flatMap(next => loop(next, acc + (name -> tpe)))
+              }
+          case _                         => Left(ScanError("expected variable name", posOf(tokens, i + 1)))
+        }
+
+    if (!isPunct(tokens, 0, "(")) Left(ScanError("expected '('", posOf(tokens, 0)))
+    else loop(1, Map.empty)
+  }
+
+  /**
+   * The operation header's var-defs of a document: skip to the first
+   * `query`/`mutation`/`subscription` Name at brace-depth 0 (fragments may precede it), skip an
+   * optional operation Name, and if the next token is `(` parse the var-defs up to the matching
+   * `)`. A shorthand `{ ... }` document, or an operation without parens, declares none. Returns the
+   * map and the index of the first token AFTER the header (or after the keyword/name when there is
+   * no header; 0 when no keyword is found).
+   */
+  def operationVars(tokens: Vector[Token]): Either[ScanError, (Map[String, VarType], Int)] = {
+    @scala.annotation.tailrec
+    def findHeader(i: Int, depth: Int): Int =
+      if (i >= tokens.length) -1
+      else
+        tokens(i) match {
+          case Token.Punct("{", _) => findHeader(i + 1, depth + 1)
+          case Token.Punct("}", _) => findHeader(i + 1, depth - 1)
+          case Token.Name(n, _)
+              if depth == 0 && (n == "query" || n == "mutation" || n == "subscription") =>
+            i
+          case _                   => findHeader(i + 1, depth)
+        }
+
+    @scala.annotation.tailrec
+    def matchParen(j: Int, depth: Int): Int =
+      if (j >= tokens.length) -1
+      else
+        tokens(j) match {
+          case Token.Punct("(", _) => matchParen(j + 1, depth + 1)
+          case Token.Punct(")", _) => if (depth == 1) j else matchParen(j + 1, depth - 1)
+          case _                   => matchParen(j + 1, depth)
+        }
+
+    val kwIdx = findHeader(0, 0)
+    if (kwIdx < 0) Right((Map.empty, 0))
+    else {
+      val afterKw   = kwIdx + 1
+      val afterName = tokens.lift(afterKw) match {
+        case Some(Token.Name(_, _)) => afterKw + 1
+        case _                      => afterKw
+      }
+      if (!isPunct(tokens, afterName, "(")) Right((Map.empty, afterName))
+      else {
+        val closeIdx = matchParen(afterName + 1, 1)
+        if (closeIdx < 0) Left(ScanError("unterminated var-defs", posOf(tokens, afterName)))
+        else parseVarDefs(tokens.slice(afterName, closeIdx + 1)).map(vars => (vars, closeIdx + 1))
+      }
+    }
+  }
+}

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -39,11 +39,15 @@ extension (inline sc:         StringContext)
    * Builds an operation `document` or a subquery's `subquery`, splicing subqueries inline. At
    * runtime it produces exactly the string the standard `s"..."` interpolator would.
    *
-   * At compile time it runs the *caller-check*: for every spliced value that declares variables (a
-   * `GraphQLSubquery` with a `type VariableDefs` member), it verifies that the variables are
-   * declared where the splice happens, with a compatible ("usable as") type. The declaration is
-   * read from the operation's `query (...)` header, or — when the splice happens inside a
-   * `GraphQLSubquery` — from that subquery's own `type VariableDefs`, so nesting is checked one
+   * At compile time the assembled document (all literal parts, with spliced holes) is lexed per the
+   * GraphQL spec — a lexical error (an unterminated string, an unknown character, ...) is a compile
+   * error — and the *caller-check* runs over the resulting tokens: for every spliced value that
+   * declares variables (a `GraphQLSubquery` with a `type VariableDefs` member), it verifies that
+   * the variables are declared where the splice happens, with a compatible ("usable as") type. The
+   * declaration is read from the operation's `query (...)` header — found by scanning tokens for
+   * the `query`/`mutation`/`subscription` keyword at brace-depth 0, so fragment definitions may
+   * precede the operation without its header being missed — or, when the splice happens inside a
+   * `GraphQLSubquery`, from that subquery's own `type VariableDefs`, so nesting is checked one
    * level at a time and holds transitively.
    *
    * Requirements are read straight off the spliced subquery's type, so the check also works when
@@ -112,74 +116,50 @@ private[clue] object GraphQLInterpolator {
       loop(Symbol.spliceOwner)
     }
 
-    def splitTopLevel(s: String): List[String] = {
-      val out   = scala.collection.mutable.ListBuffer.empty[String]
-      val cur   = new StringBuilder
-      var depth = 0
-      s.foreach {
-        case '['               => depth += 1; cur += '['
-        case ']'               => depth -= 1; cur += ']'
-        case ',' if depth == 0 => out += cur.toString; cur.clear()
-        case c                 => cur += c
-      }
-      if (cur.nonEmpty) out += cur.toString
-      out.toList
-    }
-
-    // Parse a parenthesized var-def list `($a: T, $b: U)` into name -> GraphQL type.
-    def parseVarDefs(s0: String): Map[String, String] = {
-      val s = s0.trim.stripPrefix("(").stripSuffix(")").trim.replace("$$", "$")
-      if (s.isEmpty) Map.empty
-      else
-        splitTopLevel(s).flatMap { entry =>
-          val e       = entry.trim
-          val nameEnd = e.indexOf(':')
-          if (nameEnd < 0 || !e.startsWith("$")) None
-          else {
-            val name = e.substring(1, nameEnd).trim
-            val tpe  = e.substring(nameEnd + 1).takeWhile(_ != '=').trim
-            Some(name -> tpe)
-          }
-        }.toMap
-    }
-
-    // Extract and parse the operation header `(...)` from `query (...) ...` (the first literal part).
-    def operationVars(header: String): Map[String, String] = {
-      val h    = header.replace("$$", "$")
-      val open = h.indexOf('(')
-      if (open < 0) Map.empty
-      else {
-        var depth = 0; var i = open; var end = -1
-        while (i < h.length && end < 0) {
-          h.charAt(i) match {
-            case '(' => depth += 1
-            case ')' => depth -= 1; if (depth == 0) end = i
-            case _   => ()
-          }
-          i += 1
-        }
-        if (end < 0) Map.empty else parseVarDefs(h.substring(open, end + 1))
+    // Parse a `VariableDefs` literal (`"($a: T, ...)"`, hand-written on a `GraphQLSubquery`, unlike
+    // the document itself) into its declared types, aborting with a compile error naming `ownerName`
+    // if it doesn't lex/parse.
+    def parseVariableDefs(
+      s:         String,
+      ownerName: String
+    ): Map[String, GraphQLDocumentScan.VarType] = {
+      val parsed = for {
+        tokens <- GraphQLLexer.tokenize(s).left.map(_.message)
+        vars   <- GraphQLDocumentScan.parseVarDefs(tokens).left.map(_.message)
+      } yield vars
+      parsed match {
+        case Right(vars) => vars
+        case Left(msg)   =>
+          report.errorAndAbort(s"gql: invalid VariableDefs [$s] on $ownerName: $msg")
       }
     }
 
-    // GraphQL "is variable usage allowed": the declared type must be usable where the required type
-    // is expected. Same base type, and a non-null requirement needs a non-null declared type.
-    def usableAs(declaredType: String, reqType: String): Boolean = {
-      val d = declaredType.trim; val r = reqType.trim
-      d.stripSuffix("!").trim == r.stripSuffix("!").trim && (!r.endsWith("!") || d.endsWith("!"))
-    }
+    // Lex the whole document (literal parts + splice holes) and find the operation header's
+    // var-defs. Scanning tokens (rather than the old `indexOf('(')` on raw strings) means a fragment
+    // preceding the operation, or a string/comment containing `(`, can't be mistaken for the header.
+    val tokens: Vector[GraphQLLexer.Token] =
+      GraphQLLexer.tokenizeParts(parts) match {
+        case Right(ts) => ts
+        case Left(err) => report.errorAndAbort(s"gql: ${err.message}", Position.ofMacroExpansion)
+      }
+
+    val headerVars: Map[String, GraphQLDocumentScan.VarType] =
+      GraphQLDocumentScan.operationVars(tokens) match {
+        case Right((vars, _)) => vars
+        case Left(err)        => report.errorAndAbort(s"gql: ${err.message}", Position.ofMacroExpansion)
+      }
 
     // What the splice site declares. An operation declares its variables in the document header; a
     // subquery declares them in `type VariableDefs`. Both are read (they are never both populated in
     // practice), so a splice is checked against everything in scope where it happens.
-    val enclosingVariableDefs: Map[String, String] =
+    val enclosingVariableDefs: Map[String, GraphQLDocumentScan.VarType] =
       enclosingSubquery
-        .flatMap(cls => variableDefsOf(cls.typeRef))
-        .map(parseVarDefs)
+        .flatMap(cls =>
+          variableDefsOf(cls.typeRef).map(parseVariableDefs(_, cls.name.stripSuffix("$")))
+        )
         .getOrElse(Map.empty)
 
-    val declaredVars: Map[String, String] =
-      enclosingVariableDefs ++ parts.headOption.map(operationVars).getOrElse(Map.empty)
+    val declaredVars: Map[String, GraphQLDocumentScan.VarType] = enclosingVariableDefs ++ headerVars
 
     // Where the missing declaration has to be added. `name` keeps the module-class `$` suffix for an
     // `object` subquery, which would only confuse the reader.
@@ -187,20 +167,22 @@ private[clue] object GraphQLInterpolator {
       enclosingSubquery.fold("operation")(cls => s"subquery [${cls.name.stripSuffix("$")}]")
 
     argExprs.foreach { arg =>
-      variableDefsOf(arg.asTerm.tpe).foreach { required =>
-        parseVarDefs(required).foreach { case (name, reqType) =>
+      val argTpe = arg.asTerm.tpe
+      variableDefsOf(argTpe).foreach { requiredDefs =>
+        val required = parseVariableDefs(requiredDefs, argTpe.typeSymbol.name.stripSuffix("$"))
+        required.foreach { case (name, reqType) =>
           declaredVars.get(name) match {
-            case None                                           =>
+            case None                                                               =>
               report.errorAndAbort(
-                s"gql: $declarationSite does not declare variable $$$name required by a spliced subquery (needs $reqType)",
+                s"gql: $declarationSite does not declare variable $$$name required by a spliced subquery (needs ${reqType.render})",
                 arg.asTerm.pos
               )
-            case Some(declared) if !usableAs(declared, reqType) =>
+            case Some(declared) if !GraphQLDocumentScan.usableAs(declared, reqType) =>
               report.errorAndAbort(
-                s"gql: $declarationSite declares $$$name: $declared but a spliced subquery requires it usable as $reqType",
+                s"gql: $declarationSite declares $$$name: ${declared.render} but a spliced subquery requires it usable as ${reqType.render}",
                 arg.asTerm.pos
               )
-            case _                                              => ()
+            case _                                                                  => ()
           }
         }
       }

--- a/core/src/main/scala/clue/GraphQLLexer.scala
+++ b/core/src/main/scala/clue/GraphQLLexer.scala
@@ -1,0 +1,173 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+/**
+ * GraphQL lexical analysis (spec §2.1), for the `gql` macro. Free of macro APIs so it can be
+ * unit-tested.
+ */
+private[clue] object GraphQLLexer {
+  sealed trait Token { def pos: Int } // pos: offset into the tokenized text
+  object Token       {
+    final case class Punct(value: String, pos: Int)    extends Token
+    final case class Name(value: String, pos: Int)     extends Token
+    final case class IntVal(value: String, pos: Int)   extends Token
+    final case class FloatVal(value: String, pos: Int) extends Token
+    final case class Str(value: String, pos: Int)      extends Token
+    final case class Splice(index: Int, pos: Int)      extends Token
+  }
+  import Token.*
+
+  final case class LexError(message: String, pos: Int)
+
+  private val punctChars = "!$&():=@[]{}|"
+
+  private def isNameStart(c: Char): Boolean =
+    c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+  private def isNameCont(c: Char): Boolean  = isNameStart(c) || isDigit(c)
+  private def isDigit(c:    Char): Boolean  = c >= '0' && c <= '9'
+
+  /** Tokenize one text. Comments, whitespace, commas, BOM are skipped. */
+  def tokenize(text: String): Either[LexError, Vector[Token]] = {
+    val n               = text.length
+    val tokens          = Vector.newBuilder[Token]
+    var i               = 0
+    var error: LexError = null
+
+    def readBlockString(start: Int): Unit = {
+      val sb  = new StringBuilder
+      var j   = start + 3
+      var end = -1
+      while (j < n && end < 0)
+        if (text.charAt(j) == '\\' && j + 3 < n && text.substring(j + 1, j + 4) == "\"\"\"") {
+          sb.append("\"\"\""); j += 4
+        } else if (
+          j + 2 < n && text.charAt(j) == '"' && text
+            .charAt(j + 1) == '"' && text.charAt(j + 2) == '"'
+        ) {
+          end = j + 3
+        } else { sb.append(text.charAt(j)); j += 1 }
+      if (end < 0) error = LexError("unterminated string", start)
+      else { tokens += Str(sb.toString, start); i = end }
+    }
+
+    def readString(start: Int): Unit = {
+      val sb   = new StringBuilder
+      var j    = start + 1
+      var done = false
+      while (j < n && !done && error == null)
+        text.charAt(j) match {
+          case '"'               => done = true; j += 1
+          case '\n' | '\r'       => error = LexError("unterminated string", start)
+          case '\\' if j + 1 < n =>
+            text.charAt(j + 1) match {
+              case '"'              => sb.append('"'); j += 2
+              case '\\'             => sb.append('\\'); j += 2
+              case '/'              => sb.append('/'); j += 2
+              case 'b'              => sb.append('\b'); j += 2
+              case 'f'              => sb.append('\f'); j += 2
+              case 'n'              => sb.append('\n'); j += 2
+              case 'r'              => sb.append('\r'); j += 2
+              case 't'              => sb.append('\t'); j += 2
+              case 'u' if j + 5 < n =>
+                try { sb.append(Integer.parseInt(text.substring(j + 2, j + 6), 16).toChar); j += 6 }
+                catch {
+                  case _: NumberFormatException => error = LexError("invalid unicode escape", j)
+                }
+              case other            => error = LexError(s"invalid escape '\\$other'", j)
+            }
+          case c                 => sb.append(c); j += 1
+        }
+      if (error == null && !done) error = LexError("unterminated string", start)
+      else if (error == null) { tokens += Str(sb.toString, start); i = j }
+    }
+
+    def readNumber(): Unit = {
+      val start   = i
+      var j       = i
+      if (text.charAt(j) == '-') j += 1
+      if (j < n && text.charAt(j) == '0') j += 1
+      else while (j < n && isDigit(text.charAt(j))) j += 1
+      var isFloat = false
+      if (j < n && text.charAt(j) == '.' && j + 1 < n && isDigit(text.charAt(j + 1))) {
+        isFloat = true; j += 1
+        while (j < n && isDigit(text.charAt(j))) j += 1
+      }
+      if (j < n && (text.charAt(j) == 'e' || text.charAt(j) == 'E')) {
+        var k = j + 1
+        if (k < n && (text.charAt(k) == '+' || text.charAt(k) == '-')) k += 1
+        if (k < n && isDigit(text.charAt(k))) {
+          isFloat = true
+          while (k < n && isDigit(text.charAt(k))) k += 1
+          j = k
+        }
+      }
+      if (j < n && isNameStart(text.charAt(j))) error = LexError("invalid number", start)
+      else {
+        tokens += (if (isFloat) FloatVal(text.substring(start, j), start)
+                   else IntVal(text.substring(start, j), start))
+        i = j
+      }
+    }
+
+    while (i < n && error == null) {
+      val c = text.charAt(i)
+      if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',' || c == '\uFEFF') i += 1
+      else if (c == '#') while (i < n && text.charAt(i) != '\n' && text.charAt(i) != '\r') i += 1
+      else if (c == '.') {
+        if (i + 2 < n && text.charAt(i + 1) == '.' && text.charAt(i + 2) == '.') {
+          tokens += Punct("...", i); i += 3
+        } else error = LexError("unexpected character '.'", i)
+      } else if (punctChars.indexOf(c) >= 0) { tokens += Punct(c.toString, i); i += 1 }
+      else if (c == '"') {
+        if (i + 2 < n && text.charAt(i + 1) == '"' && text.charAt(i + 2) == '"') readBlockString(i)
+        else readString(i)
+      } else if (isDigit(c) || (c == '-' && i + 1 < n && isDigit(text.charAt(i + 1)))) readNumber()
+      else if (isNameStart(c)) {
+        val start = i
+        var j     = i + 1
+        while (j < n && isNameCont(text.charAt(j))) j += 1
+        tokens += Name(text.substring(start, j), start)
+        i = j
+      } else error = LexError(s"unexpected character '$c'", i)
+    }
+
+    if (error != null) Left(error) else Right(tokens.result())
+  }
+
+  /**
+   * Tokenize the literal parts of a `gql"..."` (as `StringContext.parts`, i.e. `$$`-escaped:
+   * unescape `$$` -> `$` first) as ONE document, with a `Splice(i)` token standing in for the i-th
+   * hole. Each part must lex on its own (a string literal or comment cannot span a splice: report a
+   * LexError "unterminated string" at the offending part). Token positions are offsets into the
+   * concatenation of the unescaped parts (holes take no space).
+   */
+  def tokenizeParts(parts: List[String]): Either[LexError, Vector[Token]] = {
+    val unescaped = parts.map(_.replace("$$", "$"))
+
+    def shift(t: Token, by: Int): Token = t match {
+      case Punct(v, p)    => Punct(v, p + by)
+      case Name(v, p)     => Name(v, p + by)
+      case IntVal(v, p)   => IntVal(v, p + by)
+      case FloatVal(v, p) => FloatVal(v, p + by)
+      case Str(v, p)      => Str(v, p + by)
+      case Splice(idx, p) => Splice(idx, p + by)
+    }
+
+    def go(idx: Int, offset: Int, acc: Vector[Token]): Either[LexError, Vector[Token]] =
+      if (idx >= unescaped.length) Right(acc)
+      else
+        tokenize(unescaped(idx)) match {
+          case Left(e)   => Left(LexError(e.message, e.pos + offset))
+          case Right(ts) =>
+            val nextOffset = offset + unescaped(idx).length
+            val shifted    = ts.map(shift(_, offset))
+            val withSplice =
+              if (idx < unescaped.length - 1) shifted :+ Splice(idx, nextOffset) else shifted
+            go(idx + 1, nextOffset, acc ++ withSplice)
+        }
+
+    go(0, 0, Vector.empty)
+  }
+}

--- a/core/src/test/scala/clue/GraphQLDocumentScanSuite.scala
+++ b/core/src/test/scala/clue/GraphQLDocumentScanSuite.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import GraphQLDocumentScan.*
+import VarType.*
+
+class GraphQLDocumentScanSuite extends munit.FunSuite {
+
+  private def tokensOf(text: String): Vector[GraphQLLexer.Token] =
+    GraphQLLexer.tokenize(text).fold(e => fail(s"expected a successful tokenize, got $e"), identity)
+
+  private def varDefsOf(text: String): Map[String, VarType] =
+    parseVarDefs(tokensOf(text)).fold(e => fail(s"expected a successful parse, got $e"), identity)
+
+  test(
+    "parseVarDefs: named, list, non-null types, a nested default value containing ')', a directive"
+  ) {
+    val defs = varDefsOf("""($a: T = [1, {x: "a)b"}] @dir, $b: [U!]!)""")
+    assertEquals(
+      defs,
+      Map("a" -> Named("T", nonNull = false),
+          "b" -> ListOf(Named("U", nonNull = true), nonNull = true)
+      )
+    )
+  }
+
+  test("usableAs truth table") {
+    val episodeNN  = Named("Episode", nonNull = true)
+    val episode    = Named("Episode", nonNull = false)
+    val idListNN   = ListOf(Named("ID", nonNull = true), nonNull = true)
+    val idList     = ListOf(Named("ID", nonNull = true), nonNull = false)
+    val idNullList = ListOf(Named("ID", nonNull = false), nonNull = false)
+
+    assert(usableAs(episodeNN, episodeNN))
+    assert(usableAs(episodeNN, episode))
+    assert(!usableAs(episode, episodeNN))
+    assert(!usableAs(Named("Episode", nonNull = true), Named("Other", nonNull = true)))
+    assert(usableAs(idListNN, idList))
+    assert(!usableAs(idNullList, idList))
+  }
+
+  test("operationVars: shorthand document declares none, at index 0") {
+    assertEquals(operationVars(tokensOf("{ hero }")), Right((Map.empty[String, VarType], 0)))
+  }
+
+  test("operationVars: an anonymous operation with var-defs") {
+    val tokens             = tokensOf("query ($ep: Episode!) { hero }")
+    val Right((vars, idx)) = operationVars(tokens): @unchecked
+    assertEquals(vars, Map("ep" -> Named("Episode", nonNull = true)))
+    assertEquals(tokens(idx), GraphQLLexer.Token.Punct("{", tokens(idx).pos))
+  }
+
+  test("operationVars: a named operation with var-defs") {
+    val tokens             = tokensOf("query Foo($ep: Episode!) { hero }")
+    val Right((vars, idx)) = operationVars(tokens): @unchecked
+    assertEquals(vars, Map("ep" -> Named("Episode", nonNull = true)))
+    assertEquals(tokens(idx), GraphQLLexer.Token.Punct("{", tokens(idx).pos))
+  }
+
+  test("operationVars: an operation without parens declares none") {
+    assertEquals(operationVars(tokensOf("mutation { hero }")).map(_._1),
+                 Right(Map.empty[String, VarType])
+    )
+  }
+
+  test(
+    "operationVars: a fragment with field arguments before the operation still finds the header"
+  ) {
+    val doc              =
+      "fragment f on Character { hero(episode: NEWHOPE) { name } } query ($ep: Episode!) { hero }"
+    val Right((vars, _)) = operationVars(tokensOf(doc)): @unchecked
+    assertEquals(vars, Map("ep" -> Named("Episode", nonNull = true)))
+  }
+
+  test("parseVarDefs skips a directive with arguments on a variable definition") {
+    val tokens =
+      GraphQLLexer.tokenize("""($a: ID @dir(x: 1, y: "s)") @other, $b: Int)""").toOption.get
+    assertEquals(
+      parseVarDefs(tokens),
+      Right(
+        Map("a" -> VarType.Named("ID", nonNull = false),
+            "b" -> VarType.Named("Int", nonNull = false)
+        )
+      )
+    )
+  }
+}

--- a/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
+++ b/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
@@ -96,4 +96,35 @@ class GraphQLInterpolatorSuite extends munit.FunSuite {
     val doc = gql"query ($$ep: Episode!) $InterpolatorTestParent"
     assertEquals(doc.value, "query ($ep: Episode!) { friends { hero(episode: $ep) { name } } }")
   }
+
+  test("a document with a fragment before the operation still sees the declared variables") {
+    val doc =
+      gql"fragment f on Character { name } query ($$ep: Episode!) { hero $InterpolatorTestSub }"
+    assertEquals(
+      doc.value,
+      "fragment f on Character { name } query ($ep: Episode!) { hero { hero(episode: $ep) { name } } }"
+    )
+  }
+
+  test("a named operation's header is found") {
+    val doc = gql"query Foo($$ep: Episode!) $InterpolatorTestSub"
+    assertEquals(doc.value, "query Foo($ep: Episode!) { hero(episode: $ep) { name } }")
+  }
+
+  test("a lexical error is a compile error") {
+    // `StringContext.parts` are raw/undecoded for a custom interpolator (only `$$` needs our own
+    // unescaping, per `tokenizeParts`'s doc): a `\"` written inside a `gql"..."` literal reaches the
+    // lexer as a literal backslash, not a decoded quote. So to get a document that is genuinely
+    // unterminated (rather than one with a stray, invalid `\`), the embedded quote here is a bare
+    // `"` inside a triple-quoted `gql"""..."""`, which Scala itself leaves untouched.
+    val errors = compileErrors("gql\"\"\"query { hero(name: \"unterminated) }\"\"\"")
+    assert(errors.contains("unterminated string"), errors)
+  }
+
+  test("a fragment's field arguments are not mistaken for the header") {
+    val errors = compileErrors(
+      """gql"fragment f on Character { hero(episode: NEWHOPE) { name } } query { $InterpolatorTestSub }""""
+    )
+    assert(errors.contains("does not declare variable $ep"), errors)
+  }
 }

--- a/core/src/test/scala/clue/GraphQLLexerSuite.scala
+++ b/core/src/test/scala/clue/GraphQLLexerSuite.scala
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import GraphQLLexer.*
+import Token.*
+
+class GraphQLLexerSuite extends munit.FunSuite {
+
+  private def tokensOf(text: String): Vector[Token] =
+    tokenize(text).fold(e => fail(s"expected success, got $e"), identity)
+
+  test("every punctuator is one token") {
+    assertEquals(
+      tokensOf("! $ & ( ) ... : = @ [ ] { } |").map {
+        case p: Punct => p.value; case t => fail(s"$t")
+      },
+      Vector("!", "$", "&", "(", ")", "...", ":", "=", "@", "[", "]", "{", "}", "|")
+    )
+  }
+
+  test("a Name") {
+    assertEquals(tokensOf("_foo1Bar"), Vector(Name("_foo1Bar", 0)))
+  }
+
+  test("an IntVal") {
+    assertEquals(tokensOf("-42"), Vector(IntVal("-42", 0)))
+  }
+
+  test("a FloatVal with fraction and exponent") {
+    assertEquals(tokensOf("-4.2e+1"), Vector(FloatVal("-4.2e+1", 0)))
+  }
+
+  test("commas and whitespace are ignored") {
+    assertEquals(tokensOf("a,\t,\n ,b"), Vector(Name("a", 0), Name("b", 7)))
+  }
+
+  test("a # comment is skipped to end of line") {
+    assertEquals(tokensOf("a # comment\nb"), Vector(Name("a", 0), Name("b", 12)))
+  }
+
+  test("string escapes, including \\\" and A") {
+    // Built from pieces (rather than one escaped literal) so the GraphQL source text - each escape
+    // is a literal backslash followed by its letter, for the lexer to decode - is unambiguous.
+    val bs  = "\\"
+    val src =
+      "\"" + "a" + bs + "\"" + "A" + bs + bs + bs + "/" + bs + "b" + bs + "f" + bs + "n" + bs + "r" + bs + "t" + "A" + "\""
+    assertEquals(tokensOf(src), Vector(Str("a\"A\\/\b\f\n\r\tA", 0)))
+  }
+
+  test("a block string containing a quote and a newline") {
+    assertEquals(tokensOf("\"\"\"a \"b\nc\"\"\""), Vector(Str("a \"b\nc", 0)))
+  }
+
+  test("a block string containing an escaped triple-quote") {
+    assertEquals(tokensOf("\"\"\"a \\\"\"\" b\"\"\""), Vector(Str("a \"\"\" b", 0)))
+  }
+
+  test("... is one token") {
+    assertEquals(tokensOf("..."), Vector(Punct("...", 0)))
+  }
+
+  test("a lone . is an error") {
+    assertEquals(tokenize(".."), Left(LexError("unexpected character '.'", 0)))
+  }
+
+  test("a number immediately followed by a Name is an error") {
+    assertEquals(tokenize("1Name"), Left(LexError("invalid number", 0)))
+  }
+
+  test("an unknown character is an error with its position") {
+    assertEquals(tokenize("a % b"), Left(LexError("unexpected character '%'", 2)))
+  }
+
+  test("an unterminated string is an error") {
+    assertEquals(tokenize("\"abc"), Left(LexError("unterminated string", 0)))
+  }
+
+  test("an unterminated block string is an error") {
+    assertEquals(tokenize("\"\"\"abc"), Left(LexError("unterminated string", 0)))
+  }
+
+  test("tokenizeParts splices a hole between two parts, unescaping $$") {
+    val result = tokenizeParts(List("query ($$a: ID!) { x ", " }"))
+    assertEquals(
+      result,
+      Right(
+        Vector(
+          Name("query", 0),
+          Punct("(", 6),
+          Punct("$", 7),
+          Name("a", 8),
+          Punct(":", 9),
+          Name("ID", 11),
+          Punct("!", 13),
+          Punct(")", 14),
+          Punct("{", 16),
+          Name("x", 18),
+          Splice(0, 20),
+          Punct("}", 21)
+        )
+      )
+    )
+  }
+
+  test("a string spanning a splice is an error") {
+    val result = tokenizeParts(List("query { x: \"abc", "def\" }"))
+    assert(result.isLeft, result)
+    assert(result.swap.exists(_.message == "unterminated string"), result)
+  }
+}


### PR DESCRIPTION
Replaces the string manipulation in the `gql` macro with a small lexer for the GraphQL
lexical grammar (spec §2.1: punctuators, names, numbers, strings incl. block strings and
escapes, comments) and does the spliced-subquery caller-check on tokens.

Fixes two holes in the previous approach: the operation header was located by the first
`(`, so a `fragment` with field arguments placed before the operation was mistaken for it
(or, with a brace guard, hid it), losing the declared variables and falsely rejecting a
spliced subquery; and strings/comments were not understood at all.

Behavior change: a lexical error in a `gql` document (unterminated string, stray character)
is now a compile error. `GraphQLDocument.unsafeFromString` remains the escape hatch.

Groundwork for #853, which will add the unused-variable/fragment warnings as token walks.