### PR TITLE
Use grackle's parser in the gql macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ They must extend `GraphQLOperation[S]`, defining the following members:
 The `document` is built with the `gql` string interpolator (`import clue.gql`) rather than a plain
 `String`/`s"..."`. `gql` produces the same text at runtime, but its type (`GraphQLDocument`) can only
 be obtained through `gql`, so every operation goes through the compile-time check that splices its
-subqueries correctly (see [Subquery variables](#subquery-variables) below). `.stripMargin` works on a
-`GraphQLDocument` as it does on a `String`. For a document built by other means,
-`GraphQLDocument.unsafeFromString(...)` is the explicit (check-skipping) escape hatch.
+subqueries correctly (see [Subquery variables](#subquery-variables) below). Documents are parsed at
+compile time, so write them without margin characters (`.stripMargin` is not available on a
+`GraphQLDocument`). For a document built by other means, `GraphQLDocument.unsafeFromString(...)` is
+the explicit (check-skipping) escape hatch.
 
 #### Example
 
@@ -220,6 +221,10 @@ trait MyQuery extends GraphQLOperation[StarWars] {
 declares every variable required by each spliced subquery, with a compatible ("usable as") type. It
 reads the requirement from the subquery's `type VariableDefs` directly, so the check works even when
 the subquery comes from a dependency jar; a missing or wrong-typed variable is a compile error.
+
+`gql` documents are parsed at compile time with [grackle](https://github.com/typelevel/grackle)'s
+parser, so malformed GraphQL fails compilation; spliced subqueries are represented by a placeholder
+selection during that parse.
 
 A subquery splicing another subquery is checked the same way, against its own `VariableDefs` instead
 of an operation header:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
-ThisBuild / tlBaseVersion     := "0.59"
+ThisBuild / tlBaseVersion     := "0.60"
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 // The CI matrix covers Scala 3 only, which builds `sbt-clue` for sbt 2.x. Run the scripted tests
@@ -88,6 +88,7 @@ lazy val core =
         Settings.Libraries.Cats.value ++
           Settings.Libraries.CatsEffect.value ++
           Settings.Libraries.Fs2.value ++
+          Settings.Libraries.Grackle.value ++
           Settings.Libraries.Log4Cats.value ++
           Settings.Libraries.DisciplineMUnit.value ++
           Settings.Libraries.MUnitCatsEffect.value ++

--- a/core/src/main/scala/clue/GraphQLDocuments.scala
+++ b/core/src/main/scala/clue/GraphQLDocuments.scala
@@ -27,7 +27,9 @@ private[clue] object GraphQLDocuments {
   def placeholderDocument(parts: List[String]): String =
     parts.map(unescapeDollar).mkString(s" $TypenamePlaceholder ")
 
-  /** Wrap a parenthesized `VariableDefs` string (e.g. `"($ep: Episode!)"`) as a parseable operation. */
+  /**
+   * Wrap a parenthesized `VariableDefs` string (e.g. `"($ep: Episode!)"`) as a parseable operation.
+   */
   def wrapVariableDefs(defs: String): String = s"query $defs $TypenamePlaceholder"
 
   /**

--- a/core/src/main/scala/clue/GraphQLDocuments.scala
+++ b/core/src/main/scala/clue/GraphQLDocuments.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import grackle.Ast
+
+/**
+ * Pure helpers used by the `gql` macro to assemble and inspect GraphQL documents parsed by
+ * grackle's parser. Kept macro-free (no `scala.quoted` dependency) so they can be unit-tested
+ * directly, without `compileErrors`.
+ */
+private[clue] object GraphQLDocuments {
+
+  // A spliced subquery always stands where a selection set goes, so replacing each splice with
+  // this placeholder selection keeps the document parseable without knowing what's actually
+  // spliced in.
+  private val TypenamePlaceholder = "{ __typename }"
+
+  /** Unescape `$$` -> `$`, as in any interpolated string. */
+  def unescapeDollar(part: String): String = part.replace("$$", "$")
+
+  /**
+   * The placeholder document text: `$$` unescaped in each literal part, joined with a placeholder
+   * selection set in place of each splice.
+   */
+  def placeholderDocument(parts: List[String]): String =
+    parts.map(unescapeDollar).mkString(s" $TypenamePlaceholder ")
+
+  /** Wrap a parenthesized `VariableDefs` string (e.g. `"($ep: Episode!)"`) as a parseable operation. */
+  def wrapVariableDefs(defs: String): String = s"query $defs $TypenamePlaceholder"
+
+  /**
+   * The variables declared by every operation in `doc`, keyed by name (without the `$`). A
+   * shorthand query, or a document with only fragments, declares none. Fragments before the
+   * operation don't affect this.
+   */
+  def headerVariables(doc: Ast.Document): Map[String, Ast.Type] =
+    doc
+      .collect { case op: Ast.OperationDefinition.Operation => op }
+      .flatMap(_.variables)
+      .map(v => v.name.value -> v.tpe)
+      .toMap
+
+  /**
+   * GraphQL "is variable usage allowed": `declared` must be usable where `required` is expected.
+   * Same base type once a top-level `NonNull` is stripped from both, and a non-null requirement
+   * needs a non-null declaration.
+   */
+  def usableAs(declared: Ast.Type, required: Ast.Type): Boolean = {
+    def stripNonNull(tpe: Ast.Type): Ast.Type = tpe match {
+      case Ast.Type.NonNull(of) => of.merge
+      case other                => other
+    }
+
+    stripNonNull(declared) == stripNonNull(required) &&
+    (!required.isInstanceOf[Ast.Type.NonNull] || declared.isInstanceOf[Ast.Type.NonNull])
+  }
+}

--- a/core/src/main/scala/clue/GraphQLInterpolator.scala
+++ b/core/src/main/scala/clue/GraphQLInterpolator.scala
@@ -3,6 +3,11 @@
 
 package clue
 
+import cats.syntax.foldable.*
+import grackle.Ast
+import grackle.GraphQLParser
+import grackle.Result
+
 import scala.quoted.*
 
 /**
@@ -20,17 +25,6 @@ object GraphQLDocument {
 
   extension (document: GraphQLDocument) {
     def value: String = document
-
-    /**
-     * As `String.stripMargin`. It runs on the assembled text, so it also strips margins inside
-     * spliced subqueries — the same as calling `.stripMargin` on an `s"..."` interpolation.
-     */
-    def stripMargin: GraphQLDocument = stripMargin('|')
-
-    def stripMargin(marginChar: Char): GraphQLDocument =
-      // Explicit `StringOps` because inside this file `GraphQLDocument` is `String`, so a bare
-      // `document.stripMargin` would resolve back to this extension.
-      new scala.collection.StringOps(document).stripMargin(marginChar)
   }
 }
 
@@ -39,7 +33,12 @@ extension (inline sc:         StringContext)
    * Builds an operation `document` or a subquery's `subquery`, splicing subqueries inline. At
    * runtime it produces exactly the string the standard `s"..."` interpolator would.
    *
-   * At compile time it runs the *caller-check*: for every spliced value that declares variables (a
+   * At compile time the assembled document (with each splice stood in for by a placeholder
+   * selection) is parsed with grackle's parser: a syntax error is a compile error. Fragments may
+   * precede the operation. `GraphQLDocument.unsafeFromString` remains the escape hatch for text
+   * built by other means, which skips both the parse and the check below.
+   *
+   * The macro also runs the *caller-check*: for every spliced value that declares variables (a
    * `GraphQLSubquery` with a `type VariableDefs` member), it verifies that the variables are
    * declared where the splice happens, with a compatible ("usable as") type. The declaration is
    * read from the operation's `query (...)` header, or — when the splice happens inside a
@@ -63,6 +62,10 @@ trait GraphQLTextSyntax {
 }
 
 private[clue] object GraphQLInterpolator {
+
+  // `terseError = false` so parse failures render readable, multi-line messages.
+  private val parser: GraphQLParser =
+    GraphQLParser(GraphQLParser.defaultConfig.copy(terseError = false))
 
   def gqlImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using
     Quotes
@@ -112,74 +115,59 @@ private[clue] object GraphQLInterpolator {
       loop(Symbol.spliceOwner)
     }
 
-    def splitTopLevel(s: String): List[String] = {
-      val out   = scala.collection.mutable.ListBuffer.empty[String]
-      val cur   = new StringBuilder
-      var depth = 0
-      s.foreach {
-        case '['               => depth += 1; cur += '['
-        case ']'               => depth -= 1; cur += ']'
-        case ',' if depth == 0 => out += cur.toString; cur.clear()
-        case c                 => cur += c
+    // Parse `text`, aborting the macro expansion at `pos` with `describe(problemMessages)` on a
+    // parse failure.
+    def parseOrAbort(text: String, pos: Position, describe: String => String): Ast.Document =
+      parser.parseText(text) match {
+        case Result.Success(doc)      => doc
+        case Result.Warning(_, doc)   => doc
+        case Result.Failure(problems) =>
+          report.errorAndAbort(
+            describe(problems.toList.map(_.message).mkString("\n")),
+            pos
+          )
+        case Result.InternalError(t)  =>
+          report.errorAndAbort(describe(s"parser error: ${t.getMessage}"), pos)
       }
-      if (cur.nonEmpty) out += cur.toString
-      out.toList
-    }
 
-    // Parse a parenthesized var-def list `($a: T, $b: U)` into name -> GraphQL type.
-    def parseVarDefs(s0: String): Map[String, String] = {
-      val s = s0.trim.stripPrefix("(").stripSuffix(")").trim.replace("$$", "$")
-      if (s.isEmpty) Map.empty
-      else
-        splitTopLevel(s).flatMap { entry =>
-          val e       = entry.trim
-          val nameEnd = e.indexOf(':')
-          if (nameEnd < 0 || !e.startsWith("$")) None
-          else {
-            val name = e.substring(1, nameEnd).trim
-            val tpe  = e.substring(nameEnd + 1).takeWhile(_ != '=').trim
-            Some(name -> tpe)
-          }
-        }.toMap
-    }
+    // The assembled document, with each splice stood in for by a placeholder selection (a spliced
+    // subquery always stands where a selection set goes, so this keeps the document parseable
+    // without knowing what's actually spliced in).
+    val doc: Ast.Document =
+      parseOrAbort(
+        GraphQLDocuments.placeholderDocument(parts),
+        Position.ofMacroExpansion,
+        msg => s"gql: $msg"
+      )
 
-    // Extract and parse the operation header `(...)` from `query (...) ...` (the first literal part).
-    def operationVars(header: String): Map[String, String] = {
-      val h    = header.replace("$$", "$")
-      val open = h.indexOf('(')
-      if (open < 0) Map.empty
-      else {
-        var depth = 0; var i = open; var end = -1
-        while (i < h.length && end < 0) {
-          h.charAt(i) match {
-            case '(' => depth += 1
-            case ')' => depth -= 1; if (depth == 0) end = i
-            case _   => ()
-          }
-          i += 1
-        }
-        if (end < 0) Map.empty else parseVarDefs(h.substring(open, end + 1))
-      }
-    }
+    // What the operation's header declares. A shorthand query, or a document with only fragments,
+    // declares none. Fragments before the operation are naturally fine, since this looks at every
+    // `Operation` in the document rather than just its first literal part.
+    val headerVariables: Map[String, Ast.Type] = GraphQLDocuments.headerVariables(doc)
 
-    // GraphQL "is variable usage allowed": the declared type must be usable where the required type
-    // is expected. Same base type, and a non-null requirement needs a non-null declared type.
-    def usableAs(declaredType: String, reqType: String): Boolean = {
-      val d = declaredType.trim; val r = reqType.trim
-      d.stripSuffix("!").trim == r.stripSuffix("!").trim && (!r.endsWith("!") || d.endsWith("!"))
-    }
+    // Parse a `VariableDefs` string (e.g. `"($ep: Episode!)"`) belonging to `ownerName`, the same
+    // way, and return its variables.
+    def parseVariableDefs(defs: String, ownerName: String, pos: Position): Map[String, Ast.Type] =
+      GraphQLDocuments.headerVariables(
+        parseOrAbort(
+          GraphQLDocuments.wrapVariableDefs(defs),
+          pos,
+          msg => s"gql: invalid VariableDefs [$defs] on $ownerName: $msg"
+        )
+      )
 
     // What the splice site declares. An operation declares its variables in the document header; a
     // subquery declares them in `type VariableDefs`. Both are read (they are never both populated in
     // practice), so a splice is checked against everything in scope where it happens.
-    val enclosingVariableDefs: Map[String, String] =
+    val enclosingVariableDefs: Map[String, Ast.Type] =
       enclosingSubquery
-        .flatMap(cls => variableDefsOf(cls.typeRef))
-        .map(parseVarDefs)
+        .flatMap(cls => variableDefsOf(cls.typeRef).map(cls -> _))
+        .map { case (cls, defs) =>
+          parseVariableDefs(defs, cls.name.stripSuffix("$"), Position.ofMacroExpansion)
+        }
         .getOrElse(Map.empty)
 
-    val declaredVars: Map[String, String] =
-      enclosingVariableDefs ++ parts.headOption.map(operationVars).getOrElse(Map.empty)
+    val declaredVars: Map[String, Ast.Type] = enclosingVariableDefs ++ headerVariables
 
     // Where the missing declaration has to be added. `name` keeps the module-class `$` suffix for an
     // `object` subquery, which would only confuse the reader.
@@ -188,19 +176,21 @@ private[clue] object GraphQLInterpolator {
 
     argExprs.foreach { arg =>
       variableDefsOf(arg.asTerm.tpe).foreach { required =>
-        parseVarDefs(required).foreach { case (name, reqType) =>
+        val ownerName    = arg.asTerm.tpe.typeSymbol.name.stripSuffix("$")
+        val requiredVars = parseVariableDefs(required, ownerName, arg.asTerm.pos)
+        requiredVars.foreach { case (name, reqType) =>
           declaredVars.get(name) match {
-            case None                                           =>
+            case None                                                            =>
               report.errorAndAbort(
-                s"gql: $declarationSite does not declare variable $$$name required by a spliced subquery (needs $reqType)",
+                s"gql: $declarationSite does not declare variable $$$name required by a spliced subquery (needs ${reqType.name})",
                 arg.asTerm.pos
               )
-            case Some(declared) if !usableAs(declared, reqType) =>
+            case Some(declared) if !GraphQLDocuments.usableAs(declared, reqType) =>
               report.errorAndAbort(
-                s"gql: $declarationSite declares $$$name: $declared but a spliced subquery requires it usable as $reqType",
+                s"gql: $declarationSite declares $$$name: ${declared.name} but a spliced subquery requires it usable as ${reqType.name}",
                 arg.asTerm.pos
               )
-            case _                                              => ()
+            case _                                                               => ()
           }
         }
       }

--- a/core/src/test/scala/clue/GraphQLDocumentsSuite.scala
+++ b/core/src/test/scala/clue/GraphQLDocumentsSuite.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package clue
+
+import grackle.Ast
+import grackle.GraphQLParser
+
+class GraphQLDocumentsSuite extends munit.FunSuite {
+
+  private val parser: GraphQLParser =
+    GraphQLParser(GraphQLParser.defaultConfig.copy(terseError = false))
+
+  private def parseDoc(text: String): Ast.Document =
+    parser.parseText(text).toOption.getOrElse(fail(s"failed to parse: $text"))
+
+  // The type of a single variable `$x`, declared with GraphQL type text `tpeText`.
+  private def tpe(tpeText: String): Ast.Type =
+    GraphQLDocuments
+      .headerVariables(parseDoc(s"query ($$x: $tpeText) { __typename }"))
+      .getOrElse("x", fail(s"no variable parsed for type [$tpeText]"))
+
+  // placeholderDocument
+
+  test("placeholderDocument with no splices is the single part, unchanged") {
+    assertEquals(GraphQLDocuments.placeholderDocument(List("query { hero }")), "query { hero }")
+  }
+
+  test("placeholderDocument with one splice joins with a placeholder selection") {
+    assertEquals(
+      GraphQLDocuments.placeholderDocument(List("query (", ") { hero }")),
+      "query ( { __typename } ) { hero }"
+    )
+  }
+
+  test("placeholderDocument with two splices joins with a placeholder selection each") {
+    assertEquals(
+      GraphQLDocuments.placeholderDocument(List("a", "b", "c")),
+      "a { __typename } b { __typename } c"
+    )
+  }
+
+  test("placeholderDocument unescapes $$ in every part") {
+    assertEquals(
+      GraphQLDocuments.placeholderDocument(List("has $$ep", "trailing $$id")),
+      "has $ep { __typename } trailing $id"
+    )
+  }
+
+  // headerVariables
+
+  test("headerVariables of a shorthand query declares none") {
+    assertEquals(GraphQLDocuments.headerVariables(parseDoc("{ hero }")), Map.empty[String, Ast.Type])
+  }
+
+  test("headerVariables of a query (...) header") {
+    val vars = GraphQLDocuments.headerVariables(parseDoc("query ($ep: Episode!) { hero }"))
+    assertEquals(vars.keySet, Set("ep"))
+    assertEquals(vars("ep").name, "Episode!")
+  }
+
+  test("headerVariables of a named query Foo(...) header") {
+    val vars = GraphQLDocuments.headerVariables(parseDoc("query Foo($ep: Episode!) { hero }"))
+    assertEquals(vars.keySet, Set("ep"))
+    assertEquals(vars("ep").name, "Episode!")
+  }
+
+  test("headerVariables sees the operation's declared variables in a fragment-first document") {
+    val vars = GraphQLDocuments.headerVariables(
+      parseDoc("fragment f on Character { name } query ($ep: Episode!) { hero }")
+    )
+    assertEquals(vars.keySet, Set("ep"))
+    assertEquals(vars("ep").name, "Episode!")
+  }
+
+  // usableAs
+
+  test("usableAs: Episode! declared, Episode! required") {
+    assert(GraphQLDocuments.usableAs(tpe("Episode!"), tpe("Episode!")))
+  }
+
+  test("usableAs: Episode! declared, Episode required (non-null satisfies nullable)") {
+    assert(GraphQLDocuments.usableAs(tpe("Episode!"), tpe("Episode")))
+  }
+
+  test("usableAs: Episode declared, Episode! required is false (nullable can't satisfy non-null)") {
+    assert(!GraphQLDocuments.usableAs(tpe("Episode"), tpe("Episode!")))
+  }
+
+  test("usableAs: different names is false") {
+    assert(!GraphQLDocuments.usableAs(tpe("Episode!"), tpe("Character!")))
+  }
+
+  test("usableAs: [ID!]! declared, [ID!] required is true") {
+    assert(GraphQLDocuments.usableAs(tpe("[ID!]!"), tpe("[ID!]")))
+  }
+
+  test("usableAs: [ID] declared, [ID!] required is false") {
+    assert(!GraphQLDocuments.usableAs(tpe("[ID]"), tpe("[ID!]")))
+  }
+}

--- a/core/src/test/scala/clue/GraphQLDocumentsSuite.scala
+++ b/core/src/test/scala/clue/GraphQLDocumentsSuite.scala
@@ -50,7 +50,9 @@ class GraphQLDocumentsSuite extends munit.FunSuite {
   // headerVariables
 
   test("headerVariables of a shorthand query declares none") {
-    assertEquals(GraphQLDocuments.headerVariables(parseDoc("{ hero }")), Map.empty[String, Ast.Type])
+    assertEquals(GraphQLDocuments.headerVariables(parseDoc("{ hero }")),
+                 Map.empty[String, Ast.Type]
+    )
   }
 
   test("headerVariables of a query (...) header") {

--- a/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
+++ b/core/src/test/scala/clue/GraphQLInterpolatorSuite.scala
@@ -24,6 +24,17 @@ object InterpolatorTestParent extends GraphQLSubquery.Typed[Unit, Json] {
   override val subquery = gql"{ friends $InterpolatorTestSub }"
 }
 
+// Declares no variables at all: exercises splicing a subquery that has nothing to check.
+object InterpolatorTestSubPlain extends GraphQLSubquery.Typed[Unit, Json] {
+  override val subquery = gql"{ name }"
+}
+
+// Declares a variable of LIST type, to exercise structural (not textual) type comparison.
+object InterpolatorTestSubList extends GraphQLSubquery.Typed[Unit, Json] {
+  type VariableDefs = "($ids: [ID!])"
+  override val subquery = gql"{ humans(ids: $$ids) { name } }"
+}
+
 class GraphQLInterpolatorSuite extends munit.FunSuite {
 
   test("gql assembles the document like s-interpolation") {
@@ -32,12 +43,12 @@ class GraphQLInterpolatorSuite extends munit.FunSuite {
   }
 
   test("gql passes through a spliced value that declares no variables") {
-    val doc = gql"query { hero } trailing ${1}"
-    assertEquals(doc.value, "query { hero } trailing 1")
+    val doc = gql"query { hero $InterpolatorTestSubPlain }"
+    assertEquals(doc.value, "query { hero { name } }")
   }
 
   test("a required variable the operation does not declare is a compile error") {
-    val errors = compileErrors("""gql"query { $InterpolatorTestSub }"""")
+    val errors = compileErrors("""gql"query $InterpolatorTestSub"""")
     assert(errors.contains("does not declare variable $ep"), errors)
   }
 
@@ -50,13 +61,6 @@ class GraphQLInterpolatorSuite extends munit.FunSuite {
     // "usable as": a non-null Episode! is usable where the subquery only needs a nullable Episode.
     val doc = gql"query ($$ep: Episode!) $InterpolatorTestSubNullable"
     assertEquals(doc.value, "query ($ep: Episode!) { heroOpt(episode: $ep) { name } }")
-  }
-
-  test("stripMargin strips the assembled document") {
-    val doc = gql"""query {
-                   |  hero
-                   |}""".stripMargin
-    assertEquals(doc.value, "query {\n  hero\n}")
   }
 
   test("a subquery splicing a subquery assembles like s-interpolation") {
@@ -90,10 +94,41 @@ class GraphQLInterpolatorSuite extends munit.FunSuite {
   test("requirements propagate transitively through a nested subquery") {
     // `InterpolatorTestParent` had to declare `$ep` to splice its child, so an operation splicing
     // the parent must declare it too.
-    val errors = compileErrors("""gql"query { $InterpolatorTestParent }"""")
+    val errors = compileErrors("""gql"query $InterpolatorTestParent"""")
     assert(errors.contains("does not declare variable $ep"), errors)
 
     val doc = gql"query ($$ep: Episode!) $InterpolatorTestParent"
     assertEquals(doc.value, "query ($ep: Episode!) { friends { hero(episode: $ep) { name } } }")
+  }
+
+  test("a fragment before the operation still sees the declared variables") {
+    val doc =
+      gql"fragment f on Character { name } query ($$ep: Episode!) { hero $InterpolatorTestSub }"
+    assertEquals(
+      doc.value,
+      "fragment f on Character { name } query ($ep: Episode!) { hero { hero(episode: $ep) { name } } }"
+    )
+  }
+
+  test("a fragment's field arguments are not mistaken for the header") {
+    val errors = compileErrors(
+      """gql"fragment f on Character { hero(episode: NEWHOPE) { name } } query $InterpolatorTestSub""""
+    )
+    assert(errors.contains("does not declare variable $ep"), errors)
+  }
+
+  test("a named operation's header is found") {
+    val doc = gql"query Foo($$ep: Episode!) $InterpolatorTestSub"
+    assertEquals(doc.value, "query Foo($ep: Episode!) { hero(episode: $ep) { name } }")
+  }
+
+  test("a syntax error is a compile error") {
+    val errors = compileErrors("""gql"query { hero "  """)
+    assert(errors.contains("gql:"), errors)
+  }
+
+  test("a list variable type is compared structurally") {
+    val doc = gql"query ($$ids: [ID!]!) $InterpolatorTestSubList"
+    assertEquals(doc.value, "query ($ids: [ID!]!) { humans(ids: $ids) { name } }")
   }
 }

--- a/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
+++ b/http4s-jdk-demo/src/main/scala/clue/http4sjdkDemo/Demo.scala
@@ -33,26 +33,26 @@ object Demo extends IOApp.Simple {
 
   object Query extends GraphQLOperation.Typed.NoInput[DemoDB, Json] {
     override val document = gql"""
-      |query {
-      |  observations(WHERE: {program: {id: {EQ: "p-2"}}}) {
-      |    matches {
-      |      id
-      |      title
-      |      subtitle
-      |    }
-      |  }
-      |}""".stripMargin
+      query {
+        observations(WHERE: {program: {id: {EQ: "p-2"}}}) {
+          matches {
+            id
+            title
+            subtitle
+          }
+        }
+      }"""
   }
 
   object Subscription extends GraphQLOperation.Typed.NoInput[DemoDB, Json] {
     override val document = gql"""
-      |subscription {
-      |  observationEdit(input: {programId: "p-2"}) {
-      |    value {
-      |      id
-      |    }
-      |  }
-      |}""".stripMargin
+      subscription {
+        observationEdit(input: {programId: "p-2"}) {
+          value {
+            id
+          }
+        }
+      }"""
   }
 
   object Mutation extends GraphQLOperation[DemoDB] {
@@ -60,13 +60,13 @@ object Demo extends IOApp.Simple {
     case class Variables(observationId: String, subtitle: String)
 
     override val document                                = gql"""
-    |mutation ($$observationId: ObservationId!, $$subtitle: String){
-    |  updateObservations(input: {WHERE: {id: {EQ: $$observationId}}, SET: {subtitle: $$subtitle}}) {
-    |    observations {
-    |      id
-    |    }
-    |  }
-    |}""".stripMargin
+    mutation ($$observationId: ObservationId!, $$subtitle: String){
+      updateObservations(input: {WHERE: {id: {EQ: $$observationId}}, SET: {subtitle: $$subtitle}}) {
+        observations {
+          id
+        }
+      }
+    }"""
     override val varEncoder: Encoder.AsObject[Variables] = deriveEncoder
 
     override val dataDecoder: Decoder[Data] = Decoder[Json]


### PR DESCRIPTION
Instead of parsing ourselves in the gql macro, we now use grackle.

We are pulling grackle-core as a dependency for the moment. Hopefully 🤞 , https://github.com/typelevel/grackle/pull/947 gets accepted and we can scale down to a parser-only dependency.